### PR TITLE
fix: resolve TireType and TireCondition import issues for production …

### DIFF
--- a/apps/webApp/src/app/components/inventory/TireCard.tsx
+++ b/apps/webApp/src/app/components/inventory/TireCard.tsx
@@ -21,7 +21,8 @@ import {
   Visibility as ViewIcon,
   Inventory as InventoryIcon,
 } from '@mui/icons-material';
-import { ITire, TireType, TireCondition } from '@gt-automotive/shared-interfaces';
+import { ITire } from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 
 // Helper function to get emoji based on tire type
 const getTireEmoji = (type: TireType): string => {

--- a/apps/webApp/src/app/components/inventory/TireDialog.tsx
+++ b/apps/webApp/src/app/components/inventory/TireDialog.tsx
@@ -19,10 +19,9 @@ import {
 import { 
   ITire, 
   ITireCreateInput, 
-  ITireUpdateInput,
-  TireType,
-  TireCondition 
+  ITireUpdateInput
 } from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { TireService } from '../../services/tire.service';
 import { useAuth } from '../../hooks/useAuth';

--- a/apps/webApp/src/app/components/inventory/TireFilter.tsx
+++ b/apps/webApp/src/app/components/inventory/TireFilter.tsx
@@ -25,7 +25,8 @@ import {
   FilterList as FilterIcon,
   Clear as ClearIcon,
 } from '@mui/icons-material';
-import { ITireFilters, TireType, TireCondition } from '@gt-automotive/shared-interfaces';
+import { ITireFilters } from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 import { useTireBrands, useTireSizeSuggestions } from '../../hooks/useTires';
 
 interface TireFilterProps {

--- a/apps/webApp/src/app/pages/inventory/InventoryDashboard.tsx
+++ b/apps/webApp/src/app/pages/inventory/InventoryDashboard.tsx
@@ -37,7 +37,7 @@ import {
   useInvalidateTireQueries 
 } from '../../hooks/useTires';
 import { useAuth } from '../../hooks/useAuth';
-import { TireType } from '@gt-automotive/shared-interfaces';
+import { TireType } from '@prisma/client';
 import TireListSimple from './TireListSimple';
 
 const formatTireType = (type: TireType): string => {

--- a/apps/webApp/src/app/pages/inventory/TireDetails.tsx
+++ b/apps/webApp/src/app/pages/inventory/TireDetails.tsx
@@ -35,10 +35,7 @@ import {
   Close as CloseIcon,
 } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
-import {
-  TireType,
-  TireCondition,
-} from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 import { useAuth } from '../../hooks/useAuth';
 import { useTire, useDeleteTire } from '../../hooks/useTires';
 import StockAdjustmentDialog from '../../components/inventory/StockAdjustmentDialog';

--- a/apps/webApp/src/app/pages/inventory/TireForm.tsx
+++ b/apps/webApp/src/app/pages/inventory/TireForm.tsx
@@ -34,9 +34,8 @@ import { LoadingButton } from '@mui/lab';
 import {
   ITireCreateInput,
   ITireUpdateInput,
-  TireType,
-  TireCondition,
 } from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 import { useAuth } from '../../hooks/useAuth';
 import { 
   useTire, 

--- a/apps/webApp/src/app/pages/inventory/TireFormSimple.tsx
+++ b/apps/webApp/src/app/pages/inventory/TireFormSimple.tsx
@@ -29,9 +29,8 @@ import {
 import {
   ITireCreateInput,
   ITireUpdateInput,
-  TireType,
-  TireCondition,
 } from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 import { useAuth } from '../../hooks/useAuth';
 import { 
   useTire, 

--- a/apps/webApp/src/app/pages/inventory/TireList.tsx
+++ b/apps/webApp/src/app/pages/inventory/TireList.tsx
@@ -36,7 +36,8 @@ import {
 import { DataGrid, GridColDef, GridValueGetterParams } from '@mui/x-data-grid';
 import { useAuth } from '../../hooks/useAuth';
 import { useTires, useExportTires, useInvalidateTireQueries } from '../../hooks/useTires';
-import { ITireSearchParams, TireType, TireCondition } from '@gt-automotive/shared-interfaces';
+import { ITireSearchParams } from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 import TireCard from '../../components/inventory/TireCard';
 
 type ViewMode = 'grid' | 'list';

--- a/apps/webApp/src/app/pages/inventory/TireListSimple.tsx
+++ b/apps/webApp/src/app/pages/inventory/TireListSimple.tsx
@@ -46,7 +46,8 @@ import {
 } from '@mui/icons-material';
 import { useAuth } from '../../hooks/useAuth';
 import { useTires, useExportTires, useInvalidateTireQueries } from '../../hooks/useTires';
-import { ITireSearchParams, ITire, TireType, TireCondition } from '@gt-automotive/shared-interfaces';
+import { ITireSearchParams, ITire } from '@gt-automotive/shared-interfaces';
+import { TireType, TireCondition } from '@prisma/client';
 import { useMutation } from '@tanstack/react-query';
 import { TireService } from '../../services/tire.service';
 import TireCard from '../../components/inventory/TireCard';


### PR DESCRIPTION
…build

- Fixed Vite build failing due to TireType/TireCondition not being properly exported from shared interfaces
- Updated all tire-related components to import enums directly from @prisma/client instead of shared-interfaces
- This resolves the CommonJS/ESM module resolution issues during Vite production builds
- Build now completes successfully with proper enum type definitions

Updated components:
- TireCard, TireDialog, TireFilter components
- TireForm, TireFormSimple, TireDetails pages
- TireList, TireListSimple, InventoryDashboard pages

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📋 Description
Brief description of changes

## 🎯 Related Issue
Closes #(issue number)

## 📸 Screenshots (if applicable)
Add screenshots for UI changes

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No console errors
- [ ] Build passes locally (`yarn build`)
- [ ] Lint passes (`yarn lint`)

## 🧪 Testing Instructions
1. Step to test
2. Expected result

## 📝 Additional Notes
Any additional context or notes