### PR TITLE
fix: resolve GitHub Actions permissions for release creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write  # Required for creating releases and tags
+  packages: write  # Required for package operations
+  actions: read    # Required for workflow operations
+
 env:
   NODE_VERSION: '20'
   BUILD_CACHE_KEY: build-${{ github.sha }}
@@ -18,6 +23,9 @@ jobs:
   build-and-store:
     name: 🏗️ Build Applications
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for creating releases
+      packages: write  # Required for package operations
     outputs:
       build-version: ${{ steps.version.outputs.version }}
     steps:
@@ -99,31 +107,30 @@ jobs:
 
       - name: Create GitHub Release (Draft)
         if: github.event_name == 'push'
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: build-${{ steps.version.outputs.version }}
-          release_name: Build ${{ steps.version.outputs.version }}
-          body: |
-            ## 📦 Build Information
-            - **Version:** ${{ steps.version.outputs.version }}
-            - **Commit:** ${{ github.sha }}
-            - **Built by:** ${{ github.actor }}
-            - **Build Date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-            
-            ## 🎯 Artifacts
-            - Frontend build available
-            - Backend build available
-            - Database migrations included
-            
-            ## 📝 Changes
-            View changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
-            
-            ---
-            ⚠️ **Note:** This is a build artifact. Deployment to production requires manual approval.
-          draft: true
-          prerelease: true
+        run: |
+          # Create release using GitHub CLI
+          gh release create "build-${{ steps.version.outputs.version }}" \
+            --draft \
+            --prerelease \
+            --title "Build ${{ steps.version.outputs.version }}" \
+            --notes "## 📦 Build Information
+          - **Version:** ${{ steps.version.outputs.version }}
+          - **Commit:** ${{ github.sha }}
+          - **Built by:** ${{ github.actor }}
+          - **Build Date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          
+          ## 🎯 Artifacts
+          - Frontend build available
+          - Backend build available
+          - Database migrations included
+          
+          ## 📝 Changes
+          View changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+          
+          ---
+          ⚠️ **Note:** This is a build artifact. Deployment to production requires manual approval."
 
   notify-build:
     name: 📢 Build Notification


### PR DESCRIPTION
- Add workflow-level permissions for contents and packages
- Add job-level permissions for build-and-store job
- Replace deprecated actions/create-release@v1 with GitHub CLI
- Use gh release create command for better reliability

This resolves the "Resource not accessible by integration" error.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📋 Description
Brief description of changes

## 🎯 Related Issue
Closes #(issue number)

## 📸 Screenshots (if applicable)
Add screenshots for UI changes

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No console errors
- [ ] Build passes locally (`yarn build`)
- [ ] Lint passes (`yarn lint`)

## 🧪 Testing Instructions
1. Step to test
2. Expected result

## 📝 Additional Notes
Any additional context or notes