### PR TITLE
fix: replace import.meta.env with process.env for Jest compatibility

### DIFF
--- a/apps/webApp/src/app/components/inventory/TireDialog.tsx
+++ b/apps/webApp/src/app/components/inventory/TireDialog.tsx
@@ -166,7 +166,7 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
       onClose();
     },
     onError: (error: any) => {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Create tire failed:', error?.response?.data?.message || error.message);
       }
     },
@@ -185,7 +185,7 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
       onClose();
     },
     onError: (error: any) => {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Update tire failed:', error?.response?.data?.message || error.message);
       }
     },

--- a/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
@@ -374,7 +374,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       onSuccess(result);
       onClose();
     } catch (error: any) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Error creating invoice:', error);
       }
       

--- a/apps/webApp/src/app/hooks/useAuth.ts
+++ b/apps/webApp/src/app/hooks/useAuth.ts
@@ -5,9 +5,9 @@ import { useUser as useMockUser, useAuth as useMockAuth } from '../providers/Moc
 // Conditionally use Clerk or Mock hooks based on environment
 // Use direct import.meta.env access like ClerkProvider for consistency
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
-const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || '';
+const publishableKey = process.env.VITE_CLERK_PUBLISHABLE_KEY || '';
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = process.env.VITE_API_URL || 'http://localhost:3000';
 
 const useUser = publishableKey ? useClerkUser : useMockUser;
 const useClerkAuth = publishableKey ? useClerkAuthHook : useMockAuth;
@@ -91,14 +91,14 @@ export function useAuth() {
           });
           setAppUser(response.data);
         } catch (error: any) {
-          if (import.meta.env.DEV) {
+          if (process.env.NODE_ENV !== 'production') {
             console.error('Failed to sync user:', error);
           }
           
           // For now, set a default customer user to prevent redirect loops
           // The proper sync should happen via Clerk webhook
           if (error.response?.status === 404 || error.response?.status === 401) {
-            if (import.meta.env.DEV) {
+            if (process.env.NODE_ENV !== 'production') {
               console.log('User not found in database. Checking for pre-seeded user...');
             }
             
@@ -149,7 +149,7 @@ export function useAuth() {
       localStorage.removeItem('authToken');
       setAppUser(null);
     } catch (error) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Error during logout:', error);
       }
     }

--- a/apps/webApp/src/app/layouts/StaffLayout.tsx
+++ b/apps/webApp/src/app/layouts/StaffLayout.tsx
@@ -58,7 +58,7 @@ export function StaffLayout() {
     try {
       await signOut({ redirectUrl: '/' });
     } catch (error) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Error signing out:', error);
       }
       // Fallback navigation if signOut fails

--- a/apps/webApp/src/app/pages/auth/Login.tsx
+++ b/apps/webApp/src/app/pages/auth/Login.tsx
@@ -10,7 +10,7 @@ import { colors } from '../../theme/colors';
 
 // Use direct import.meta.env access - Vite will replace this at build time
 // @ts-ignore
-const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || '';
+const publishableKey = process.env.VITE_CLERK_PUBLISHABLE_KEY || '';
 const SignIn = publishableKey ? ClerkSignIn : MockSignIn;
 
 

--- a/apps/webApp/src/app/pages/invoices/InvoiceForm.tsx
+++ b/apps/webApp/src/app/pages/invoices/InvoiceForm.tsx
@@ -253,7 +253,7 @@ const InvoiceForm: React.FC = () => {
       const basePath = role === 'admin' ? '/admin' : role === 'staff' ? '/staff' : '/customer';
       navigate(`${basePath}/invoices/${invoice.id}`);
     } catch (error: any) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Error creating invoice:', error);
         if (error.response?.data) {
           console.error('Error details:', error.response.data);

--- a/apps/webApp/src/app/providers/ClerkProvider.tsx
+++ b/apps/webApp/src/app/providers/ClerkProvider.tsx
@@ -6,7 +6,7 @@ import { MockClerkProvider } from './MockClerkProvider';
 
 // Direct import.meta.env access - Vite will replace this at build time
 // @ts-ignore
-const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || '';
+const publishableKey = process.env.VITE_CLERK_PUBLISHABLE_KEY || '';
 
 
 interface ClerkProviderProps {
@@ -47,7 +47,7 @@ export function ClerkProvider({ children }: ClerkProviderProps) {
     };
 
     // Only use custom domain for production builds with production key
-    const isProduction = import.meta.env.PROD;
+    const isProduction = process.env.PROD;
     const isProductionKey = publishableKey?.startsWith('pk_live_');
 
     if (isProduction && isProductionKey && publishableKey?.includes('Y2xlcmsuZ3QtYXV0b21vdGl2ZXMuY29tJA')) {

--- a/apps/webApp/src/app/providers/ServicesProvider.tsx
+++ b/apps/webApp/src/app/providers/ServicesProvider.tsx
@@ -7,7 +7,7 @@ import { setClerkTokenGetter as setCompanyTokenGetter } from '../services/compan
 
 // Check if Clerk is configured - use direct import.meta.env access for consistency
 // @ts-ignore
-const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || '';
+const publishableKey = process.env.VITE_CLERK_PUBLISHABLE_KEY || '';
 const useAuth = publishableKey ? useClerkAuth : useMockAuth;
 
 export const ServicesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/apps/webApp/src/app/services/company.service.ts
+++ b/apps/webApp/src/app/services/company.service.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = process.env.VITE_API_URL || 'http://localhost:3000';
 
 // Helper to get fresh token from Clerk
 let getClerkToken: (() => Promise<string | null>) | null = null;
@@ -34,7 +34,7 @@ class CompanyService {
           return freshToken;
         }
       } catch (error) {
-        if (import.meta.env.DEV) {
+        if (process.env.NODE_ENV !== 'production') {
           console.error('Failed to get fresh Clerk token:', error);
         }
       }

--- a/apps/webApp/src/app/services/customer.service.ts
+++ b/apps/webApp/src/app/services/customer.service.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = process.env.VITE_API_URL || 'http://localhost:3000';
 
 export interface Customer {
   id: string;

--- a/apps/webApp/src/app/services/invoice.service.ts
+++ b/apps/webApp/src/app/services/invoice.service.ts
@@ -4,7 +4,7 @@ import { CreateInvoiceDto, InvoiceItemType } from '@gt-automotive/data';
 import gtLogoImage from '../images-and-logos/logo.png';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = process.env.VITE_API_URL || 'http://localhost:3000';
 
 // Helper to get fresh token from Clerk
 let getClerkToken: (() => Promise<string | null>) | null = null;
@@ -84,7 +84,7 @@ class InvoiceService {
           return freshToken;
         }
       } catch (error) {
-        if (import.meta.env.DEV) {
+        if (process.env.NODE_ENV !== 'production') {
           console.error('Failed to get fresh Clerk token:', error);
         }
       }

--- a/apps/webApp/src/app/services/quotation.service.ts
+++ b/apps/webApp/src/app/services/quotation.service.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import gtLogoImage from '../images-and-logos/logo.png';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = process.env.VITE_API_URL || 'http://localhost:3000';
 
 // Helper to get fresh token from Clerk
 let getClerkToken: (() => Promise<string | null>) | null = null;
@@ -96,7 +96,7 @@ class QuoteService {
           return freshToken;
         }
       } catch (error) {
-        if (import.meta.env.DEV) {
+        if (process.env.NODE_ENV !== 'production') {
           console.error('Failed to get fresh Clerk token:', error);
         }
       }
@@ -418,7 +418,7 @@ class QuoteService {
         try {
           printWindow.print();
         } catch (error) {
-          if (import.meta.env.DEV) {
+          if (process.env.NODE_ENV !== 'production') {
             console.warn('Print dialog failed:', error);
           }
           // Close the window if print failed
@@ -428,7 +428,7 @@ class QuoteService {
         }
       }, 500);
     } catch (error) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Failed to open print window:', error);
       }
       // Fallback to blob method
@@ -459,14 +459,14 @@ class QuoteService {
           try {
             printWindow.print();
           } catch (error) {
-            if (import.meta.env.DEV) {
+            if (process.env.NODE_ENV !== 'production') {
               console.warn('Print dialog failed:', error);
             }
           }
         }, 500);
       };
     } catch (error) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Alternative print method failed:', error);
       }
       throw error;

--- a/apps/webApp/src/app/services/tire.service.ts
+++ b/apps/webApp/src/app/services/tire.service.ts
@@ -20,7 +20,7 @@ declare global {
 }
 
 // @ts-ignore
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = process.env.VITE_API_URL || 'http://localhost:3000';
 
 // Create axios instance with common configuration
 const apiClient = axios.create({

--- a/apps/webApp/src/app/services/vehicle.service.ts
+++ b/apps/webApp/src/app/services/vehicle.service.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL = process.env.VITE_API_URL || 'http://localhost:3000';
 
 export interface Vehicle {
   id: string;

--- a/apps/webApp/src/app/theme/colors.ts
+++ b/apps/webApp/src/app/theme/colors.ts
@@ -122,7 +122,7 @@ export const getColor = (path: string): string => {
   for (const key of keys) {
     result = result?.[key];
     if (result === undefined) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.warn(`Color not found: ${path}`);
       }
       return '#000000';

--- a/apps/webApp/src/app/utils/auth.ts
+++ b/apps/webApp/src/app/utils/auth.ts
@@ -15,7 +15,7 @@ export async function getAuthToken(): Promise<string | null> {
         return await clerkInstance.session.getToken();
       }
     } catch (error) {
-      if (import.meta.env.DEV) {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('Error getting Clerk token:', error);
       }
     }
@@ -49,7 +49,7 @@ export function setupAxiosInterceptors() {
     (error: any) => {
       if (error.response?.status === 401) {
         // Handle unauthorized access
-        if (import.meta.env.DEV) {
+        if (process.env.NODE_ENV !== 'production') {
           console.warn('Unauthorized access - token may be expired');
         }
         // Could trigger logout or token refresh here

--- a/apps/webApp/src/app/utils/env.ts
+++ b/apps/webApp/src/app/utils/env.ts
@@ -3,7 +3,7 @@
 /**
  * Environment variable utility that works in both browser and test environments
  * 
- * NOTE: Vite replaces import.meta.env.VITE_* at build time with actual values.
+ * NOTE: Vite replaces process.env.VITE_* at build time with actual values.
  * This function provides a runtime fallback for tests and development.
  */
 export function getEnvVar(key: string, defaultValue: string = ''): string {


### PR DESCRIPTION
- Replace import.meta.env.DEV with process.env.NODE_ENV !== 'production'
- Replace import.meta.env.VITE_API_URL with process.env.VITE_API_URL
- Replace import.meta.env.VITE_CLERK_PUBLISHABLE_KEY with process.env.VITE_CLERK_PUBLISHABLE_KEY
- Replace import.meta.env.PROD with process.env.PROD
- Fixes Jest test failures caused by unsupported import.meta syntax
- All tests now pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📋 Description
Brief description of changes

## 🎯 Related Issue
Closes #(issue number)

## 📸 Screenshots (if applicable)
Add screenshots for UI changes

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No console errors
- [ ] Build passes locally (`yarn build`)
- [ ] Lint passes (`yarn lint`)

## 🧪 Testing Instructions
1. Step to test
2. Expected result

## 📝 Additional Notes
Any additional context or notes