### PR TITLE
Fix: Vite CI/CD Build Path Resolution

### DIFF
--- a/apps/webApp/vite.config.ts
+++ b/apps/webApp/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig(() => ({
   // },
   resolve: {
     alias: {
-      '@gt-automotive/data': '/Users/vishaltoora/projects/gt-automotives-app/libs/data/src/index.ts',
+      '@gt-automotive/data': '../../libs/data/src/index.ts',
     },
     // Module resolution handled by symlinks in node_modules
   },


### PR DESCRIPTION
## Summary
- Fixed Vite alias configuration for CI/CD compatibility
- Changed @gt-automotive/data alias from absolute to relative path
- Resolves GitHub Actions build failures

## Changes
- Updated vite.config.ts to use relative path: '../../libs/data/src/index.ts'
- Maintains local development functionality
- Fixes path resolution in GitHub Actions runners

## Test Plan
- [x] Local build passes successfully (yarn build:web)
- [x] Development servers still working
- [x] TypeScript compilation passes
- [ ] CI/CD build should now succeed

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>