### PR TITLE
fix: correct deployment paths for server and frontend builds

### DIFF
--- a/.github/workflows/deploy-to-lightsail.yml
+++ b/.github/workflows/deploy-to-lightsail.yml
@@ -63,7 +63,7 @@ jobs:
         
         # Copy backend files
         if [ "${{ inputs.deploy_backend }}" == "true" ]; then
-          cp -r dist/server deployment/
+          cp -r server/dist deployment/server
           cp server/package.json deployment/
           cp -r server/prisma deployment/
         fi
@@ -71,7 +71,7 @@ jobs:
         # Copy frontend files
         if [ "${{ inputs.deploy_frontend }}" == "true" ]; then
           mkdir -p deployment/frontend
-          cp -r dist/apps/webApp/* deployment/frontend/
+          cp -r apps/webApp/dist/* deployment/frontend/
         fi
         
         # Copy deployment scripts


### PR DESCRIPTION
- Server builds to server/dist/ (not dist/server)
- Frontend builds to apps/webApp/dist/ (not dist/apps/webApp)
- Updated GitHub Actions workflow deployment package paths
- Tested both builds locally to confirm correct output directories

## 📋 Description
Brief description of changes

## 🎯 Related Issue
Closes #(issue number)

## 📸 Screenshots (if applicable)
Add screenshots for UI changes

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No console errors
- [ ] Build passes locally (`yarn build`)
- [ ] Lint passes (`yarn lint`)

## 🧪 Testing Instructions
1. Step to test
2. Expected result

## 📝 Additional Notes
Any additional context or notes