### PR TITLE
feat: multiple customer emails + PST-exempt flag

### DIFF
--- a/apps/webApp/src/app/components/common/EmailPromptDialog.tsx
+++ b/apps/webApp/src/app/components/common/EmailPromptDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -11,40 +11,135 @@ import {
   Box,
   Typography,
   IconButton,
-  CircularProgress,
+  List,
+  ListItem,
+  Divider,
+  useTheme,
 } from '@mui/material';
-import { Close as CloseIcon, Email as EmailIcon } from '@mui/icons-material';
+import {
+  Close as CloseIcon,
+  Email as EmailIcon,
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Send as SendIcon,
+} from '@mui/icons-material';
 
 interface EmailPromptDialogProps {
   open: boolean;
   onClose: () => void;
   onSubmit: (email: string, saveToCustomer: boolean) => Promise<void>;
+  /** Multi-recipient submit handler. Used when `multiple` is true. */
+  onSubmitMultiple?: (
+    emails: string[],
+    saveToCustomer: boolean
+  ) => Promise<void>;
+  /** Known emails for the recipient (primary + additional). Enables checkbox selection. */
+  availableEmails?: string[];
+  /** Enable multi-recipient mode (checkboxes + add-more). */
+  multiple?: boolean;
   customerName: string;
   customerId?: string;
   documentType: 'invoice' | 'quotation';
   documentNumber: string;
 }
 
+const validateEmail = (email: string): boolean => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+
 export const EmailPromptDialog: React.FC<EmailPromptDialogProps> = ({
   open,
   onClose,
   onSubmit,
+  onSubmitMultiple,
+  availableEmails,
+  multiple = false,
   customerName,
   customerId,
   documentType,
   documentNumber,
 }) => {
+  const theme = useTheme();
+
+  // Single-email mode state
   const [email, setEmail] = useState('');
+
+  // Multi-email mode state
+  const knownEmails = useMemo(
+    () => Array.from(new Set((availableEmails ?? []).filter((e) => !!e))),
+    [availableEmails]
+  );
+  const [selected, setSelected] = useState<string[]>([]);
+  const [extraEmails, setExtraEmails] = useState<string[]>([]);
+  const [newEmail, setNewEmail] = useState('');
+
   const [saveToCustomer, setSaveToCustomer] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const validateEmail = (email: string): boolean => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
+  // Reset state whenever the dialog opens
+  useEffect(() => {
+    if (open) {
+      setEmail('');
+      setExtraEmails([]);
+      setNewEmail('');
+      // Pre-select all known emails (or the first one if many) when opening
+      setSelected(knownEmails);
+      setSaveToCustomer(true);
+      setError('');
+    }
+  }, [open, knownEmails]);
+
+  const toggleSelected = (value: string) => {
+    setSelected((prev) =>
+      prev.includes(value) ? prev.filter((e) => e !== value) : [...prev, value]
+    );
+    setError('');
   };
 
-  const handleSubmit = async () => {
+  const handleAddEmail = () => {
+    const trimmed = newEmail.trim();
+    if (!trimmed) return;
+    if (!validateEmail(trimmed)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+    if ([...knownEmails, ...extraEmails].includes(trimmed)) {
+      setError('That email is already in the list');
+      return;
+    }
+    setExtraEmails((prev) => [...prev, trimmed]);
+    setSelected((prev) => [...prev, trimmed]);
+    setNewEmail('');
+    setError('');
+  };
+
+  const handleRemoveExtra = (value: string) => {
+    setExtraEmails((prev) => prev.filter((e) => e !== value));
+    setSelected((prev) => prev.filter((e) => e !== value));
+  };
+
+  const handleSubmitMultiple = async () => {
+    const recipients = selected.filter((e) => !!e);
+    if (recipients.length === 0) {
+      setError('Select at least one email address');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+    try {
+      await onSubmitMultiple?.(recipients, saveToCustomer && !!customerId);
+      handleClose();
+    } catch (err) {
+      setError('Failed to send email. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmitSingle = async () => {
     if (!email.trim()) {
       setError('Email is required');
       return;
@@ -68,13 +163,24 @@ export const EmailPromptDialog: React.FC<EmailPromptDialogProps> = ({
 
   const handleClose = () => {
     setEmail('');
+    setSelected([]);
+    setExtraEmails([]);
+    setNewEmail('');
     setSaveToCustomer(true);
     setError('');
     onClose();
   };
 
+  const docLabel = documentType === 'invoice' ? 'Invoice' : 'Quotation';
+  const canSubmit = multiple ? selected.length > 0 : !!email.trim();
+
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+    <Dialog
+      open={open}
+      onClose={loading ? undefined : handleClose}
+      maxWidth="sm"
+      fullWidth
+    >
       <DialogTitle
         sx={{
           bgcolor: 'primary.main',
@@ -86,67 +192,314 @@ export const EmailPromptDialog: React.FC<EmailPromptDialogProps> = ({
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <EmailIcon />
-          Send {documentType === 'invoice' ? 'Invoice' : 'Quotation'}
+          Send {docLabel}
         </Box>
-        <IconButton onClick={handleClose} size="small" sx={{ color: 'white' }}>
+        <IconButton
+          onClick={handleClose}
+          size="small"
+          sx={{ color: 'white' }}
+          disabled={loading}
+        >
           <CloseIcon />
         </IconButton>
       </DialogTitle>
-      <DialogContent>
-        <Box sx={{ pt: 2 }}>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Customer <strong>{customerName}</strong> does not have an email on file.
-            Please enter an email address to send {documentType} <strong>{documentNumber}</strong>.
-          </Typography>
-
-          <TextField
-            fullWidth
-            label="Email Address"
-            type="email"
-            value={email}
-            onChange={(e) => {
-              setEmail(e.target.value);
-              setError('');
+      {loading ? (
+        <DialogContent>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 2.5,
+              py: 6,
             }}
-            error={!!error}
-            helperText={error}
-            placeholder="customer@example.com"
-            autoFocus
-            autoComplete="off"
-          />
+          >
+            {/* Spinning gradient ring with a pulsing paper-plane icon */}
+            <Box
+              sx={{
+                position: 'relative',
+                width: 72,
+                height: 72,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Box
+                sx={{
+                  position: 'absolute',
+                  inset: 0,
+                  borderRadius: '50%',
+                  background: `conic-gradient(from 90deg, ${theme.palette.primary.main}00, ${theme.palette.primary.main})`,
+                  WebkitMask:
+                    'radial-gradient(farthest-side, #0000 calc(100% - 5px), #000 calc(100% - 5px))',
+                  mask: 'radial-gradient(farthest-side, #0000 calc(100% - 5px), #000 calc(100% - 5px))',
+                  animation: 'emailRingSpin 0.9s linear infinite',
+                  '@keyframes emailRingSpin': {
+                    to: { transform: 'rotate(360deg)' },
+                  },
+                }}
+              />
+              <SendIcon
+                sx={{
+                  color: 'primary.main',
+                  fontSize: 30,
+                  animation: 'emailPlanePulse 1.4s ease-in-out infinite',
+                  '@keyframes emailPlanePulse': {
+                    '0%, 100%': {
+                      transform: 'translate(0, 0) scale(1)',
+                      opacity: 0.8,
+                    },
+                    '50%': {
+                      transform: 'translate(2px, -2px) scale(1.12)',
+                      opacity: 1,
+                    },
+                  },
+                }}
+              />
+            </Box>
 
-          {customerId && (
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={saveToCustomer}
-                  onChange={(e) => setSaveToCustomer(e.target.checked)}
-                  color="primary"
-                />
-              }
-              label={
-                <Typography variant="body2">
-                  Save this email to {customerName}'s profile for future use
-                </Typography>
-              }
-              sx={{ mt: 2 }}
-            />
-          )}
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose} disabled={loading}>
-          Cancel
-        </Button>
-        <Button
-          onClick={handleSubmit}
-          variant="contained"
-          disabled={loading || !email.trim()}
-          startIcon={loading ? <CircularProgress size={16} /> : <EmailIcon />}
-        >
-          {loading ? 'Sending...' : 'Send Email'}
-        </Button>
-      </DialogActions>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                Sending {docLabel.toLowerCase()}…
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  gap: 0.6,
+                  justifyContent: 'center',
+                  mt: 1,
+                }}
+              >
+                {[0, 1, 2].map((i) => (
+                  <Box
+                    key={i}
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      bgcolor: 'primary.main',
+                      animation: 'emailDotBounce 1s ease-in-out infinite',
+                      animationDelay: `${i * 0.15}s`,
+                      '@keyframes emailDotBounce': {
+                        '0%, 100%': {
+                          opacity: 0.3,
+                          transform: 'translateY(0)',
+                        },
+                        '50%': { opacity: 1, transform: 'translateY(-4px)' },
+                      },
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
+          </Box>
+        </DialogContent>
+      ) : (
+        <>
+          <DialogContent>
+            <Box sx={{ pt: 2 }}>
+              {multiple ? (
+                <>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mb: 1 }}
+                  >
+                    Select the email address(es) to send {documentType}{' '}
+                    <strong>{documentNumber}</strong> to
+                    {customerName ? (
+                      <>
+                        {' '}
+                        for <strong>{customerName}</strong>
+                      </>
+                    ) : null}
+                    .
+                  </Typography>
+
+                  {knownEmails.length > 0 ? (
+                    <List dense disablePadding>
+                      {knownEmails.map((e, idx) => (
+                        <ListItem key={e} disableGutters disablePadding>
+                          <FormControlLabel
+                            control={
+                              <Checkbox
+                                checked={selected.includes(e)}
+                                onChange={() => toggleSelected(e)}
+                                color="primary"
+                              />
+                            }
+                            label={
+                              <Typography variant="body2">
+                                {e}
+                                {idx === 0 && (
+                                  <Typography
+                                    component="span"
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{ ml: 1 }}
+                                  >
+                                    (primary)
+                                  </Typography>
+                                )}
+                              </Typography>
+                            }
+                          />
+                        </ListItem>
+                      ))}
+                    </List>
+                  ) : (
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mb: 1 }}
+                    >
+                      This customer has no email on file. Add one below.
+                    </Typography>
+                  )}
+
+                  {/* Manually added emails */}
+                  {extraEmails.map((e) => (
+                    <Box key={e} display="flex" alignItems="center" gap={1}>
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={selected.includes(e)}
+                            onChange={() => toggleSelected(e)}
+                            color="primary"
+                          />
+                        }
+                        label={<Typography variant="body2">{e}</Typography>}
+                      />
+                      <IconButton
+                        aria-label="Remove email"
+                        size="small"
+                        onClick={() => handleRemoveExtra(e)}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+                  ))}
+
+                  <Divider sx={{ my: 2 }} />
+
+                  <Box display="flex" alignItems="flex-start" gap={1}>
+                    <TextField
+                      fullWidth
+                      size="small"
+                      label="Add another email"
+                      type="email"
+                      value={newEmail}
+                      onChange={(e) => {
+                        setNewEmail(e.target.value);
+                        setError('');
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          handleAddEmail();
+                        }
+                      }}
+                      placeholder="someone@example.com"
+                      error={!!error}
+                      helperText={error}
+                      autoComplete="off"
+                    />
+                    <Button
+                      onClick={handleAddEmail}
+                      startIcon={<AddIcon />}
+                      sx={{ mt: 0.5, whiteSpace: 'nowrap' }}
+                      disabled={!newEmail.trim()}
+                    >
+                      Add
+                    </Button>
+                  </Box>
+
+                  {customerId && (
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={saveToCustomer}
+                          onChange={(e) => setSaveToCustomer(e.target.checked)}
+                          color="primary"
+                        />
+                      }
+                      label={
+                        <Typography variant="body2">
+                          Save new emails to {customerName || 'customer'}'s
+                          profile
+                        </Typography>
+                      }
+                      sx={{ mt: 1 }}
+                    />
+                  )}
+                </>
+              ) : (
+                <>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mb: 2 }}
+                  >
+                    Customer <strong>{customerName}</strong> does not have an
+                    email on file. Please enter an email address to send{' '}
+                    {documentType} <strong>{documentNumber}</strong>.
+                  </Typography>
+
+                  <TextField
+                    fullWidth
+                    label="Email Address"
+                    type="email"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      setError('');
+                    }}
+                    error={!!error}
+                    helperText={error}
+                    placeholder="customer@example.com"
+                    autoFocus
+                    autoComplete="off"
+                  />
+
+                  {customerId && (
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={saveToCustomer}
+                          onChange={(e) => setSaveToCustomer(e.target.checked)}
+                          color="primary"
+                        />
+                      }
+                      label={
+                        <Typography variant="body2">
+                          Save this email to {customerName}'s profile for future
+                          use
+                        </Typography>
+                      }
+                      sx={{ mt: 2 }}
+                    />
+                  )}
+                </>
+              )}
+            </Box>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose}>Cancel</Button>
+            <Button
+              onClick={multiple ? handleSubmitMultiple : handleSubmitSingle}
+              variant="contained"
+              disabled={!canSubmit}
+              startIcon={<EmailIcon />}
+            >
+              {multiple && selected.length > 1
+                ? `Send to ${selected.length} recipients`
+                : 'Send Email'}
+            </Button>
+          </DialogActions>
+        </>
+      )}
     </Dialog>
   );
 };

--- a/apps/webApp/src/app/components/customers/CustomerDetailsDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDetailsDialog.tsx
@@ -53,7 +53,13 @@ import {
   CreditCard as CreditCardIcon,
 } from '@mui/icons-material';
 import { TransitionProps } from '@mui/material/transitions';
-import { customerService, Customer, Vehicle, Invoice, Appointment } from '../../requests/customer.requests';
+import {
+  customerService,
+  Customer,
+  Vehicle,
+  Invoice,
+  Appointment,
+} from '../../requests/customer.requests';
 import { appointmentService } from '../../requests/appointment.requests';
 import { colors } from '../../theme/colors';
 import { formatPhoneForDisplay } from '../../utils/phone';
@@ -72,7 +78,7 @@ const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
     children: React.ReactElement;
   },
-  ref: React.Ref<unknown>,
+  ref: React.Ref<unknown>
 ) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
@@ -121,16 +127,24 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
   const [customer, setCustomer] = useState<Customer | null>(null);
   const [tabValue, setTabValue] = useState(0);
   const [invoiceDialogOpen, setInvoiceDialogOpen] = useState(false);
-  const [selectedInvoiceId, setSelectedInvoiceId] = useState<string | null>(null);
+  const [selectedInvoiceId, setSelectedInvoiceId] = useState<string | null>(
+    null
+  );
   const [appointmentDialogOpen, setAppointmentDialogOpen] = useState(false);
   const [selectedAppointment, setSelectedAppointment] = useState<any>(null);
-  const [customerDetailsExpanded, setCustomerDetailsExpanded] = useState(!isMobile);
+  const [customerDetailsExpanded, setCustomerDetailsExpanded] = useState(
+    !isMobile
+  );
   const [paymentDialogOpen, setPaymentDialogOpen] = useState(false);
-  const [selectedInvoiceForPayment, setSelectedInvoiceForPayment] = useState<Invoice | null>(null);
+  const [selectedInvoiceForPayment, setSelectedInvoiceForPayment] =
+    useState<Invoice | null>(null);
   const [squarePaymentDialogOpen, setSquarePaymentDialogOpen] = useState(false);
-  const [selectedInvoiceForSquare, setSelectedInvoiceForSquare] = useState<Invoice | null>(null);
-  const [appointmentPaymentDialogOpen, setAppointmentPaymentDialogOpen] = useState(false);
-  const [selectedAppointmentForPayment, setSelectedAppointmentForPayment] = useState<Appointment | null>(null);
+  const [selectedInvoiceForSquare, setSelectedInvoiceForSquare] =
+    useState<Invoice | null>(null);
+  const [appointmentPaymentDialogOpen, setAppointmentPaymentDialogOpen] =
+    useState(false);
+  const [selectedAppointmentForPayment, setSelectedAppointmentForPayment] =
+    useState<Appointment | null>(null);
 
   useEffect(() => {
     if (open && customerId) {
@@ -152,21 +166,26 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
       const data = await customerService.getCustomer(customerId);
       setCustomer(data);
     } catch (err: any) {
-      setError(err.response?.data?.message || 'Failed to load customer details');
+      setError(
+        err.response?.data?.message || 'Failed to load customer details'
+      );
     } finally {
       setLoading(false);
     }
   };
 
   const getInitials = (firstName?: string, lastName?: string) => {
-    return `${firstName?.charAt(0) || ''}${lastName?.charAt(0) || ''}`.toUpperCase();
+    return `${firstName?.charAt(0) || ''}${
+      lastName?.charAt(0) || ''
+    }`.toUpperCase();
   };
 
   const formatCurrency = (amount: number) => {
+    const value = Number(amount) || 0;
     return new Intl.NumberFormat('en-CA', {
       style: 'currency',
       currency: 'CAD',
-    }).format(amount);
+    }).format(value);
   };
 
   const formatDate = (dateString: string) => {
@@ -177,7 +196,9 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
     }
   };
 
-  const getStatusColor = (status: string): 'success' | 'warning' | 'error' | 'info' | 'default' => {
+  const getStatusColor = (
+    status: string
+  ): 'success' | 'warning' | 'error' | 'info' | 'default' => {
     switch (status) {
       case 'PAID':
       case 'COMPLETED':
@@ -242,11 +263,15 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
     }
   };
 
-  const handleStatusChange = async (appointmentId: string, newStatus: string, paymentData?: any) => {
+  const handleStatusChange = async (
+    appointmentId: string,
+    newStatus: string,
+    paymentData?: any
+  ) => {
     try {
       await appointmentService.updateAppointment(appointmentId, {
         status: newStatus as any,
-        ...paymentData
+        ...paymentData,
       });
       loadCustomer();
     } catch (err) {
@@ -274,7 +299,10 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
     if (!selectedInvoiceForPayment) return;
 
     try {
-      await invoiceService.markInvoiceAsPaid(selectedInvoiceForPayment.id, paymentMethod);
+      await invoiceService.markInvoiceAsPaid(
+        selectedInvoiceForPayment.id,
+        paymentMethod
+      );
       loadCustomer(); // Refresh to update outstanding balance
       onPaymentSuccess?.(); // Notify parent to refresh list
     } catch (err) {
@@ -324,18 +352,28 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
 
       // Update appointment with payment data
       // IMPORTANT: Always keep the ORIGINAL expectedAmount - don't overwrite with remaining amount
-      await appointmentService.updateAppointment(selectedAppointmentForPayment.id, {
-        paymentAmount: (selectedAppointmentForPayment.paymentAmount || 0) + paymentData.totalAmount,
-        // Keep original expectedAmount, only set if not already set
-        expectedAmount: selectedAppointmentForPayment.expectedAmount,
-        paymentBreakdown: [...((existingBreakdown as any[]) || []), ...paymentData.payments],
-        completionEmployeeIds: paymentData.completionEmployeeIds,
-        productSaleAmount: paymentData.productSaleAmount,
-        productSaleItems: paymentData.productSaleItems,
-        notes: paymentData.paymentNotes ?
-          `${selectedAppointmentForPayment.notes || ''}\nPayment: ${paymentData.paymentNotes}`.trim() :
-          selectedAppointmentForPayment.notes,
-      });
+      await appointmentService.updateAppointment(
+        selectedAppointmentForPayment.id,
+        {
+          paymentAmount:
+            (selectedAppointmentForPayment.paymentAmount || 0) +
+            paymentData.totalAmount,
+          // Keep original expectedAmount, only set if not already set
+          expectedAmount: selectedAppointmentForPayment.expectedAmount,
+          paymentBreakdown: [
+            ...((existingBreakdown as any[]) || []),
+            ...paymentData.payments,
+          ],
+          completionEmployeeIds: paymentData.completionEmployeeIds,
+          productSaleAmount: paymentData.productSaleAmount,
+          productSaleItems: paymentData.productSaleItems,
+          notes: paymentData.paymentNotes
+            ? `${selectedAppointmentForPayment.notes || ''}\nPayment: ${
+                paymentData.paymentNotes
+              }`.trim()
+            : selectedAppointmentForPayment.notes,
+        }
+      );
       loadCustomer(); // Refresh to update outstanding balance
       onPaymentSuccess?.(); // Notify parent to refresh list
     } catch (err) {
@@ -374,59 +412,72 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
         businessName: customer?.businessName,
         address: customer?.address,
       },
-      vehicle: apt.vehicle ? {
-        id: apt.vehicle.id,
-        year: apt.vehicle.year,
-        make: apt.vehicle.make,
-        model: apt.vehicle.model,
-        licensePlate: apt.vehicle.licensePlate,
-      } : undefined,
+      vehicle: apt.vehicle
+        ? {
+            id: apt.vehicle.id,
+            year: apt.vehicle.year,
+            make: apt.vehicle.make,
+            model: apt.vehicle.model,
+            licensePlate: apt.vehicle.licensePlate,
+          }
+        : undefined,
       employees: apt.employees,
     };
   };
 
   // Separate upcoming and past appointments
-  const upcomingAppointments = customer?.appointments?.filter(
-    (apt) => isAfter(parseISO(apt.scheduledDate), new Date()) && !['CANCELLED', 'COMPLETED', 'NO_SHOW'].includes(apt.status)
-  ) || [];
+  const upcomingAppointments =
+    customer?.appointments?.filter(
+      (apt) =>
+        isAfter(parseISO(apt.scheduledDate), new Date()) &&
+        !['CANCELLED', 'COMPLETED', 'NO_SHOW'].includes(apt.status)
+    ) || [];
 
-  const pastAppointments = customer?.appointments?.filter(
-    (apt) => !isAfter(parseISO(apt.scheduledDate), new Date()) || ['CANCELLED', 'COMPLETED', 'NO_SHOW'].includes(apt.status)
-  ) || [];
+  const pastAppointments =
+    customer?.appointments?.filter(
+      (apt) =>
+        !isAfter(parseISO(apt.scheduledDate), new Date()) ||
+        ['CANCELLED', 'COMPLETED', 'NO_SHOW'].includes(apt.status)
+    ) || [];
 
   // Separate unpaid and paid invoices
-  const unpaidInvoices = customer?.invoices?.filter(
-    (inv) => ['PENDING', 'DRAFT'].includes(inv.status)
-  ) || [];
+  const unpaidInvoices =
+    customer?.invoices?.filter((inv) =>
+      ['PENDING', 'DRAFT'].includes(inv.status)
+    ) || [];
 
-  const paidInvoices = customer?.invoices?.filter(
-    (inv) => inv.status === 'PAID'
-  ) || [];
+  const paidInvoices =
+    customer?.invoices?.filter((inv) => inv.status === 'PAID') || [];
 
   // Find completed appointments with outstanding balance (unpaid or partially paid)
-  const unpaidAppointments = customer?.appointments?.filter((apt) => {
-    if (apt.status !== 'COMPLETED') return false;
-    const expected = apt.expectedAmount || 0;
-    const paid = apt.paymentAmount || 0;
-    return expected > 0 && paid < expected;
-  }) || [];
+  const unpaidAppointments =
+    customer?.appointments?.filter((apt) => {
+      if (apt.status !== 'COMPLETED') return false;
+      const expected = Number(apt.expectedAmount) || 0;
+      const paid = Number(apt.paymentAmount) || 0;
+      return expected > 0 && paid < expected;
+    }) || [];
 
-  // Calculate outstanding balance from unpaid invoices AND unpaid appointments
+  // Calculate outstanding balance from unpaid invoices AND unpaid appointments.
+  // Amounts arrive from the API as Prisma Decimal strings, so coerce to numbers
+  // before arithmetic — otherwise `+` concatenates strings and yields NaN.
   const invoiceOutstanding = unpaidInvoices.reduce(
-    (sum, inv) => sum + (inv.total || 0),
+    (sum, inv) => sum + (Number(inv.total) || 0),
     0
   );
 
   const appointmentOutstanding = unpaidAppointments.reduce((sum, apt) => {
-    const expected = apt.expectedAmount || 0;
-    const paid = apt.paymentAmount || 0;
+    const expected = Number(apt.expectedAmount) || 0;
+    const paid = Number(apt.paymentAmount) || 0;
     return sum + (expected - paid);
   }, 0);
 
-  const calculatedOutstandingBalance = invoiceOutstanding + appointmentOutstanding;
+  const calculatedOutstandingBalance =
+    invoiceOutstanding + appointmentOutstanding;
 
   // Count total outstanding items
-  const outstandingItemsCount = unpaidInvoices.length + unpaidAppointments.length;
+  const outstandingItemsCount =
+    unpaidInvoices.length + unpaidAppointments.length;
 
   return (
     <Dialog
@@ -444,8 +495,8 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
             display: 'flex',
             flexDirection: 'column',
             height: '100vh',
-          })
-        }
+          }),
+        },
       }}
     >
       <DialogTitle
@@ -460,9 +511,14 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
           flexShrink: 0,
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}
+        >
           <PersonIcon sx={{ fontSize: { xs: 20, sm: 28 } }} />
-          <Typography variant={isMobile ? 'subtitle1' : 'h6'} sx={{ fontWeight: 600 }}>
+          <Typography
+            variant={isMobile ? 'subtitle1' : 'h6'}
+            sx={{ fontWeight: 600 }}
+          >
             Customer Details
           </Typography>
         </Box>
@@ -473,7 +529,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                 onClick={handleEditClick}
                 sx={{
                   color: 'white',
-                  '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' }
+                  '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' },
                 }}
               >
                 <EditIcon />
@@ -484,7 +540,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
             onClick={onClose}
             sx={{
               color: 'white',
-              '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' }
+              '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' },
             }}
           >
             <CloseIcon />
@@ -501,7 +557,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
         }}
       >
         {loading ? (
-          <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight="400px"
+          >
             <CircularProgress />
           </Box>
         ) : error ? (
@@ -522,7 +583,9 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     gap: 1.5,
                     cursor: 'pointer',
                   }}
-                  onClick={() => setCustomerDetailsExpanded(!customerDetailsExpanded)}
+                  onClick={() =>
+                    setCustomerDetailsExpanded(!customerDetailsExpanded)
+                  }
                 >
                   <Avatar
                     sx={{
@@ -539,7 +602,9 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                       {customer.firstName} {customer.lastName}
                     </Typography>
                     <Typography variant="body2" color="text.secondary" noWrap>
-                      {customer.phone ? formatPhoneForDisplay(customer.phone) : 'No phone'}
+                      {customer.phone
+                        ? formatPhoneForDisplay(customer.phone)
+                        : 'No phone'}
                       {customer.businessName && ` • ${customer.businessName}`}
                     </Typography>
                   </Box>
@@ -554,7 +619,11 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                       />
                     )}
                     <IconButton size="small">
-                      {customerDetailsExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                      {customerDetailsExpanded ? (
+                        <ExpandLessIcon />
+                      ) : (
+                        <ExpandMoreIcon />
+                      )}
                     </IconButton>
                   </Box>
                 </Box>
@@ -567,18 +636,32 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                       {customer.email && (
                         <Box display="flex" alignItems="center" gap={1}>
                           <EmailIcon fontSize="small" color="action" />
-                          <Typography variant="body2">{customer.email}</Typography>
+                          <Typography variant="body2">
+                            {customer.email}
+                          </Typography>
                         </Box>
                       )}
                       {customer.address && (
                         <Box display="flex" alignItems="flex-start" gap={1}>
-                          <LocationIcon fontSize="small" color="action" sx={{ mt: 0.2 }} />
-                          <Typography variant="body2">{customer.address}</Typography>
+                          <LocationIcon
+                            fontSize="small"
+                            color="action"
+                            sx={{ mt: 0.2 }}
+                          />
+                          <Typography variant="body2">
+                            {customer.address}
+                          </Typography>
                         </Box>
                       )}
                       {customer.stats?.lastVisitDate && (
                         <Typography variant="caption" color="text.secondary">
-                          Last visit: {formatDistanceToNow(parseISO(customer.stats.lastVisitDate as unknown as string), { addSuffix: true })}
+                          Last visit:{' '}
+                          {formatDistanceToNow(
+                            parseISO(
+                              customer.stats.lastVisitDate as unknown as string
+                            ),
+                            { addSuffix: true }
+                          )}
                         </Typography>
                       )}
                     </Stack>
@@ -588,22 +671,53 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                       <Grid size={6}>
                         <Card sx={{ bgcolor: 'success.light' }}>
                           <CardContent sx={{ p: 1, '&:last-child': { pb: 1 } }}>
-                            <Typography variant="caption" color="success.dark" fontWeight="medium">
+                            <Typography
+                              variant="caption"
+                              color="success.dark"
+                              fontWeight="medium"
+                            >
                               Total Spent
                             </Typography>
-                            <Typography variant="body2" fontWeight="bold" color="success.dark">
+                            <Typography
+                              variant="body2"
+                              fontWeight="bold"
+                              color="success.dark"
+                            >
                               {formatCurrency(customer.stats?.totalSpent || 0)}
                             </Typography>
                           </CardContent>
                         </Card>
                       </Grid>
                       <Grid size={6}>
-                        <Card sx={{ bgcolor: calculatedOutstandingBalance > 0 ? 'warning.light' : colors.neutral[100] }}>
+                        <Card
+                          sx={{
+                            bgcolor:
+                              calculatedOutstandingBalance > 0
+                                ? 'warning.light'
+                                : colors.neutral[100],
+                          }}
+                        >
                           <CardContent sx={{ p: 1, '&:last-child': { pb: 1 } }}>
-                            <Typography variant="caption" color={calculatedOutstandingBalance > 0 ? 'warning.dark' : 'text.secondary'} fontWeight="medium">
+                            <Typography
+                              variant="caption"
+                              color={
+                                calculatedOutstandingBalance > 0
+                                  ? 'warning.dark'
+                                  : 'text.secondary'
+                              }
+                              fontWeight="medium"
+                            >
                               Outstanding
                             </Typography>
-                            <Typography variant="body2" fontWeight="bold" color={calculatedOutstandingBalance > 0 ? 'warning.dark' : 'text.secondary'}>
+                            <Typography
+                              variant="body2"
+                              fontWeight="bold"
+                              color={
+                                calculatedOutstandingBalance > 0
+                                  ? 'warning.dark'
+                                  : 'text.secondary'
+                              }
+                            >
                               {formatCurrency(calculatedOutstandingBalance)}
                             </Typography>
                           </CardContent>
@@ -635,7 +749,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                           {customer.firstName} {customer.lastName}
                         </Typography>
                         {customer.businessName && (
-                          <Box display="flex" alignItems="center" gap={0.5} mt={0.5}>
+                          <Box
+                            display="flex"
+                            alignItems="center"
+                            gap={0.5}
+                            mt={0.5}
+                          >
                             <BusinessIcon fontSize="small" color="action" />
                             <Typography variant="body2" color="text.secondary">
                               {customer.businessName}
@@ -646,7 +765,9 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                           <Box display="flex" alignItems="center" gap={1}>
                             <PhoneIcon fontSize="small" color="action" />
                             <Typography variant="body2">
-                              {customer.phone ? formatPhoneForDisplay(customer.phone) : 'No phone'}
+                              {customer.phone
+                                ? formatPhoneForDisplay(customer.phone)
+                                : 'No phone'}
                             </Typography>
                           </Box>
                           <Box display="flex" alignItems="center" gap={1}>
@@ -657,14 +778,31 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                           </Box>
                           {customer.address && (
                             <Box display="flex" alignItems="flex-start" gap={1}>
-                              <LocationIcon fontSize="small" color="action" sx={{ mt: 0.2 }} />
-                              <Typography variant="body2">{customer.address}</Typography>
+                              <LocationIcon
+                                fontSize="small"
+                                color="action"
+                                sx={{ mt: 0.2 }}
+                              />
+                              <Typography variant="body2">
+                                {customer.address}
+                              </Typography>
                             </Box>
                           )}
                         </Stack>
                         {customer.stats?.lastVisitDate && (
-                          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                            Last visit: {formatDistanceToNow(parseISO(customer.stats.lastVisitDate as unknown as string), { addSuffix: true })}
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ mt: 1, display: 'block' }}
+                          >
+                            Last visit:{' '}
+                            {formatDistanceToNow(
+                              parseISO(
+                                customer.stats
+                                  .lastVisitDate as unknown as string
+                              ),
+                              { addSuffix: true }
+                            )}
                           </Typography>
                         )}
                       </Box>
@@ -678,13 +816,29 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                       <Grid size={6}>
                         <Card sx={{ height: '100%', bgcolor: 'success.light' }}>
                           <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-                            <Box display="flex" alignItems="center" gap={0.5} mb={0.5}>
-                              <TrendingUpIcon fontSize="small" sx={{ color: 'success.dark' }} />
-                              <Typography variant="caption" color="success.dark" fontWeight="medium">
+                            <Box
+                              display="flex"
+                              alignItems="center"
+                              gap={0.5}
+                              mb={0.5}
+                            >
+                              <TrendingUpIcon
+                                fontSize="small"
+                                sx={{ color: 'success.dark' }}
+                              />
+                              <Typography
+                                variant="caption"
+                                color="success.dark"
+                                fontWeight="medium"
+                              >
                                 Total Spent
                               </Typography>
                             </Box>
-                            <Typography variant="h6" fontWeight="bold" color="success.dark">
+                            <Typography
+                              variant="h6"
+                              fontWeight="bold"
+                              color="success.dark"
+                            >
                               {formatCurrency(customer.stats?.totalSpent || 0)}
                             </Typography>
                           </CardContent>
@@ -693,20 +847,40 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
 
                       {/* Outstanding Balance */}
                       <Grid size={6}>
-                        <Card sx={{
-                          height: '100%',
-                          bgcolor: calculatedOutstandingBalance > 0 ? 'warning.light' : colors.neutral[100]
-                        }}>
+                        <Card
+                          sx={{
+                            height: '100%',
+                            bgcolor:
+                              calculatedOutstandingBalance > 0
+                                ? 'warning.light'
+                                : colors.neutral[100],
+                          }}
+                        >
                           <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-                            <Box display="flex" alignItems="center" gap={0.5} mb={0.5}>
+                            <Box
+                              display="flex"
+                              alignItems="center"
+                              gap={0.5}
+                              mb={0.5}
+                            >
                               {calculatedOutstandingBalance > 0 ? (
-                                <WarningIcon fontSize="small" sx={{ color: 'warning.dark' }} />
+                                <WarningIcon
+                                  fontSize="small"
+                                  sx={{ color: 'warning.dark' }}
+                                />
                               ) : (
-                                <CheckCircleIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+                                <CheckCircleIcon
+                                  fontSize="small"
+                                  sx={{ color: 'text.secondary' }}
+                                />
                               )}
                               <Typography
                                 variant="caption"
-                                color={calculatedOutstandingBalance > 0 ? 'warning.dark' : 'text.secondary'}
+                                color={
+                                  calculatedOutstandingBalance > 0
+                                    ? 'warning.dark'
+                                    : 'text.secondary'
+                                }
                                 fontWeight="medium"
                               >
                                 Outstanding
@@ -715,7 +889,11 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                             <Typography
                               variant="h6"
                               fontWeight="bold"
-                              color={calculatedOutstandingBalance > 0 ? 'warning.dark' : 'text.secondary'}
+                              color={
+                                calculatedOutstandingBalance > 0
+                                  ? 'warning.dark'
+                                  : 'text.secondary'
+                              }
                             >
                               {formatCurrency(calculatedOutstandingBalance)}
                             </Typography>
@@ -731,7 +909,13 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
             <Divider />
 
             {/* Tabs Section - Outstanding, Appointments, Invoices, Vehicles */}
-            <Box sx={{ borderBottom: 1, borderColor: 'divider', px: { xs: 1, sm: 2 } }}>
+            <Box
+              sx={{
+                borderBottom: 1,
+                borderColor: 'divider',
+                px: { xs: 1, sm: 2 },
+              }}
+            >
               <Tabs
                 value={tabValue}
                 onChange={handleTabChange}
@@ -741,43 +925,66 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                 <Tab
                   icon={<WalletIcon />}
                   iconPosition="start"
-                  label={isMobile ? '' : `Outstanding (${outstandingItemsCount})`}
+                  label={
+                    isMobile ? '' : `Outstanding (${outstandingItemsCount})`
+                  }
                   sx={{
                     minHeight: 48,
-                    color: outstandingItemsCount > 0 ? 'warning.main' : undefined,
+                    color:
+                      outstandingItemsCount > 0 ? 'warning.main' : undefined,
                     '&.Mui-selected': {
-                      color: outstandingItemsCount > 0 ? 'warning.dark' : undefined,
-                    }
+                      color:
+                        outstandingItemsCount > 0 ? 'warning.dark' : undefined,
+                    },
                   }}
                 />
                 <Tab
                   icon={<CalendarIcon />}
                   iconPosition="start"
-                  label={isMobile ? '' : `Appointments (${customer.appointments?.length || 0})`}
+                  label={
+                    isMobile
+                      ? ''
+                      : `Appointments (${customer.appointments?.length || 0})`
+                  }
                   sx={{ minHeight: 48 }}
                 />
                 <Tab
                   icon={<ReceiptIcon />}
                   iconPosition="start"
-                  label={isMobile ? '' : `Invoices (${customer.invoices?.length || 0})`}
+                  label={
+                    isMobile
+                      ? ''
+                      : `Invoices (${customer.invoices?.length || 0})`
+                  }
                   sx={{ minHeight: 48 }}
                 />
                 <Tab
                   icon={<CarIcon />}
                   iconPosition="start"
-                  label={isMobile ? '' : `Vehicles (${customer.vehicles?.length || 0})`}
+                  label={
+                    isMobile
+                      ? ''
+                      : `Vehicles (${customer.vehicles?.length || 0})`
+                  }
                   sx={{ minHeight: 48 }}
                 />
               </Tabs>
             </Box>
 
-            <Box sx={{
-              p: { xs: 1.5, sm: 3 },
-              minHeight: { xs: 250, sm: 400 },
-              maxHeight: { xs: customerDetailsExpanded ? 'calc(100vh - 450px)' : 'calc(100vh - 220px)', sm: 400 },
-              overflow: 'auto',
-              flex: 1,
-            }}>
+            <Box
+              sx={{
+                p: { xs: 1.5, sm: 3 },
+                minHeight: { xs: 250, sm: 400 },
+                maxHeight: {
+                  xs: customerDetailsExpanded
+                    ? 'calc(100vh - 450px)'
+                    : 'calc(100vh - 220px)',
+                  sm: 400,
+                },
+                overflow: 'auto',
+                flex: 1,
+              }}
+            >
               {/* Outstanding Tab (index 0) */}
               <TabPanel value={tabValue} index={0}>
                 {outstandingItemsCount > 0 ? (
@@ -785,24 +992,49 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     {/* Summary Card */}
                     <Card sx={{ mb: 3, bgcolor: 'warning.light' }}>
                       <CardContent sx={{ py: 2 }}>
-                        <Box display="flex" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={2}>
+                        <Box
+                          display="flex"
+                          justifyContent="space-between"
+                          alignItems="center"
+                          flexWrap="wrap"
+                          gap={2}
+                        >
                           <Box>
-                            <Typography variant="subtitle2" color="warning.dark">
+                            <Typography
+                              variant="subtitle2"
+                              color="warning.dark"
+                            >
                               Total Outstanding Balance
                             </Typography>
-                            <Typography variant="h4" fontWeight="bold" color="warning.dark">
+                            <Typography
+                              variant="h4"
+                              fontWeight="bold"
+                              color="warning.dark"
+                            >
                               {formatCurrency(calculatedOutstandingBalance)}
                             </Typography>
                           </Box>
                           <Box textAlign="right">
                             {unpaidInvoices.length > 0 && (
-                              <Typography variant="caption" color="warning.dark" display="block">
-                                {unpaidInvoices.length} unpaid invoice{unpaidInvoices.length !== 1 ? 's' : ''}: {formatCurrency(invoiceOutstanding)}
+                              <Typography
+                                variant="caption"
+                                color="warning.dark"
+                                display="block"
+                              >
+                                {unpaidInvoices.length} unpaid invoice
+                                {unpaidInvoices.length !== 1 ? 's' : ''}:{' '}
+                                {formatCurrency(invoiceOutstanding)}
                               </Typography>
                             )}
                             {unpaidAppointments.length > 0 && (
-                              <Typography variant="caption" color="warning.dark" display="block">
-                                {unpaidAppointments.length} unpaid appointment{unpaidAppointments.length !== 1 ? 's' : ''}: {formatCurrency(appointmentOutstanding)}
+                              <Typography
+                                variant="caption"
+                                color="warning.dark"
+                                display="block"
+                              >
+                                {unpaidAppointments.length} unpaid appointment
+                                {unpaidAppointments.length !== 1 ? 's' : ''}:{' '}
+                                {formatCurrency(appointmentOutstanding)}
                               </Typography>
                             )}
                           </Box>
@@ -813,7 +1045,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     {/* Unpaid Invoice Cards */}
                     {unpaidInvoices.length > 0 && (
                       <Box mb={3}>
-                        <Typography variant="subtitle2" color="warning.main" fontWeight="bold" mb={2}>
+                        <Typography
+                          variant="subtitle2"
+                          color="warning.main"
+                          fontWeight="bold"
+                          mb={2}
+                        >
                           Unpaid Invoices ({unpaidInvoices.length})
                         </Typography>
                         <Grid container spacing={2}>
@@ -821,21 +1058,37 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                             <Grid size={{ xs: 12, sm: 6 }} key={invoice.id}>
                               <Card variant="outlined" sx={{ height: '100%' }}>
                                 <CardContent>
-                                  <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
+                                  <Box
+                                    display="flex"
+                                    justifyContent="space-between"
+                                    alignItems="flex-start"
+                                    mb={2}
+                                  >
                                     <Box>
                                       <Typography
                                         variant="subtitle1"
                                         fontWeight="bold"
                                         sx={{
                                           cursor: 'pointer',
-                                          '&:hover': { color: 'primary.main', textDecoration: 'underline' }
+                                          '&:hover': {
+                                            color: 'primary.main',
+                                            textDecoration: 'underline',
+                                          },
                                         }}
-                                        onClick={() => handleInvoiceClick(invoice.id)}
+                                        onClick={() =>
+                                          handleInvoiceClick(invoice.id)
+                                        }
                                       >
                                         #{invoice.invoiceNumber}
                                       </Typography>
-                                      <Typography variant="caption" color="text.secondary">
-                                        {formatDate(invoice.invoiceDate || invoice.createdAt)}
+                                      <Typography
+                                        variant="caption"
+                                        color="text.secondary"
+                                      >
+                                        {formatDate(
+                                          invoice.invoiceDate ||
+                                            invoice.createdAt
+                                        )}
                                       </Typography>
                                     </Box>
                                     <Chip
@@ -846,18 +1099,39 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                   </Box>
 
                                   {invoice.vehicle && (
-                                    <Box display="flex" alignItems="center" gap={0.5} mb={1}>
-                                      <CarIcon fontSize="small" color="action" />
-                                      <Typography variant="body2" color="text.secondary">
-                                        {invoice.vehicle.year} {invoice.vehicle.make} {invoice.vehicle.model}
+                                    <Box
+                                      display="flex"
+                                      alignItems="center"
+                                      gap={0.5}
+                                      mb={1}
+                                    >
+                                      <CarIcon
+                                        fontSize="small"
+                                        color="action"
+                                      />
+                                      <Typography
+                                        variant="body2"
+                                        color="text.secondary"
+                                      >
+                                        {invoice.vehicle.year}{' '}
+                                        {invoice.vehicle.make}{' '}
+                                        {invoice.vehicle.model}
                                       </Typography>
                                     </Box>
                                   )}
 
                                   <Divider sx={{ my: 1.5 }} />
 
-                                  <Box display="flex" justifyContent="space-between" alignItems="center">
-                                    <Typography variant="h6" fontWeight="bold" color="warning.dark">
+                                  <Box
+                                    display="flex"
+                                    justifyContent="space-between"
+                                    alignItems="center"
+                                  >
+                                    <Typography
+                                      variant="h6"
+                                      fontWeight="bold"
+                                      color="warning.dark"
+                                    >
                                       {formatCurrency(invoice.total)}
                                     </Typography>
                                     <Box display="flex" gap={1}>
@@ -866,7 +1140,9 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                         color="primary"
                                         size="small"
                                         startIcon={<CreditCardIcon />}
-                                        onClick={() => handlePayInvoiceWithSquare(invoice)}
+                                        onClick={() =>
+                                          handlePayInvoiceWithSquare(invoice)
+                                        }
                                       >
                                         Card
                                       </Button>
@@ -875,7 +1151,9 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                         color="success"
                                         size="small"
                                         startIcon={<PaymentIcon />}
-                                        onClick={() => handlePayInvoice(invoice)}
+                                        onClick={() =>
+                                          handlePayInvoice(invoice)
+                                        }
                                       >
                                         Pay
                                       </Button>
@@ -892,7 +1170,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     {/* Unpaid Appointments Cards */}
                     {unpaidAppointments.length > 0 && (
                       <Box>
-                        <Typography variant="subtitle2" color="warning.main" fontWeight="bold" mb={2}>
+                        <Typography
+                          variant="subtitle2"
+                          color="warning.main"
+                          fontWeight="bold"
+                          mb={2}
+                        >
                           Unpaid Appointments ({unpaidAppointments.length})
                         </Typography>
                         <Grid container spacing={2}>
@@ -904,29 +1187,60 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
 
                             return (
                               <Grid size={{ xs: 12, sm: 6 }} key={apt.id}>
-                                <Card variant="outlined" sx={{ height: '100%', borderColor: 'warning.main' }}>
+                                <Card
+                                  variant="outlined"
+                                  sx={{
+                                    height: '100%',
+                                    borderColor: 'warning.main',
+                                  }}
+                                >
                                   <CardContent>
-                                    <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
+                                    <Box
+                                      display="flex"
+                                      justifyContent="space-between"
+                                      alignItems="flex-start"
+                                      mb={2}
+                                    >
                                       <Box>
-                                        <Typography variant="subtitle1" fontWeight="bold">
+                                        <Typography
+                                          variant="subtitle1"
+                                          fontWeight="bold"
+                                        >
                                           {apt.serviceType.replace(/_/g, ' ')}
                                         </Typography>
-                                        <Typography variant="caption" color="text.secondary">
+                                        <Typography
+                                          variant="caption"
+                                          color="text.secondary"
+                                        >
                                           {formatDate(apt.scheduledDate)}
                                         </Typography>
                                       </Box>
                                       <Chip
-                                        label={isPartialPaid ? 'Partial' : 'Unpaid'}
+                                        label={
+                                          isPartialPaid ? 'Partial' : 'Unpaid'
+                                        }
                                         size="small"
                                         color="warning"
                                       />
                                     </Box>
 
                                     {apt.vehicle && (
-                                      <Box display="flex" alignItems="center" gap={0.5} mb={1}>
-                                        <CarIcon fontSize="small" color="action" />
-                                        <Typography variant="body2" color="text.secondary">
-                                          {apt.vehicle.year} {apt.vehicle.make} {apt.vehicle.model}
+                                      <Box
+                                        display="flex"
+                                        alignItems="center"
+                                        gap={0.5}
+                                        mb={1}
+                                      >
+                                        <CarIcon
+                                          fontSize="small"
+                                          color="action"
+                                        />
+                                        <Typography
+                                          variant="body2"
+                                          color="text.secondary"
+                                        >
+                                          {apt.vehicle.year} {apt.vehicle.make}{' '}
+                                          {apt.vehicle.model}
                                         </Typography>
                                       </Box>
                                     )}
@@ -934,8 +1248,15 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                     <Divider sx={{ my: 1.5 }} />
 
                                     <Box>
-                                      <Box display="flex" justifyContent="space-between" mb={0.5}>
-                                        <Typography variant="body2" color="text.secondary">
+                                      <Box
+                                        display="flex"
+                                        justifyContent="space-between"
+                                        mb={0.5}
+                                      >
+                                        <Typography
+                                          variant="body2"
+                                          color="text.secondary"
+                                        >
                                           Expected:
                                         </Typography>
                                         <Typography variant="body2">
@@ -943,21 +1264,43 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                         </Typography>
                                       </Box>
                                       {isPartialPaid && (
-                                        <Box display="flex" justifyContent="space-between" mb={0.5}>
-                                          <Typography variant="body2" color="text.secondary">
+                                        <Box
+                                          display="flex"
+                                          justifyContent="space-between"
+                                          mb={0.5}
+                                        >
+                                          <Typography
+                                            variant="body2"
+                                            color="text.secondary"
+                                          >
                                             Paid:
                                           </Typography>
-                                          <Typography variant="body2" color="success.main">
+                                          <Typography
+                                            variant="body2"
+                                            color="success.main"
+                                          >
                                             {formatCurrency(paid)}
                                           </Typography>
                                         </Box>
                                       )}
-                                      <Box display="flex" justifyContent="space-between" alignItems="center">
+                                      <Box
+                                        display="flex"
+                                        justifyContent="space-between"
+                                        alignItems="center"
+                                      >
                                         <Box>
-                                          <Typography variant="body2" fontWeight="bold" color="warning.dark">
+                                          <Typography
+                                            variant="body2"
+                                            fontWeight="bold"
+                                            color="warning.dark"
+                                          >
                                             Outstanding:
                                           </Typography>
-                                          <Typography variant="h6" fontWeight="bold" color="warning.dark">
+                                          <Typography
+                                            variant="h6"
+                                            fontWeight="bold"
+                                            color="warning.dark"
+                                          >
                                             {formatCurrency(outstanding)}
                                           </Typography>
                                         </Box>
@@ -966,7 +1309,9 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                           color="success"
                                           size="small"
                                           startIcon={<PaymentIcon />}
-                                          onClick={() => handleReceiveAppointmentPayment(apt)}
+                                          onClick={() =>
+                                            handleReceiveAppointmentPayment(apt)
+                                          }
                                         >
                                           Receive
                                         </Button>
@@ -983,8 +1328,14 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                   </Box>
                 ) : (
                   <Box textAlign="center" py={4}>
-                    <CheckCircleIcon sx={{ fontSize: 48, color: 'success.main', mb: 1 }} />
-                    <Typography variant="h6" color="success.main" fontWeight="medium">
+                    <CheckCircleIcon
+                      sx={{ fontSize: 48, color: 'success.main', mb: 1 }}
+                    />
+                    <Typography
+                      variant="h6"
+                      color="success.main"
+                      fontWeight="medium"
+                    >
                       All Paid Up!
                     </Typography>
                     <Typography color="text.secondary">
@@ -1001,14 +1352,21 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     {/* Upcoming Appointments Section */}
                     {upcomingAppointments.length > 0 && (
                       <Box mb={3}>
-                        <Typography variant="subtitle2" color="info.main" fontWeight="bold" mb={2}>
+                        <Typography
+                          variant="subtitle2"
+                          color="info.main"
+                          fontWeight="bold"
+                          mb={2}
+                        >
                           Upcoming Appointments ({upcomingAppointments.length})
                         </Typography>
                         <Grid container spacing={2}>
                           {upcomingAppointments.map((apt: Appointment) => (
                             <Grid size={{ xs: 12, md: 6 }} key={apt.id}>
                               <AppointmentCard
-                                appointment={convertToAppointmentCardFormat(apt)}
+                                appointment={convertToAppointmentCardFormat(
+                                  apt
+                                )}
                                 showActions={true}
                                 onEdit={handleEditAppointment}
                                 onDelete={handleDeleteAppointment}
@@ -1024,26 +1382,40 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     {/* Past Appointments Section */}
                     {pastAppointments.length > 0 && (
                       <Box>
-                        <Typography variant="subtitle2" color="text.secondary" fontWeight="bold" mb={2}>
+                        <Typography
+                          variant="subtitle2"
+                          color="text.secondary"
+                          fontWeight="bold"
+                          mb={2}
+                        >
                           Appointment History ({pastAppointments.length})
                         </Typography>
                         <Grid container spacing={2}>
-                          {pastAppointments.slice(0, 6).map((apt: Appointment) => (
-                            <Grid size={{ xs: 12, md: 6 }} key={apt.id}>
-                              <AppointmentCard
-                                appointment={convertToAppointmentCardFormat(apt)}
-                                showActions={true}
-                                onEdit={handleEditAppointment}
-                                onDelete={handleDeleteAppointment}
-                                onStatusChange={handleStatusChange}
-                                onPaymentComplete={loadCustomer}
-                              />
-                            </Grid>
-                          ))}
+                          {pastAppointments
+                            .slice(0, 6)
+                            .map((apt: Appointment) => (
+                              <Grid size={{ xs: 12, md: 6 }} key={apt.id}>
+                                <AppointmentCard
+                                  appointment={convertToAppointmentCardFormat(
+                                    apt
+                                  )}
+                                  showActions={true}
+                                  onEdit={handleEditAppointment}
+                                  onDelete={handleDeleteAppointment}
+                                  onStatusChange={handleStatusChange}
+                                  onPaymentComplete={loadCustomer}
+                                />
+                              </Grid>
+                            ))}
                         </Grid>
                         {pastAppointments.length > 6 && (
-                          <Typography variant="caption" color="text.secondary" sx={{ mt: 2, display: 'block' }}>
-                            Showing 6 of {pastAppointments.length} past appointments
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ mt: 2, display: 'block' }}
+                          >
+                            Showing 6 of {pastAppointments.length} past
+                            appointments
                           </Typography>
                         )}
                       </Box>
@@ -1051,8 +1423,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                   </Box>
                 ) : (
                   <Box textAlign="center" py={4}>
-                    <CalendarIcon sx={{ fontSize: 48, color: colors.neutral[300], mb: 1 }} />
-                    <Typography color="text.secondary">No appointments found</Typography>
+                    <CalendarIcon
+                      sx={{ fontSize: 48, color: colors.neutral[300], mb: 1 }}
+                    />
+                    <Typography color="text.secondary">
+                      No appointments found
+                    </Typography>
                   </Box>
                 )}
               </TabPanel>
@@ -1064,7 +1440,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     {/* Unpaid Invoices Section */}
                     {unpaidInvoices.length > 0 && (
                       <Box mb={3}>
-                        <Typography variant="subtitle2" color="warning.main" fontWeight="bold" mb={1}>
+                        <Typography
+                          variant="subtitle2"
+                          color="warning.main"
+                          fontWeight="bold"
+                          mb={1}
+                        >
                           Unpaid Invoices ({unpaidInvoices.length})
                         </Typography>
                         <TableContainer component={Paper} variant="outlined">
@@ -1080,28 +1461,48 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                             </TableHead>
                             <TableBody>
                               {unpaidInvoices.map((invoice: Invoice) => (
-                                <TableRow key={invoice.id} sx={{ bgcolor: 'warning.light' }}>
+                                <TableRow
+                                  key={invoice.id}
+                                  sx={{ bgcolor: 'warning.light' }}
+                                >
                                   <TableCell>
                                     <Link
                                       component="button"
                                       variant="body2"
                                       fontWeight="medium"
-                                      onClick={() => handleInvoiceClick(invoice.id)}
+                                      onClick={() =>
+                                        handleInvoiceClick(invoice.id)
+                                      }
                                       sx={{
                                         cursor: 'pointer',
                                         textDecoration: 'none',
-                                        '&:hover': { textDecoration: 'underline' },
+                                        '&:hover': {
+                                          textDecoration: 'underline',
+                                        },
                                       }}
                                     >
                                       {invoice.invoiceNumber}
                                     </Link>
                                     {isMobile && (
-                                      <Typography variant="caption" color="text.secondary" display="block">
-                                        {formatDate(invoice.invoiceDate || invoice.createdAt)}
+                                      <Typography
+                                        variant="caption"
+                                        color="text.secondary"
+                                        display="block"
+                                      >
+                                        {formatDate(
+                                          invoice.invoiceDate ||
+                                            invoice.createdAt
+                                        )}
                                       </Typography>
                                     )}
                                   </TableCell>
-                                  {!isMobile && <TableCell>{formatDate(invoice.invoiceDate || invoice.createdAt)}</TableCell>}
+                                  {!isMobile && (
+                                    <TableCell>
+                                      {formatDate(
+                                        invoice.invoiceDate || invoice.createdAt
+                                      )}
+                                    </TableCell>
+                                  )}
                                   {!isMobile && (
                                     <TableCell>
                                       {invoice.vehicle
@@ -1117,7 +1518,10 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                     />
                                   </TableCell>
                                   <TableCell align="right">
-                                    <Typography fontWeight="bold" color="warning.dark">
+                                    <Typography
+                                      fontWeight="bold"
+                                      color="warning.dark"
+                                    >
                                       {formatCurrency(invoice.total)}
                                     </Typography>
                                   </TableCell>
@@ -1132,7 +1536,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     {/* Paid/Other Invoices Section */}
                     {paidInvoices.length > 0 && (
                       <Box>
-                        <Typography variant="subtitle2" color="text.secondary" fontWeight="bold" mb={1}>
+                        <Typography
+                          variant="subtitle2"
+                          color="text.secondary"
+                          fontWeight="bold"
+                          mb={1}
+                        >
                           Invoice History
                         </Typography>
                         <TableContainer component={Paper} variant="outlined">
@@ -1147,52 +1556,76 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                               </TableRow>
                             </TableHead>
                             <TableBody>
-                              {paidInvoices.slice(0, 5).map((invoice: Invoice) => (
-                                <TableRow key={invoice.id} hover>
-                                  <TableCell>
-                                    <Link
-                                      component="button"
-                                      variant="body2"
-                                      onClick={() => handleInvoiceClick(invoice.id)}
-                                      sx={{
-                                        cursor: 'pointer',
-                                        textDecoration: 'none',
-                                        '&:hover': { textDecoration: 'underline' },
-                                      }}
-                                    >
-                                      {invoice.invoiceNumber}
-                                    </Link>
-                                    {isMobile && (
-                                      <Typography variant="caption" color="text.secondary" display="block">
-                                        {formatDate(invoice.invoiceDate || invoice.createdAt)}
-                                      </Typography>
-                                    )}
-                                  </TableCell>
-                                  {!isMobile && <TableCell>{formatDate(invoice.invoiceDate || invoice.createdAt)}</TableCell>}
-                                  {!isMobile && (
+                              {paidInvoices
+                                .slice(0, 5)
+                                .map((invoice: Invoice) => (
+                                  <TableRow key={invoice.id} hover>
                                     <TableCell>
-                                      {invoice.vehicle
-                                        ? `${invoice.vehicle.year} ${invoice.vehicle.make} ${invoice.vehicle.model}`
-                                        : '-'}
+                                      <Link
+                                        component="button"
+                                        variant="body2"
+                                        onClick={() =>
+                                          handleInvoiceClick(invoice.id)
+                                        }
+                                        sx={{
+                                          cursor: 'pointer',
+                                          textDecoration: 'none',
+                                          '&:hover': {
+                                            textDecoration: 'underline',
+                                          },
+                                        }}
+                                      >
+                                        {invoice.invoiceNumber}
+                                      </Link>
+                                      {isMobile && (
+                                        <Typography
+                                          variant="caption"
+                                          color="text.secondary"
+                                          display="block"
+                                        >
+                                          {formatDate(
+                                            invoice.invoiceDate ||
+                                              invoice.createdAt
+                                          )}
+                                        </Typography>
+                                      )}
                                     </TableCell>
-                                  )}
-                                  <TableCell>
-                                    <Chip
-                                      label={invoice.status}
-                                      size="small"
-                                      color={getStatusColor(invoice.status)}
-                                    />
-                                  </TableCell>
-                                  <TableCell align="right">
-                                    {formatCurrency(invoice.total)}
-                                  </TableCell>
-                                </TableRow>
-                              ))}
+                                    {!isMobile && (
+                                      <TableCell>
+                                        {formatDate(
+                                          invoice.invoiceDate ||
+                                            invoice.createdAt
+                                        )}
+                                      </TableCell>
+                                    )}
+                                    {!isMobile && (
+                                      <TableCell>
+                                        {invoice.vehicle
+                                          ? `${invoice.vehicle.year} ${invoice.vehicle.make} ${invoice.vehicle.model}`
+                                          : '-'}
+                                      </TableCell>
+                                    )}
+                                    <TableCell>
+                                      <Chip
+                                        label={invoice.status}
+                                        size="small"
+                                        color={getStatusColor(invoice.status)}
+                                      />
+                                    </TableCell>
+                                    <TableCell align="right">
+                                      {formatCurrency(invoice.total)}
+                                    </TableCell>
+                                  </TableRow>
+                                ))}
                             </TableBody>
                           </Table>
                         </TableContainer>
                         {paidInvoices.length > 5 && (
-                          <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ mt: 1, display: 'block' }}
+                          >
                             Showing 5 of {paidInvoices.length} paid invoices
                           </Typography>
                         )}
@@ -1201,8 +1634,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                   </Box>
                 ) : (
                   <Box textAlign="center" py={4}>
-                    <ReceiptIcon sx={{ fontSize: 48, color: colors.neutral[300], mb: 1 }} />
-                    <Typography color="text.secondary">No invoices found</Typography>
+                    <ReceiptIcon
+                      sx={{ fontSize: 48, color: colors.neutral[300], mb: 1 }}
+                    />
+                    <Typography color="text.secondary">
+                      No invoices found
+                    </Typography>
                   </Box>
                 )}
               </TabPanel>
@@ -1215,25 +1652,43 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                       <Grid size={{ xs: 12, sm: 6, md: 4 }} key={vehicle.id}>
                         <Card variant="outlined">
                           <CardContent>
-                            <Box display="flex" alignItems="center" gap={1} mb={1}>
+                            <Box
+                              display="flex"
+                              alignItems="center"
+                              gap={1}
+                              mb={1}
+                            >
                               <CarIcon color="primary" />
-                              <Typography variant="subtitle1" fontWeight="medium">
+                              <Typography
+                                variant="subtitle1"
+                                fontWeight="medium"
+                              >
                                 {vehicle.year} {vehicle.make} {vehicle.model}
                               </Typography>
                             </Box>
                             <Stack spacing={0.5}>
                               {vehicle.licensePlate && (
-                                <Typography variant="body2" color="text.secondary">
-                                  License: <strong>{vehicle.licensePlate}</strong>
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                >
+                                  License:{' '}
+                                  <strong>{vehicle.licensePlate}</strong>
                                 </Typography>
                               )}
                               {vehicle.vin && (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                >
                                   VIN: {vehicle.vin}
                                 </Typography>
                               )}
                               {vehicle.mileage && (
-                                <Typography variant="body2" color="text.secondary">
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                >
                                   Mileage: {vehicle.mileage.toLocaleString()} km
                                 </Typography>
                               )}
@@ -1245,8 +1700,12 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                   </Grid>
                 ) : (
                   <Box textAlign="center" py={4}>
-                    <CarIcon sx={{ fontSize: 48, color: colors.neutral[300], mb: 1 }} />
-                    <Typography color="text.secondary">No vehicles registered</Typography>
+                    <CarIcon
+                      sx={{ fontSize: 48, color: colors.neutral[300], mb: 1 }}
+                    />
+                    <Typography color="text.secondary">
+                      No vehicles registered
+                    </Typography>
                   </Box>
                 )}
               </TabPanel>
@@ -1293,12 +1752,16 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
           appointmentId={selectedAppointmentForPayment.id}
           defaultExpectedAmount={
             // Show REMAINING amount (expected - already paid), not full expected
-            (selectedAppointmentForPayment.expectedAmount || 0) - (selectedAppointmentForPayment.paymentAmount || 0)
+            (selectedAppointmentForPayment.expectedAmount || 0) -
+            (selectedAppointmentForPayment.paymentAmount || 0)
           }
           // Don't pass existingPayments - we want a fresh payment entry for the remaining balance
           assignedEmployeeIds={
-            selectedAppointmentForPayment.employees && selectedAppointmentForPayment.employees.length > 0
-              ? selectedAppointmentForPayment.employees.map((ae) => ae.employee.id)
+            selectedAppointmentForPayment.employees &&
+            selectedAppointmentForPayment.employees.length > 0
+              ? selectedAppointmentForPayment.employees.map(
+                  (ae) => ae.employee.id
+                )
               : []
           }
         />

--- a/apps/webApp/src/app/components/customers/CustomerDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDialog.tsx
@@ -17,6 +17,7 @@ import {
   useMediaQuery,
   FormControlLabel,
   Switch,
+  Checkbox,
 } from '@mui/material';
 import {
   Close as CloseIcon,
@@ -24,9 +25,16 @@ import {
   Edit as EditIcon,
   Save as SaveIcon,
   Cancel as CancelIcon,
+  Add as AddIcon,
+  Delete as DeleteIcon,
 } from '@mui/icons-material';
-import { TransitionProps} from '@mui/material/transitions';
-import { customerService, Customer, CreateCustomerDto, UpdateCustomerDto } from '../../requests/customer.requests';
+import { TransitionProps } from '@mui/material/transitions';
+import {
+  customerService,
+  Customer,
+  CreateCustomerDto,
+  UpdateCustomerDto,
+} from '../../requests/customer.requests';
 import { colors } from '../../theme/colors';
 import { PhoneInput } from '../common/PhoneInput';
 import { AddressAutocomplete } from '../common/AddressAutocomplete';
@@ -39,7 +47,7 @@ const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
     children: React.ReactElement;
   },
-  ref: React.Ref<unknown>,
+  ref: React.Ref<unknown>
 ) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
@@ -73,7 +81,9 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
     address: 'Prince George, BC',
     businessName: '',
     smsEnabled: true,
+    pstExempt: false,
   });
+  const [additionalEmails, setAdditionalEmails] = useState<string[]>([]);
 
   useEffect(() => {
     if (open) {
@@ -87,7 +97,9 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
           address: initialCustomer.address || '',
           businessName: initialCustomer.businessName || '',
           smsEnabled: initialCustomer.smsPreference?.optedIn ?? true,
+          pstExempt: initialCustomer.pstExempt ?? false,
         });
+        setAdditionalEmails(initialCustomer.additionalEmails || []);
       } else if (customerId) {
         // Load customer data if only ID is provided
         loadCustomer(customerId);
@@ -101,7 +113,9 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
           address: 'Prince George, BC',
           businessName: '',
           smsEnabled: true,
+          pstExempt: false,
         });
+        setAdditionalEmails([]);
       }
       setError(null);
     }
@@ -119,7 +133,9 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
         address: customer.address || '',
         businessName: customer.businessName || '',
         smsEnabled: customer.smsPreference?.optedIn ?? true,
+        pstExempt: customer.pstExempt ?? false,
       });
+      setAdditionalEmails(customer.additionalEmails || []);
     } catch (err: any) {
       setError(err.response?.data?.message || 'Failed to load customer');
     } finally {
@@ -136,9 +152,16 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
 
       let customerId_local = customerId;
 
+      // Drop blank rows and trim before sending
+      const cleanedAdditionalEmails = additionalEmails
+        .map((email) => email.trim())
+        .filter((email) => email !== '');
+
       if (isEdit && customerId) {
         const updateData: UpdateCustomerDto = {
           email: formData.email,
+          additionalEmails: cleanedAdditionalEmails,
+          pstExempt: formData.pstExempt,
           firstName: formData.firstName,
           lastName: formData.lastName,
           phone: formData.phone,
@@ -149,6 +172,8 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
       } else {
         const createData: CreateCustomerDto = {
           email: formData.email,
+          additionalEmails: cleanedAdditionalEmails,
+          pstExempt: formData.pstExempt,
           firstName: formData.firstName,
           lastName: formData.lastName,
           phone: formData.phone,
@@ -194,18 +219,35 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
     }
   };
 
-  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: e.target.value,
-    }));
-  };
+  const handleChange =
+    (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFormData((prev) => ({
+        ...prev,
+        [field]: e.target.value,
+      }));
+    };
 
   const handlePhoneChange = (value: string) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
       phone: value,
     }));
+  };
+
+  const handleAdditionalEmailChange =
+    (index: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setAdditionalEmails((prev) =>
+        prev.map((email, i) => (i === index ? value : email))
+      );
+    };
+
+  const handleAddEmail = () => {
+    setAdditionalEmails((prev) => [...prev, '']);
+  };
+
+  const handleRemoveEmail = (index: number) => {
+    setAdditionalEmails((prev) => prev.filter((_, i) => i !== index));
   };
 
   return (
@@ -224,8 +266,8 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
             display: 'flex',
             flexDirection: 'column',
             height: '100vh',
-          })
-        }
+          }),
+        },
       }}
     >
       <DialogTitle
@@ -240,9 +282,19 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
           flexShrink: 0,
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}>
-          {!isMobile && (isEdit ? <EditIcon sx={{ fontSize: 24 }} /> : <PersonAddIcon sx={{ fontSize: 24 }} />)}
-          <Typography variant={isMobile ? 'subtitle1' : 'h6'} sx={{ fontWeight: 600 }}>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}
+        >
+          {!isMobile &&
+            (isEdit ? (
+              <EditIcon sx={{ fontSize: 24 }} />
+            ) : (
+              <PersonAddIcon sx={{ fontSize: 24 }} />
+            ))}
+          <Typography
+            variant={isMobile ? 'subtitle1' : 'h6'}
+            sx={{ fontWeight: 600 }}
+          >
             {isEdit ? 'Edit Customer' : 'Add New Customer'}
           </Typography>
         </Box>
@@ -250,7 +302,7 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
           onClick={onClose}
           sx={{
             color: 'white',
-            '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' }
+            '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' },
           }}
         >
           <CloseIcon />
@@ -265,12 +317,17 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
           flex: '1 1 auto',
           minHeight: 0,
           '&:first-of-type': {
-            paddingTop: { xs: 2, sm: 3 }
-          }
+            paddingTop: { xs: 2, sm: 3 },
+          },
         }}
       >
         {loading ? (
-          <Box display="flex" justifyContent="center" alignItems="center" minHeight="300px">
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight="300px"
+          >
             <CircularProgress />
           </Box>
         ) : (
@@ -313,7 +370,47 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
                   onChange={handleChange('email')}
                   disabled={saving}
                   size={isMobile ? 'small' : 'medium'}
+                  helperText="Primary email"
                 />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Box>
+                  {additionalEmails.map((email, index) => (
+                    <Box
+                      key={index}
+                      display="flex"
+                      alignItems="center"
+                      gap={1}
+                      mb={2}
+                    >
+                      <TextField
+                        fullWidth
+                        size={isMobile ? 'small' : 'medium'}
+                        type="email"
+                        label={`Email ${index + 2}`}
+                        value={email}
+                        onChange={handleAdditionalEmailChange(index)}
+                        disabled={saving}
+                      />
+                      <IconButton
+                        aria-label="Remove email"
+                        onClick={() => handleRemoveEmail(index)}
+                        disabled={saving}
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </Box>
+                  ))}
+                  <Button
+                    startIcon={<AddIcon />}
+                    onClick={handleAddEmail}
+                    disabled={saving}
+                    size="small"
+                    sx={{ mt: 0.5 }}
+                  >
+                    Add Email
+                  </Button>
+                </Box>
               </Grid>
               <Grid size={{ xs: 12, md: 6 }}>
                 <PhoneInput
@@ -345,6 +442,34 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
                 />
               </Grid>
 
+              {/* PST Exempt */}
+              <Grid size={{ xs: 12 }}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={formData.pstExempt}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          pstExempt: e.target.checked,
+                        })
+                      }
+                      disabled={saving}
+                      color="primary"
+                    />
+                  }
+                  label={
+                    <Box>
+                      <Typography variant="body1">PST Exempt</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        When enabled, all invoices for this customer are charged
+                        0% PST (GST still applies)
+                      </Typography>
+                    </Box>
+                  }
+                />
+              </Grid>
+
               {/* SMS Notifications Toggle */}
               <Grid size={{ xs: 12 }}>
                 <Box sx={{ mt: 1 }}>
@@ -352,14 +477,21 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
                     control={
                       <Switch
                         checked={formData.smsEnabled}
-                        onChange={(e) => setFormData({ ...formData, smsEnabled: e.target.checked })}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            smsEnabled: e.target.checked,
+                          })
+                        }
                         disabled={saving || !formData.phone}
                         color="primary"
                       />
                     }
                     label={
                       <Box>
-                        <Typography variant="body1">Enable SMS Notifications</Typography>
+                        <Typography variant="body1">
+                          Enable SMS Notifications
+                        </Typography>
                         <Typography variant="caption" color="text.secondary">
                           {formData.phone
                             ? 'Receive appointment reminders, service updates, and promotional messages'
@@ -375,13 +507,15 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
         )}
       </DialogContent>
 
-      <DialogActions sx={{
-        p: { xs: 2, sm: 2.5 },
-        borderTop: `1px solid ${colors.neutral[200]}`,
-        flexShrink: 0,
-        gap: { xs: 1, sm: 0 },
-        flexDirection: isMobile ? 'column-reverse' : 'row'
-      }}>
+      <DialogActions
+        sx={{
+          p: { xs: 2, sm: 2.5 },
+          borderTop: `1px solid ${colors.neutral[200]}`,
+          flexShrink: 0,
+          gap: { xs: 1, sm: 0 },
+          flexDirection: isMobile ? 'column-reverse' : 'row',
+        }}
+      >
         <Button
           onClick={onClose}
           variant="outlined"
@@ -403,10 +537,10 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
             background: colors.gradients.primary,
             '&:hover': {
               background: colors.gradients.primary,
-            }
+            },
           }}
         >
-          {saving ? 'Saving...' : (isEdit ? 'Update' : 'Create')}
+          {saving ? 'Saving...' : isEdit ? 'Update' : 'Create'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
@@ -34,7 +34,7 @@ const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
     children: React.ReactElement;
   },
-  ref: React.Ref<unknown>,
+  ref: React.Ref<unknown>
 ) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
@@ -54,7 +54,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   invoice = null,
   quotationId,
 }) => {
-  const { } = useAuth();
+  const {} = useAuth();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [customers, setCustomers] = useState<any[]>([]);
@@ -65,7 +65,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   const [loading, setLoading] = useState(false);
   const [isNewCustomer, setIsNewCustomer] = useState(false);
   const isEditMode = Boolean(invoice);
-  
+
   const [customerForm, setCustomerForm] = useState({
     firstName: '',
     lastName: '',
@@ -74,7 +74,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
     phone: '',
     email: '',
   });
-  
+
   const [formData, setFormData] = useState({
     customerId: '',
     vehicleId: '',
@@ -86,7 +86,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
     status: 'PENDING',
     invoiceDate: new Date().toISOString().split('T')[0], // Today's date in YYYY-MM-DD format
   });
-  
+
   const [items, setItems] = useState<InvoiceItem[]>([]);
   const [newItem, setNewItem] = useState<InvoiceItem>({
     itemType: InvoiceItemType.SERVICE,
@@ -99,7 +99,10 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   });
 
   const formatTireType = (type: string) => {
-    return type.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, l => l.toUpperCase());
+    return type
+      .replace(/_/g, ' ')
+      .toLowerCase()
+      .replace(/\b\w/g, (l) => l.toUpperCase());
   };
 
   const calculateItemTotal = (item: InvoiceItem) => {
@@ -110,20 +113,24 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       return {
         subtotal: baseTotal,
         discountAmount: 0,
-        total: baseTotal // baseTotal is already negative for DISCOUNT items
+        total: baseTotal, // baseTotal is already negative for DISCOUNT items
       };
     }
 
     // For DISCOUNT_PERCENTAGE items, calculate based on other items
     if (item.itemType === InvoiceItemType.DISCOUNT_PERCENTAGE) {
       const otherItemsSubtotal = items
-        .filter(i => i.itemType !== InvoiceItemType.DISCOUNT && i.itemType !== InvoiceItemType.DISCOUNT_PERCENTAGE)
-        .reduce((sum, i) => sum + (i.quantity * i.unitPrice), 0);
+        .filter(
+          (i) =>
+            i.itemType !== InvoiceItemType.DISCOUNT &&
+            i.itemType !== InvoiceItemType.DISCOUNT_PERCENTAGE
+        )
+        .reduce((sum, i) => sum + i.quantity * i.unitPrice, 0);
       const percentageDiscount = (otherItemsSubtotal * item.unitPrice) / 100;
       return {
         subtotal: baseTotal,
         discountAmount: 0,
-        total: -percentageDiscount // Negative value for discount
+        total: -percentageDiscount, // Negative value for discount
       };
     }
 
@@ -140,7 +147,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
     return {
       subtotal: baseTotal,
       discountAmount,
-      total: baseTotal - discountAmount
+      total: baseTotal - discountAmount,
     };
   };
 
@@ -180,7 +187,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       phone: '',
       email: '',
     });
-    const defaultCompany = companies.find(c => c.isDefault) || companies[0];
+    const defaultCompany = companies.find((c) => c.isDefault) || companies[0];
     setFormData({
       customerId: '',
       vehicleId: '',
@@ -230,7 +237,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       paymentMethod: invoiceData.paymentMethod || '',
       notes: invoiceData.notes || '',
       status: invoiceData.status || 'PENDING',
-      invoiceDate: invoiceData.invoiceDate ? new Date(invoiceData.invoiceDate).toISOString().split('T')[0] : new Date().toISOString().split('T')[0],
+      invoiceDate: invoiceData.invoiceDate
+        ? new Date(invoiceData.invoiceDate).toISOString().split('T')[0]
+        : new Date().toISOString().split('T')[0],
     });
 
     // Populate items
@@ -257,12 +266,13 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   const loadData = async () => {
     try {
       // Use getCustomersSimple() for faster loading - no stats needed for autocomplete
-      const [customersData, tiresResult, servicesData, companiesData] = await Promise.all([
-        customerService.getCustomersSimple(),
-        TireService.getTires({ page: 1, limit: 100 }),
-        serviceService.getAll(),
-        companyService.getCompanies(),
-      ]);
+      const [customersData, tiresResult, servicesData, companiesData] =
+        await Promise.all([
+          customerService.getCustomersSimple(),
+          TireService.getTires({ page: 1, limit: 100 }),
+          serviceService.getAll(),
+          companyService.getCompanies(),
+        ]);
       setCustomers(customersData);
       setTires(tiresResult.items || []);
       setServices(servicesData);
@@ -270,8 +280,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
 
       // Set default company if not in edit mode
       if (!isEditMode && companiesData.length > 0) {
-        const defaultCompany = companiesData.find(c => c.isDefault) || companiesData[0];
-        setFormData(prev => ({ ...prev, companyId: defaultCompany.id }));
+        const defaultCompany =
+          companiesData.find((c) => c.isDefault) || companiesData[0];
+        setFormData((prev) => ({ ...prev, companyId: defaultCompany.id }));
       }
 
       // Return loaded data for use in initialization
@@ -297,7 +308,10 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
     }
   };
 
-  const loadQuotationData = async (quoteId: string, companiesList: Company[]) => {
+  const loadQuotationData = async (
+    quoteId: string,
+    companiesList: Company[]
+  ) => {
     try {
       const quotation = await quotationService.getQuote(quoteId);
 
@@ -315,8 +329,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       setIsNewCustomer(true);
 
       // Set form data with companies passed as parameter
-      const defaultCompany = companiesList.find(c => c.isDefault) || companiesList[0];
-      setFormData(prev => ({
+      const defaultCompany =
+        companiesList.find((c) => c.isDefault) || companiesList[0];
+      setFormData((prev) => ({
         ...prev,
         customerId: '', // Explicitly clear customerId for new customer
         vehicleId: '', // Clear vehicle selection
@@ -328,7 +343,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       }));
 
       // Convert quotation items to invoice items
-      const invoiceItems: InvoiceItem[] = quotation.items.map(item => ({
+      const invoiceItems: InvoiceItem[] = quotation.items.map((item) => ({
         itemType: item.itemType as InvoiceItemType,
         description: item.description,
         quantity: item.quantity,
@@ -387,7 +402,14 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
 
       invoiceData = {
         items: items.map((item) => {
-          const { itemType, description, quantity, unitPrice, tireId, tireName } = item;
+          const {
+            itemType,
+            description,
+            quantity,
+            unitPrice,
+            tireId,
+            tireName,
+          } = item;
           const itemData: any = {
             itemType,
             description,
@@ -430,7 +452,11 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
         if (customerId) {
           // When using existing customer, only send customerId
           invoiceData.customerId = customerId;
-        } else if (isNewCustomer && customerForm.firstName && customerForm.lastName) {
+        } else if (
+          isNewCustomer &&
+          customerForm.firstName &&
+          customerForm.lastName
+        ) {
           // When creating new customer, send customerData
           invoiceData.customerData = {
             firstName: customerForm.firstName,
@@ -478,7 +504,10 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
           : error.response.data.message || 'Unknown error';
         alert(`Error creating invoice: ${errorMessage}`);
       } else {
-        alert(`Error ${isEditMode ? 'updating' : 'creating'} invoice: ` + error.message);
+        alert(
+          `Error ${isEditMode ? 'updating' : 'creating'} invoice: ` +
+            error.message
+        );
       }
     } finally {
       setLoading(false);
@@ -487,7 +516,14 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
 
   const handleCustomerSelect = (customer: any) => {
     if (customer) {
-      setFormData({ ...formData, customerId: customer.id, vehicleId: '' });
+      // PST-exempt customers are charged 0% PST; reflect it in the form so the
+      // displayed total matches what the backend will compute.
+      setFormData({
+        ...formData,
+        customerId: customer.id,
+        vehicleId: '',
+        pstRate: customer.pstExempt ? 0 : 0.07,
+      });
       setCustomerForm({
         firstName: customer.firstName || '',
         lastName: customer.lastName || '',
@@ -510,16 +546,19 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   };
 
   const handleAddItem = () => {
-    if (newItem.description && (
-      newItem.itemType === InvoiceItemType.DISCOUNT ? newItem.unitPrice < 0 :
-      newItem.itemType === InvoiceItemType.DISCOUNT_PERCENTAGE ? newItem.unitPrice > 0 && newItem.unitPrice <= 100 :
-      newItem.unitPrice > 0
-    )) {
+    if (
+      newItem.description &&
+      (newItem.itemType === InvoiceItemType.DISCOUNT
+        ? newItem.unitPrice < 0
+        : newItem.itemType === InvoiceItemType.DISCOUNT_PERCENTAGE
+        ? newItem.unitPrice > 0 && newItem.unitPrice <= 100
+        : newItem.unitPrice > 0)
+    ) {
       const calculation = calculateItemTotal(newItem);
       const itemWithCalculations = {
         ...newItem,
         discountAmount: calculation.discountAmount,
-        total: calculation.total
+        total: calculation.total,
       };
       console.log('Adding item to invoice:', itemWithCalculations);
 
@@ -554,7 +593,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   };
 
   const handleTireSelect = (tireId: string) => {
-    const tire = tires.find(t => t.id === tireId);
+    const tire = tires.find((t) => t.id === tireId);
     if (tire) {
       console.log('Selected tire:', tire);
       console.log('Tire name:', tire.name);
@@ -562,7 +601,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
         ...newItem,
         tireId: tire.id,
         itemType: InvoiceItemType.TIRE,
-        description: `${tire.brand} ${formatTireType(tire.type)} - ${tire.size}`,
+        description: `${tire.brand} ${formatTireType(tire.type)} - ${
+          tire.size
+        }`,
         unitPrice: parseFloat(tire.price),
         tireName: tire.name || undefined,
       };
@@ -587,8 +628,8 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
             display: 'flex',
             flexDirection: 'column',
             height: '100vh',
-          })
-        }
+          }),
+        },
       }}
     >
       <DialogTitle
@@ -602,11 +643,18 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
           px: { xs: 2, sm: 3 },
           ...(isMobile && {
             flexShrink: 0,
-          })
+          }),
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}>
-          <ReceiptIcon sx={{ fontSize: { xs: 24, sm: 28 }, display: { xs: 'none', sm: 'block' } }} />
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}
+        >
+          <ReceiptIcon
+            sx={{
+              fontSize: { xs: 24, sm: 28 },
+              display: { xs: 'none', sm: 'block' },
+            }}
+          />
           <Box>
             <Typography
               variant={isMobile ? 'h6' : 'h5'}
@@ -616,7 +664,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
             </Typography>
             {!isMobile && (
               <Typography variant="body2" sx={{ opacity: 0.9 }}>
-                {isEditMode ? 'Update invoice details and items' : 'Generate professional invoices for your customers'}
+                {isEditMode
+                  ? 'Update invoice details and items'
+                  : 'Generate professional invoices for your customers'}
               </Typography>
             )}
           </Box>
@@ -626,7 +676,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
           size={isMobile ? 'small' : 'medium'}
           sx={{
             color: 'white',
-            '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' }
+            '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' },
           }}
         >
           <CloseIcon fontSize={isMobile ? 'small' : 'medium'} />
@@ -640,7 +690,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
             flex: '1 1 auto',
             overflowY: 'auto',
             minHeight: 0,
-          })
+          }),
         }}
       >
         <InvoiceFormContent
@@ -676,7 +726,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
           ...(isMobile && {
             flexShrink: 0,
             backgroundColor: 'white',
-          })
+          }),
         }}
       >
         <Button
@@ -690,8 +740,8 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
             color: colors.text.secondary,
             '&:hover': {
               borderColor: colors.neutral[600],
-              background: colors.neutral[50]
-            }
+              background: colors.neutral[50],
+            },
           }}
         >
           Cancel
@@ -701,27 +751,36 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
           variant="contained"
           size="large"
           fullWidth={isMobile}
-          disabled={loading || (!formData.customerId && (!customerForm.firstName || !customerForm.lastName)) || items.length === 0}
+          disabled={
+            loading ||
+            (!formData.customerId &&
+              (!customerForm.firstName || !customerForm.lastName)) ||
+            items.length === 0
+          }
           sx={{
             background: colors.primary.main,
             color: 'white',
             minWidth: 140,
-            '&:hover': { 
+            '&:hover': {
               background: colors.primary.dark,
             },
             '&:disabled': {
               background: colors.neutral[300],
-              color: colors.neutral[500]
-            }
+              color: colors.neutral[500],
+            },
           }}
         >
           {loading
-            ? (isEditMode ? 'Updating...' : 'Creating...')
-            : (isEditMode
-                ? (isMobile ? 'Update' : 'Update Invoice')
-                : (isMobile ? 'Create' : 'Create Invoice')
-              )
-          }
+            ? isEditMode
+              ? 'Updating...'
+              : 'Creating...'
+            : isEditMode
+            ? isMobile
+              ? 'Update'
+              : 'Update Invoice'
+            : isMobile
+            ? 'Create'
+            : 'Create Invoice'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/webApp/src/app/pages/customers/CustomerForm.tsx
+++ b/apps/webApp/src/app/pages/customers/CustomerForm.tsx
@@ -11,11 +11,22 @@ import {
   CircularProgress,
   FormControlLabel,
   Switch,
+  Checkbox,
+  IconButton,
 } from '@mui/material';
-import { Save as SaveIcon, Cancel as CancelIcon } from '@mui/icons-material';
+import {
+  Save as SaveIcon,
+  Cancel as CancelIcon,
+  Add as AddIcon,
+  Delete as DeleteIcon,
+} from '@mui/icons-material';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '@clerk/clerk-react';
-import { customerService, CreateCustomerDto, UpdateCustomerDto } from '../../requests/customer.requests';
+import {
+  customerService,
+  CreateCustomerDto,
+  UpdateCustomerDto,
+} from '../../requests/customer.requests';
 import { PhoneInput } from '../../components/common/PhoneInput';
 import { AddressAutocomplete } from '../../components/common/AddressAutocomplete';
 import axios from 'axios';
@@ -40,7 +51,9 @@ export function CustomerForm() {
     phone: '',
     address: 'Prince George, BC',
     businessName: '',
+    pstExempt: false,
   });
+  const [additionalEmails, setAdditionalEmails] = useState<string[]>([]);
 
   useEffect(() => {
     if (isEdit && id) {
@@ -59,7 +72,9 @@ export function CustomerForm() {
         phone: customer.phone || '',
         address: customer.address || '',
         businessName: customer.businessName || '',
+        pstExempt: customer.pstExempt ?? false,
       });
+      setAdditionalEmails(customer.additionalEmails || []);
 
       // Load SMS preferences
       try {
@@ -70,7 +85,7 @@ export function CustomerForm() {
             headers: {
               'Content-Type': 'application/json',
               ...(token && { Authorization: `Bearer ${token}` }),
-            }
+            },
           }
         );
         setSmsEnabled(prefsResponse.data.optedIn || false);
@@ -94,11 +109,22 @@ export function CustomerForm() {
 
       let customerId = id;
 
+      // Drop blank rows and trim before sending
+      const cleanedAdditionalEmails = additionalEmails
+        .map((email) => email.trim())
+        .filter((email) => email !== '');
+
       if (isEdit && id) {
-        const updateData: UpdateCustomerDto = { ...formData };
+        const updateData: UpdateCustomerDto = {
+          ...formData,
+          additionalEmails: cleanedAdditionalEmails,
+        };
         await customerService.updateCustomer(id, updateData);
       } else {
-        const createData: CreateCustomerDto = { ...formData };
+        const createData: CreateCustomerDto = {
+          ...formData,
+          additionalEmails: cleanedAdditionalEmails,
+        };
         const newCustomer = await customerService.createCustomer(createData);
         customerId = newCustomer.id;
       }
@@ -119,7 +145,7 @@ export function CustomerForm() {
             headers: {
               'Content-Type': 'application/json',
               ...(token && { Authorization: `Bearer ${token}` }),
-            }
+            },
           }
         );
       }
@@ -132,23 +158,45 @@ export function CustomerForm() {
     }
   };
 
-  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: e.target.value,
-    }));
-  };
+  const handleChange =
+    (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFormData((prev) => ({
+        ...prev,
+        [field]: e.target.value,
+      }));
+    };
 
   const handlePhoneChange = (value: string) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
       phone: value,
     }));
   };
 
+  const handleAdditionalEmailChange =
+    (index: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setAdditionalEmails((prev) =>
+        prev.map((email, i) => (i === index ? value : email))
+      );
+    };
+
+  const handleAddEmail = () => {
+    setAdditionalEmails((prev) => [...prev, '']);
+  };
+
+  const handleRemoveEmail = (index: number) => {
+    setAdditionalEmails((prev) => prev.filter((_, i) => i !== index));
+  };
+
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="60vh"
+      >
         <CircularProgress />
       </Box>
     );
@@ -198,7 +246,46 @@ export function CustomerForm() {
                   value={formData.email}
                   onChange={handleChange('email')}
                   disabled={saving}
+                  helperText="Primary email"
                 />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Box>
+                  {additionalEmails.map((email, index) => (
+                    <Box
+                      key={index}
+                      display="flex"
+                      alignItems="center"
+                      gap={1}
+                      mb={2}
+                    >
+                      <TextField
+                        fullWidth
+                        type="email"
+                        label={`Email ${index + 2}`}
+                        value={email}
+                        onChange={handleAdditionalEmailChange(index)}
+                        disabled={saving}
+                      />
+                      <IconButton
+                        aria-label="Remove email"
+                        onClick={() => handleRemoveEmail(index)}
+                        disabled={saving}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+                  ))}
+                  <Button
+                    startIcon={<AddIcon />}
+                    onClick={handleAddEmail}
+                    disabled={saving}
+                    size="small"
+                    sx={{ mt: 0.5 }}
+                  >
+                    Add Email
+                  </Button>
+                </Box>
               </Grid>
               <Grid size={{ xs: 12, md: 6 }}>
                 <PhoneInput
@@ -221,7 +308,9 @@ export function CustomerForm() {
                     }
                     label={
                       <Box>
-                        <Typography variant="body1">Enable SMS Notifications</Typography>
+                        <Typography variant="body1">
+                          Enable SMS Notifications
+                        </Typography>
                         <Typography variant="caption" color="text.secondary">
                           {formData.phone
                             ? 'Receive appointment reminders, service updates, and promotional messages'
@@ -252,6 +341,32 @@ export function CustomerForm() {
                 />
               </Grid>
               <Grid size={12}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={formData.pstExempt}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          pstExempt: e.target.checked,
+                        })
+                      }
+                      disabled={saving}
+                      color="primary"
+                    />
+                  }
+                  label={
+                    <Box>
+                      <Typography variant="body1">PST Exempt</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        When enabled, all invoices for this customer are charged
+                        0% PST (GST still applies)
+                      </Typography>
+                    </Box>
+                  }
+                />
+              </Grid>
+              <Grid size={12}>
                 <Box display="flex" gap={2} justifyContent="flex-end">
                   <Button
                     variant="outlined"
@@ -267,7 +382,7 @@ export function CustomerForm() {
                     startIcon={<SaveIcon />}
                     disabled={saving}
                   >
-                    {saving ? 'Saving...' : (isEdit ? 'Update' : 'Create')}
+                    {saving ? 'Saving...' : isEdit ? 'Update' : 'Create'}
                   </Button>
                 </Box>
               </Grid>

--- a/apps/webApp/src/app/pages/invoices/InvoiceList.tsx
+++ b/apps/webApp/src/app/pages/invoices/InvoiceList.tsx
@@ -48,7 +48,6 @@ import { useConfirmation } from '../../contexts/ConfirmationContext';
 import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { PaymentMethod } from '../../../enums';
 
-
 const InvoiceList: React.FC = () => {
   const navigate = useNavigate();
   const theme = useTheme();
@@ -73,7 +72,9 @@ const InvoiceList: React.FC = () => {
   const [editingInvoice, setEditingInvoice] = useState<Invoice | null>(null);
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [paymentDialogOpen, setPaymentDialogOpen] = useState(false);
-  const [invoiceToMarkPaid, setInvoiceToMarkPaid] = useState<Invoice | null>(null);
+  const [invoiceToMarkPaid, setInvoiceToMarkPaid] = useState<Invoice | null>(
+    null
+  );
   const [emailDialogOpen, setEmailDialogOpen] = useState(false);
   const [invoiceForEmail, setInvoiceForEmail] = useState<Invoice | null>(null);
 
@@ -137,14 +138,19 @@ const InvoiceList: React.FC = () => {
 
   const handleSearch = async () => {
     try {
-      const hasFilters = searchParams.status || searchParams.search || searchParams.companyId || searchParams.startDate || searchParams.endDate;
+      const hasFilters =
+        searchParams.status ||
+        searchParams.search ||
+        searchParams.companyId ||
+        searchParams.startDate ||
+        searchParams.endDate;
 
       const filtered = hasFilters
         ? await invoiceService.searchInvoices({
             // Pass combined search to both customerName and invoiceNumber
             customerName: searchParams.search || undefined,
             invoiceNumber: searchParams.search || undefined,
-            status: searchParams.status as any || undefined,
+            status: (searchParams.status as any) || undefined,
             companyId: searchParams.companyId || undefined,
             startDate: searchParams.startDate || undefined,
             endDate: searchParams.endDate || undefined,
@@ -158,7 +164,10 @@ const InvoiceList: React.FC = () => {
     }
   };
 
-  const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    value: number
+  ) => {
     setPage(value);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
@@ -166,7 +175,6 @@ const InvoiceList: React.FC = () => {
   const handlePrint = (invoice: Invoice) => {
     invoiceService.printInvoice(invoice);
   };
-
 
   const handleDelete = async (invoice: Invoice) => {
     const confirmed = await confirm({
@@ -202,7 +210,10 @@ const InvoiceList: React.FC = () => {
     if (!invoiceToMarkPaid) return;
 
     try {
-      await invoiceService.markInvoiceAsPaid(invoiceToMarkPaid.id, paymentMethod);
+      await invoiceService.markInvoiceAsPaid(
+        invoiceToMarkPaid.id,
+        paymentMethod
+      );
       loadInvoices(); // Refresh the list
       setInvoiceToMarkPaid(null);
     } catch (error) {
@@ -211,54 +222,50 @@ const InvoiceList: React.FC = () => {
   };
 
   const handleSendEmail = async (invoice: Invoice) => {
-    // If customer has no email, open the email prompt dialog
-    if (!invoice.customer?.email) {
-      setInvoiceForEmail(invoice);
-      setEmailDialogOpen(true);
-      return;
-    }
-
-    // Customer has email, confirm and send directly
-    const confirmed = await confirm({
-      title: 'Send Invoice Email',
-      message: `Send invoice ${invoice.invoiceNumber} to ${invoice.customer.email}?\n\nThis will generate a PDF and send it via email to the customer.`,
-      confirmText: 'Send Email',
-      cancelText: 'Cancel',
-    });
-
-    if (confirmed) {
-      try {
-        await invoiceService.sendInvoiceEmail(invoice.id);
-        await confirm({
-          title: 'Invoice Sent Successfully!',
-          message: `Invoice ${invoice.invoiceNumber} has been emailed to ${invoice.customer.email}`,
-          confirmText: 'OK',
-          showCancelButton: false,
-        });
-      } catch (error) {
-        showApiError(error, 'Failed to send invoice email');
-      }
-    }
+    // Always open the dialog so the user can pick which email(s) to send to
+    setInvoiceForEmail(invoice);
+    setEmailDialogOpen(true);
   };
 
-  const handleEmailPromptSubmit = async (email: string, saveToCustomer: boolean) => {
+  const handleEmailPromptSubmit = async (
+    emails: string[],
+    saveToCustomer: boolean
+  ) => {
     if (!invoiceForEmail) return;
+    const invoice = invoiceForEmail;
 
     try {
-      const result = await invoiceService.sendInvoiceEmail(invoiceForEmail.id, email, saveToCustomer);
-      await confirm({
-        title: 'Invoice Sent Successfully!',
-        message: `Invoice ${invoiceForEmail.invoiceNumber} has been emailed to ${result.emailUsed || email}${saveToCustomer ? '\n\nEmail has been saved to customer profile.' : ''}`,
-        confirmText: 'OK',
-        showCancelButton: false,
-      });
+      const result = await invoiceService.sendInvoiceEmail(
+        invoice.id,
+        emails,
+        saveToCustomer
+      );
+
+      // Close the email dialog first so its loading spinner doesn't linger
+      // behind the success confirmation dialog.
+      setEmailDialogOpen(false);
+      setInvoiceForEmail(null);
+
       // Refresh invoices to show updated customer email if saved
       if (saveToCustomer) {
         loadInvoices();
       }
+
+      await confirm({
+        title: 'Invoice Sent Successfully!',
+        message: `Invoice ${invoice.invoiceNumber} has been emailed to ${
+          result.emailUsed || emails.join(', ')
+        }${
+          saveToCustomer
+            ? '\n\nNew emails have been saved to the customer profile.'
+            : ''
+        }`,
+        confirmText: 'OK',
+        showCancelButton: false,
+      });
     } catch (error) {
       showApiError(error, 'Failed to send invoice email');
-      throw error; // Re-throw to keep dialog open
+      throw error; // Re-throw to keep dialog open on failure
     }
   };
 
@@ -269,7 +276,16 @@ const InvoiceList: React.FC = () => {
     setEditingInvoice(null);
     // Optionally navigate to the invoice details (only for new invoices)
     if (!editingInvoice) {
-      const basePath = role === 'admin' ? '/admin' : role === 'supervisor' ? '/supervisor' : role === 'staff' ? '/staff' : role === 'accountant' ? '/accountant' : '/customer';
+      const basePath =
+        role === 'admin'
+          ? '/admin'
+          : role === 'supervisor'
+          ? '/supervisor'
+          : role === 'staff'
+          ? '/staff'
+          : role === 'accountant'
+          ? '/accountant'
+          : '/customer';
       navigate(`${basePath}/invoices/${invoice.id}`);
     }
   };
@@ -315,8 +331,10 @@ const InvoiceList: React.FC = () => {
     return date.toLocaleDateString('en-US', { timeZone: 'UTC' });
   };
 
-  const canCreateInvoice = role === 'staff' || role === 'supervisor' || role === 'admin';
-  const canManageInvoice = role === 'staff' || role === 'supervisor' || role === 'admin';
+  const canCreateInvoice =
+    role === 'staff' || role === 'supervisor' || role === 'admin';
+  const canManageInvoice =
+    role === 'staff' || role === 'supervisor' || role === 'admin';
   const canDeleteInvoice = role === 'admin';
 
   const getInvoiceActions = (invoice: Invoice): ActionItem[] => {
@@ -326,7 +344,16 @@ const InvoiceList: React.FC = () => {
         label: 'View Details',
         icon: <ViewIcon />,
         onClick: () => {
-          const basePath = role === 'admin' ? '/admin' : role === 'supervisor' ? '/supervisor' : role === 'staff' ? '/staff' : role === 'accountant' ? '/accountant' : '/customer';
+          const basePath =
+            role === 'admin'
+              ? '/admin'
+              : role === 'supervisor'
+              ? '/supervisor'
+              : role === 'staff'
+              ? '/staff'
+              : role === 'accountant'
+              ? '/accountant'
+              : '/customer';
           navigate(`${basePath}/invoices/${invoice.id}`);
         },
         show: true,
@@ -378,14 +405,16 @@ const InvoiceList: React.FC = () => {
 
   return (
     <Box sx={{ p: { xs: 1, sm: 3 } }}>
-      <Box sx={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        mb: { xs: 2, sm: 3 },
-        flexDirection: isMobile ? 'column' : 'row',
-        gap: { xs: 2, sm: 0 },
-        alignItems: isMobile ? 'stretch' : 'center'
-      }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          mb: { xs: 2, sm: 3 },
+          flexDirection: isMobile ? 'column' : 'row',
+          gap: { xs: 2, sm: 0 },
+          alignItems: isMobile ? 'stretch' : 'center',
+        }}
+      >
         <Typography variant={isMobile ? 'h5' : 'h4'} component="h1">
           Invoices
         </Typography>
@@ -413,9 +442,27 @@ const InvoiceList: React.FC = () => {
           }}
           onClick={() => isMobile && setFiltersExpanded(!filtersExpanded)}
         >
-          <FilterListIcon sx={{ color: theme.palette.primary.main, fontSize: isMobile ? 20 : 24 }} />
-          <Typography variant={isMobile ? 'subtitle1' : 'h6'} sx={{ fontWeight: 600 }}>
-            Filters {isMobile && `(${[searchParams.status, searchParams.search, searchParams.companyId, searchParams.startDate, searchParams.endDate].filter(Boolean).length})`}
+          <FilterListIcon
+            sx={{
+              color: theme.palette.primary.main,
+              fontSize: isMobile ? 20 : 24,
+            }}
+          />
+          <Typography
+            variant={isMobile ? 'subtitle1' : 'h6'}
+            sx={{ fontWeight: 600 }}
+          >
+            Filters{' '}
+            {isMobile &&
+              `(${
+                [
+                  searchParams.status,
+                  searchParams.search,
+                  searchParams.companyId,
+                  searchParams.startDate,
+                  searchParams.endDate,
+                ].filter(Boolean).length
+              })`}
           </Typography>
           {isMobile && (
             <IconButton size="small" sx={{ ml: 'auto' }}>
@@ -449,7 +496,9 @@ const InvoiceList: React.FC = () => {
                 select
                 label="Status"
                 value={searchParams.status}
-                onChange={(e) => setSearchParams({ ...searchParams, status: e.target.value })}
+                onChange={(e) =>
+                  setSearchParams({ ...searchParams, status: e.target.value })
+                }
                 size={isMobile ? 'small' : 'medium'}
               >
                 <MenuItem value="">All</MenuItem>
@@ -466,7 +515,12 @@ const InvoiceList: React.FC = () => {
                 select
                 label="Company"
                 value={searchParams.companyId}
-                onChange={(e) => setSearchParams({ ...searchParams, companyId: e.target.value })}
+                onChange={(e) =>
+                  setSearchParams({
+                    ...searchParams,
+                    companyId: e.target.value,
+                  })
+                }
                 size={isMobile ? 'small' : 'medium'}
               >
                 <MenuItem value="">All Companies</MenuItem>
@@ -483,7 +537,12 @@ const InvoiceList: React.FC = () => {
                 type="date"
                 label="Start Date"
                 value={searchParams.startDate}
-                onChange={(e) => setSearchParams({ ...searchParams, startDate: e.target.value })}
+                onChange={(e) =>
+                  setSearchParams({
+                    ...searchParams,
+                    startDate: e.target.value,
+                  })
+                }
                 size={isMobile ? 'small' : 'medium'}
                 InputLabelProps={{ shrink: true }}
               />
@@ -494,7 +553,9 @@ const InvoiceList: React.FC = () => {
                 type="date"
                 label="End Date"
                 value={searchParams.endDate}
-                onChange={(e) => setSearchParams({ ...searchParams, endDate: e.target.value })}
+                onChange={(e) =>
+                  setSearchParams({ ...searchParams, endDate: e.target.value })
+                }
                 size={isMobile ? 'small' : 'medium'}
                 InputLabelProps={{ shrink: true }}
               />
@@ -521,31 +582,57 @@ const InvoiceList: React.FC = () => {
                   p: 1.5,
                   border: `1px solid ${theme.palette.divider}`,
                   borderLeft: `4px solid ${
-                    invoice.status === 'PAID' ? theme.palette.success.main :
-                    invoice.status === 'PENDING' ? theme.palette.warning.main :
-                    invoice.status === 'CANCELLED' ? theme.palette.error.main :
-                    theme.palette.grey[400]
+                    invoice.status === 'PAID'
+                      ? theme.palette.success.main
+                      : invoice.status === 'PENDING'
+                      ? theme.palette.warning.main
+                      : invoice.status === 'CANCELLED'
+                      ? theme.palette.error.main
+                      : theme.palette.grey[400]
                   }`,
                 }}
               >
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 0.75 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-start',
+                    mb: 0.75,
+                  }}
+                >
                   <Box sx={{ flex: 1 }}>
                     <Link
                       onClick={() => {
-                        const basePath = role === 'admin' ? '/admin' : role === 'supervisor' ? '/supervisor' : role === 'staff' ? '/staff' : role === 'accountant' ? '/accountant' : '/customer';
+                        const basePath =
+                          role === 'admin'
+                            ? '/admin'
+                            : role === 'supervisor'
+                            ? '/supervisor'
+                            : role === 'staff'
+                            ? '/staff'
+                            : role === 'accountant'
+                            ? '/accountant'
+                            : '/customer';
                         navigate(`${basePath}/invoices/${invoice.id}`);
                       }}
                       sx={{
                         cursor: 'pointer',
                         textDecoration: 'none',
-                        '&:hover': { textDecoration: 'underline' }
+                        '&:hover': { textDecoration: 'underline' },
                       }}
                     >
-                      <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.25, fontSize: '0.875rem' }}>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ fontWeight: 700, mb: 0.25, fontSize: '0.875rem' }}
+                      >
                         {invoice.invoiceNumber}
                       </Typography>
                     </Link>
-                    <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ fontSize: '0.7rem' }}
+                    >
                       {formatDate(invoice.invoiceDate || invoice.createdAt)}
                     </Typography>
                   </Box>
@@ -556,11 +643,16 @@ const InvoiceList: React.FC = () => {
                   />
                 </Box>
 
-                <Typography variant="body2" sx={{ mb: 0.75, fontSize: '0.8rem' }}>
+                <Typography
+                  variant="body2"
+                  sx={{ mb: 0.75, fontSize: '0.8rem' }}
+                >
                   {(() => {
                     const customer = invoice.customer;
                     if (customer?.firstName || customer?.lastName) {
-                      const fullName = `${customer.firstName || ''} ${customer.lastName || ''}`.trim();
+                      const fullName = `${customer.firstName || ''} ${
+                        customer.lastName || ''
+                      }`.trim();
                       if (customer.businessName) {
                         return `${fullName} (${customer.businessName})`;
                       }
@@ -570,7 +662,9 @@ const InvoiceList: React.FC = () => {
                   })()}
                 </Typography>
 
-                <Box sx={{ display: 'flex', gap: 0.5, mb: 1, flexWrap: 'wrap' }}>
+                <Box
+                  sx={{ display: 'flex', gap: 0.5, mb: 1, flexWrap: 'wrap' }}
+                >
                   <Chip
                     label={invoice.status}
                     color={getStatusColor(invoice.status)}
@@ -589,17 +683,44 @@ const InvoiceList: React.FC = () => {
                 <Divider sx={{ my: 1 }} />
 
                 <Stack spacing={0.5}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ fontSize: '0.7rem' }}
+                    >
                       Total
                     </Typography>
-                    <Typography variant="body2" sx={{ fontWeight: 700, color: theme.palette.success.main, fontSize: '0.875rem' }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 700,
+                        color: theme.palette.success.main,
+                        fontSize: '0.875rem',
+                      }}
+                    >
                       {formatCurrency(invoice.total)}
                     </Typography>
                   </Box>
                   {invoice.paymentMethod && (
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ fontSize: '0.7rem' }}
+                      >
                         Payment
                       </Typography>
                       <Typography variant="caption" sx={{ fontSize: '0.7rem' }}>
@@ -634,25 +755,38 @@ const InvoiceList: React.FC = () => {
                   <TableCell>
                     <Link
                       onClick={() => {
-                        const basePath = role === 'admin' ? '/admin' : role === 'supervisor' ? '/supervisor' : role === 'staff' ? '/staff' : role === 'accountant' ? '/accountant' : '/customer';
+                        const basePath =
+                          role === 'admin'
+                            ? '/admin'
+                            : role === 'supervisor'
+                            ? '/supervisor'
+                            : role === 'staff'
+                            ? '/staff'
+                            : role === 'accountant'
+                            ? '/accountant'
+                            : '/customer';
                         navigate(`${basePath}/invoices/${invoice.id}`);
                       }}
                       sx={{
                         cursor: 'pointer',
                         textDecoration: 'none',
                         fontWeight: 600,
-                        '&:hover': { textDecoration: 'underline' }
+                        '&:hover': { textDecoration: 'underline' },
                       }}
                     >
                       {invoice.invoiceNumber}
                     </Link>
                   </TableCell>
-                  <TableCell>{formatDate(invoice.invoiceDate || invoice.createdAt)}</TableCell>
+                  <TableCell>
+                    {formatDate(invoice.invoiceDate || invoice.createdAt)}
+                  </TableCell>
                   <TableCell>
                     {(() => {
                       const customer = invoice.customer;
                       if (customer?.firstName || customer?.lastName) {
-                        const fullName = `${customer.firstName || ''} ${customer.lastName || ''}`.trim();
+                        const fullName = `${customer.firstName || ''} ${
+                          customer.lastName || ''
+                        }`.trim();
                         if (customer.businessName) {
                           return `${fullName} (${customer.businessName})`;
                         }
@@ -665,7 +799,9 @@ const InvoiceList: React.FC = () => {
                     <Chip
                       label={invoice.company?.name || 'Unknown'}
                       size="small"
-                      color={getCompanyColor(invoice.company?.name || 'Unknown')}
+                      color={getCompanyColor(
+                        invoice.company?.name || 'Unknown'
+                      )}
                       variant="filled"
                     />
                   </TableCell>
@@ -678,7 +814,9 @@ const InvoiceList: React.FC = () => {
                     />
                   </TableCell>
                   <TableCell>
-                    {invoice.paymentMethod ? invoice.paymentMethod.replace(/_/g, ' ') : '-'}
+                    {invoice.paymentMethod
+                      ? invoice.paymentMethod.replace(/_/g, ' ')
+                      : '-'}
                   </TableCell>
                   <TableCell align="center">
                     <ActionsMenu
@@ -703,7 +841,14 @@ const InvoiceList: React.FC = () => {
 
       {/* Pagination */}
       {totalPages > 1 && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', mt: { xs: 2, sm: 3 }, mb: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            mt: { xs: 2, sm: 3 },
+            mb: 2,
+          }}
+        >
           <Pagination
             count={totalPages}
             page={page}
@@ -738,18 +883,29 @@ const InvoiceList: React.FC = () => {
         invoiceNumber={invoiceToMarkPaid?.invoiceNumber || ''}
       />
 
-      {/* Email Prompt Dialog - For sending email when customer has no email */}
+      {/* Email Prompt Dialog - Select one or more recipient emails */}
       <EmailPromptDialog
         open={emailDialogOpen}
         onClose={() => {
           setEmailDialogOpen(false);
           setInvoiceForEmail(null);
         }}
-        onSubmit={handleEmailPromptSubmit}
+        multiple
+        onSubmit={async () => undefined}
+        onSubmitMultiple={handleEmailPromptSubmit}
+        availableEmails={(() => {
+          const customer = invoiceForEmail?.customer;
+          return [
+            ...(customer?.email ? [customer.email] : []),
+            ...(customer?.additionalEmails ?? []),
+          ];
+        })()}
         customerName={(() => {
           const customer = invoiceForEmail?.customer;
           if (customer?.firstName || customer?.lastName) {
-            return `${customer.firstName || ''} ${customer.lastName || ''}`.trim();
+            return `${customer.firstName || ''} ${
+              customer.lastName || ''
+            }`.trim();
           }
           return 'Customer';
         })()}

--- a/apps/webApp/src/app/requests/invoice.requests.ts
+++ b/apps/webApp/src/app/requests/invoice.requests.ts
@@ -51,7 +51,9 @@ class InvoiceService {
 
     return `
       <h3 style="margin: 0; line-height: 1.1;">Vehicle Information:</h3>
-      <p style="margin: 0;">${vehicleDescription ? `${vehicleDescription}<br>` : ''}
+      <p style="margin: 0;">${
+        vehicleDescription ? `${vehicleDescription}<br>` : ''
+      }
       ${vehicle.vin ? `<strong>VIN Number:</strong> ${vehicle.vin}<br>` : ''}
       ${
         vehicle.licensePlate
@@ -137,12 +139,17 @@ class InvoiceService {
 
   async sendInvoiceEmail(
     id: string,
-    email?: string,
+    emails?: string | string[],
     saveToCustomer?: boolean
   ): Promise<{ success: boolean; message: string; emailUsed?: string }> {
+    const emailList = Array.isArray(emails)
+      ? emails
+      : emails
+      ? [emails]
+      : undefined;
     const response = await axios.post(
       `${API_URL}/api/invoices/${id}/send-email`,
-      { email, saveToCustomer },
+      { emails: emailList, saveToCustomer },
       {
         headers: await this.getHeaders(),
       }

--- a/libs/data/src/lib/customer.dto.ts
+++ b/libs/data/src/lib/customer.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsArray,
   IsBoolean,
   IsEmail,
   IsNotEmpty,
@@ -17,20 +18,43 @@ export class CreateCustomerDto {
   @IsNotEmpty()
   lastName!: string;
 
-  @ValidateIf((o) => o.email !== '' && o.email !== null && o.email !== undefined)
+  @ValidateIf(
+    (o) => o.email !== '' && o.email !== null && o.email !== undefined
+  )
   @IsEmail({}, { message: 'Please enter a valid email address' })
   email?: string;
 
-  @ValidateIf((o) => o.phone !== '' && o.phone !== null && o.phone !== undefined)
-  @Matches(/^[\d\s\-\(\)]+$/, { message: 'Phone number can only contain digits, spaces, dashes, and parentheses' })
+  @IsOptional()
+  @IsArray()
+  @IsEmail({}, { each: true, message: 'Please enter valid email addresses' })
+  additionalEmails?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  pstExempt?: boolean;
+
+  @ValidateIf(
+    (o) => o.phone !== '' && o.phone !== null && o.phone !== undefined
+  )
+  @Matches(/^[\d\s\-\(\)]+$/, {
+    message:
+      'Phone number can only contain digits, spaces, dashes, and parentheses',
+  })
   @Matches(/\d{10}/, { message: 'Phone number must contain exactly 10 digits' })
   phone?: string;
 
-  @ValidateIf((o) => o.address !== '' && o.address !== null && o.address !== undefined)
+  @ValidateIf(
+    (o) => o.address !== '' && o.address !== null && o.address !== undefined
+  )
   @IsString()
   address?: string;
 
-  @ValidateIf((o) => o.businessName !== '' && o.businessName !== null && o.businessName !== undefined)
+  @ValidateIf(
+    (o) =>
+      o.businessName !== '' &&
+      o.businessName !== null &&
+      o.businessName !== undefined
+  )
   @IsString()
   businessName?: string;
 
@@ -60,20 +84,43 @@ export class UpdateCustomerDto {
   @IsString()
   lastName?: string;
 
-  @ValidateIf((o) => o.email !== '' && o.email !== null && o.email !== undefined)
+  @ValidateIf(
+    (o) => o.email !== '' && o.email !== null && o.email !== undefined
+  )
   @IsEmail({}, { message: 'Please enter a valid email address' })
   email?: string;
 
-  @ValidateIf((o) => o.phone !== '' && o.phone !== null && o.phone !== undefined)
-  @Matches(/^[\d\s\-\(\)]+$/, { message: 'Phone number can only contain digits, spaces, dashes, and parentheses' })
+  @IsOptional()
+  @IsArray()
+  @IsEmail({}, { each: true, message: 'Please enter valid email addresses' })
+  additionalEmails?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  pstExempt?: boolean;
+
+  @ValidateIf(
+    (o) => o.phone !== '' && o.phone !== null && o.phone !== undefined
+  )
+  @Matches(/^[\d\s\-\(\)]+$/, {
+    message:
+      'Phone number can only contain digits, spaces, dashes, and parentheses',
+  })
   @Matches(/\d{10}/, { message: 'Phone number must contain exactly 10 digits' })
   phone?: string;
 
-  @ValidateIf((o) => o.address !== '' && o.address !== null && o.address !== undefined)
+  @ValidateIf(
+    (o) => o.address !== '' && o.address !== null && o.address !== undefined
+  )
   @IsString()
   address?: string;
 
-  @ValidateIf((o) => o.businessName !== '' && o.businessName !== null && o.businessName !== undefined)
+  @ValidateIf(
+    (o) =>
+      o.businessName !== '' &&
+      o.businessName !== null &&
+      o.businessName !== undefined
+  )
   @IsString()
   businessName?: string;
 
@@ -173,7 +220,13 @@ export interface CustomerAppointmentDto {
   vehicle?: CustomerVehicleDto;
   scheduledDate: string;
   serviceType: string;
-  status: 'SCHEDULED' | 'CONFIRMED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED' | 'NO_SHOW';
+  status:
+    | 'SCHEDULED'
+    | 'CONFIRMED'
+    | 'IN_PROGRESS'
+    | 'COMPLETED'
+    | 'CANCELLED'
+    | 'NO_SHOW';
   notes?: string;
   employees?: CustomerAppointmentEmployeeDto[];
   paymentAmount?: number;
@@ -196,6 +249,14 @@ export class CustomerResponseDto {
   @IsOptional()
   @IsEmail()
   email?: string;
+
+  @IsOptional()
+  @IsArray()
+  additionalEmails?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  pstExempt?: boolean;
 
   @IsOptional()
   @IsString()

--- a/libs/data/src/lib/invoice.dto.ts
+++ b/libs/data/src/lib/invoice.dto.ts
@@ -43,7 +43,10 @@ export class InvoiceItemDto {
   quantity!: number;
 
   @IsNumber()
-  @ValidateIf((o: any) => o.itemType !== 'DISCOUNT' && o.itemType !== 'DISCOUNT_PERCENTAGE')
+  @ValidateIf(
+    (o: any) =>
+      o.itemType !== 'DISCOUNT' && o.itemType !== 'DISCOUNT_PERCENTAGE'
+  )
   @IsPositive({ message: 'Unit price must be positive for non-discount items' })
   unitPrice!: number; // Can be negative for DISCOUNT items
 
@@ -214,6 +217,8 @@ export interface InvoiceCustomerDto {
   name?: string | null;
   businessName?: string | null;
   email?: string | null;
+  additionalEmails?: string[] | null;
+  pstExempt?: boolean | null;
   phone?: string | null;
   address?: string | null;
 }

--- a/libs/database/src/lib/prisma/migrations/20260625174629_add_customer_additional_emails/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260625174629_add_customer_additional_emails/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Customer" ADD COLUMN     "additionalEmails" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/libs/database/src/lib/prisma/migrations/20260625191506_add_customer_pst_exempt/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260625191506_add_customer_pst_exempt/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Customer" ADD COLUMN     "pstExempt" BOOLEAN NOT NULL DEFAULT false;

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -78,6 +78,8 @@ model Customer {
   firstName       String
   lastName        String
   email           String?
+  additionalEmails String[]        @default([]) // Extra emails (e.g. spouse, business) for invoice sending
+  pstExempt       Boolean          @default(false) // When true, invoices for this customer are charged 0% PST
   phone           String?
   address         String?
   businessName    String?

--- a/server/src/appointments/appointment-invoice.service.ts
+++ b/server/src/appointments/appointment-invoice.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, BadRequestException, NotFoundException, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
 import { PrismaService } from '@gt-automotive/database';
 import { InvoiceRepository } from '../invoices/repositories/invoice.repository';
 import { Invoice, InvoiceItemType, Appointment } from '@prisma/client';
@@ -46,7 +51,7 @@ export class AppointmentInvoiceService {
 
   constructor(
     private readonly prisma: PrismaService,
-    private readonly invoiceRepository: InvoiceRepository,
+    private readonly invoiceRepository: InvoiceRepository
   ) {}
 
   /**
@@ -54,7 +59,7 @@ export class AppointmentInvoiceService {
    * Automatically calculates GST (5%) and PST (7%) from the service amount
    */
   async createInvoiceFromAppointment(
-    params: CreateInvoiceFromAppointmentParams,
+    params: CreateInvoiceFromAppointmentParams
   ): Promise<Invoice> {
     const {
       appointmentId,
@@ -93,15 +98,27 @@ export class AppointmentInvoiceService {
 
     if (existingInvoice) {
       this.logger.warn(
-        `Invoice already exists for appointment ${appointmentId}: ${existingInvoice.invoiceNumber}`,
+        `Invoice already exists for appointment ${appointmentId}: ${existingInvoice.invoiceNumber}`
       );
       throw new BadRequestException(
-        `Invoice ${existingInvoice.invoiceNumber} already exists for this appointment`,
+        `Invoice ${existingInvoice.invoiceNumber} already exists for this appointment`
       );
     }
 
     // 3. Calculate taxes (GST 5% + PST 7%) - tip is NOT taxed
     const taxes = calculateTaxes(serviceAmount);
+
+    // PST-exempt customers are charged 0% PST
+    const apptCustomer = await this.prisma.customer.findUnique({
+      where: { id: appointment.customerId },
+      select: { pstExempt: true },
+    });
+    if (apptCustomer?.pstExempt) {
+      taxes.pstRate = 0;
+      taxes.pstAmount = 0;
+      taxes.totalAmount = Number((taxes.subtotal + taxes.gstAmount).toFixed(2));
+    }
+
     const tip = tipAmount || 0;
     const totalWithTip = taxes.totalAmount + tip;
 
@@ -121,7 +138,9 @@ export class AppointmentInvoiceService {
     const invoiceNumber = await this.invoiceRepository.generateInvoiceNumber();
 
     this.logger.log(
-      `Creating invoice for appointment ${appointmentId}: ${serviceDescription} - $${totalWithTip}${tip > 0 ? ` (includes $${tip} tip)` : ''}`,
+      `Creating invoice for appointment ${appointmentId}: ${serviceDescription} - $${totalWithTip}${
+        tip > 0 ? ` (includes $${tip} tip)` : ''
+      }`
     );
 
     // 7. Build invoice items array. If a product sale is included, split it
@@ -150,9 +169,7 @@ export class AppointmentInvoiceService {
     if (productAmount > 0) {
       const productLabel =
         productSaleItems && productSaleItems.length > 0
-          ? productSaleItems
-              .map((p) => PRODUCT_LABELS[p] || p)
-              .join(', ')
+          ? productSaleItems.map((p) => PRODUCT_LABELS[p] || p).join(', ')
           : 'Product Sale';
       // Use TIRE itemType when only tires, otherwise PART for the generic case.
       const onlyTires =
@@ -194,11 +211,13 @@ export class AppointmentInvoiceService {
         createdBy: userId,
         paidAt: status === 'PAID' ? new Date() : undefined,
       },
-      invoiceItems,
+      invoiceItems
     );
 
     this.logger.log(
-      `Invoice ${invoiceNumber} created successfully for appointment ${appointmentId} (status: ${status}, method: ${paymentMethod})${squarePaymentId ? ` (linked to Square payment ${squarePaymentId})` : ''}`,
+      `Invoice ${invoiceNumber} created successfully for appointment ${appointmentId} (status: ${status}, method: ${paymentMethod})${
+        squarePaymentId ? ` (linked to Square payment ${squarePaymentId})` : ''
+      }`
     );
 
     return invoice;
@@ -223,7 +242,9 @@ export class AppointmentInvoiceService {
   /**
    * Get invoice for an appointment (if exists)
    */
-  async getInvoiceForAppointment(appointmentId: string): Promise<Invoice | null> {
+  async getInvoiceForAppointment(
+    appointmentId: string
+  ): Promise<Invoice | null> {
     return this.prisma.invoice.findFirst({
       where: { appointmentId },
       include: {

--- a/server/src/customers/customers.service.ts
+++ b/server/src/customers/customers.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { CreateCustomerDto, UpdateCustomerDto } from '@gt-automotive/data';
 import { CustomerRepository } from './repositories/customer.repository';
 import { AuditRepository } from '../audit/repositories/audit.repository';
@@ -9,15 +13,19 @@ export class CustomersService {
   constructor(
     private readonly customerRepository: CustomerRepository,
     private readonly auditRepository: AuditRepository,
-    private readonly prisma: PrismaService,
+    private readonly prisma: PrismaService
   ) {}
 
   async create(createCustomerDto: CreateCustomerDto, createdBy: string) {
     // Check for existing customer with same email if provided
     if (createCustomerDto.email) {
-      const existingCustomer = await this.customerRepository.findByEmail(createCustomerDto.email);
+      const existingCustomer = await this.customerRepository.findByEmail(
+        createCustomerDto.email
+      );
       if (existingCustomer) {
-        throw new BadRequestException('A customer with this email already exists');
+        throw new BadRequestException(
+          'A customer with this email already exists'
+        );
       }
     }
 
@@ -27,6 +35,8 @@ export class CustomersService {
         firstName: createCustomerDto.firstName,
         lastName: createCustomerDto.lastName,
         email: createCustomerDto.email,
+        additionalEmails: createCustomerDto.additionalEmails ?? [],
+        pstExempt: createCustomerDto.pstExempt ?? false,
         phone: createCustomerDto.phone,
         address: createCustomerDto.address,
         businessName: createCustomerDto.businessName,
@@ -36,20 +46,23 @@ export class CustomersService {
     // Auto-create SMS preferences if customer has a phone number
     // Use provided preferences or default to opted-in for better user experience
     if (customer.phone) {
-      await this.prisma.smsPreference.create({
-        data: {
-          customer: {
-            connect: { id: customer.id },
+      await this.prisma.smsPreference
+        .create({
+          data: {
+            customer: {
+              connect: { id: customer.id },
+            },
+            optedIn: createCustomerDto.smsOptedIn ?? true,
+            appointmentReminders:
+              createCustomerDto.smsAppointmentReminders ?? true,
+            serviceUpdates: createCustomerDto.smsServiceUpdates ?? true,
+            promotional: createCustomerDto.smsPromotional ?? false,
           },
-          optedIn: createCustomerDto.smsOptedIn ?? true,
-          appointmentReminders: createCustomerDto.smsAppointmentReminders ?? true,
-          serviceUpdates: createCustomerDto.smsServiceUpdates ?? true,
-          promotional: createCustomerDto.smsPromotional ?? false,
-        },
-      }).catch(err => {
-        console.error('Failed to create SMS preferences for customer:', err);
-        // Don't throw error - customer was created successfully
-      });
+        })
+        .catch((err) => {
+          console.error('Failed to create SMS preferences for customer:', err);
+          // Don't throw error - customer was created successfully
+        });
     }
 
     // Log the action
@@ -100,6 +113,8 @@ export class CustomersService {
         firstName: true,
         lastName: true,
         email: true,
+        additionalEmails: true,
+        pstExempt: true,
         phone: true,
         address: true,
         businessName: true,
@@ -124,7 +139,12 @@ export class CustomersService {
     };
   }
 
-  async update(id: string, updateCustomerDto: UpdateCustomerDto, userId: string, userRole: string) {
+  async update(
+    id: string,
+    updateCustomerDto: UpdateCustomerDto,
+    userId: string,
+    userRole: string
+  ) {
     const customer = await this.customerRepository.findById(id);
 
     if (!customer) {
@@ -135,12 +155,30 @@ export class CustomersService {
     const updatedCustomer = await this.prisma.customer.update({
       where: { id },
       data: {
-        ...(updateCustomerDto.firstName && { firstName: updateCustomerDto.firstName }),
-        ...(updateCustomerDto.lastName && { lastName: updateCustomerDto.lastName }),
-        ...(updateCustomerDto.email !== undefined && { email: updateCustomerDto.email }),
-        ...(updateCustomerDto.phone !== undefined && { phone: updateCustomerDto.phone }),
-        ...(updateCustomerDto.address !== undefined && { address: updateCustomerDto.address }),
-        ...(updateCustomerDto.businessName !== undefined && { businessName: updateCustomerDto.businessName }),
+        ...(updateCustomerDto.firstName && {
+          firstName: updateCustomerDto.firstName,
+        }),
+        ...(updateCustomerDto.lastName && {
+          lastName: updateCustomerDto.lastName,
+        }),
+        ...(updateCustomerDto.email !== undefined && {
+          email: updateCustomerDto.email,
+        }),
+        ...(updateCustomerDto.additionalEmails !== undefined && {
+          additionalEmails: updateCustomerDto.additionalEmails,
+        }),
+        ...(updateCustomerDto.pstExempt !== undefined && {
+          pstExempt: updateCustomerDto.pstExempt,
+        }),
+        ...(updateCustomerDto.phone !== undefined && {
+          phone: updateCustomerDto.phone,
+        }),
+        ...(updateCustomerDto.address !== undefined && {
+          address: updateCustomerDto.address,
+        }),
+        ...(updateCustomerDto.businessName !== undefined && {
+          businessName: updateCustomerDto.businessName,
+        }),
       },
       include: {
         vehicles: true,
@@ -148,12 +186,13 @@ export class CustomersService {
     });
 
     // Update SMS preferences if provided and customer has phone
-    if (updatedCustomer.phone && (
-      updateCustomerDto.smsOptedIn !== undefined ||
-      updateCustomerDto.smsAppointmentReminders !== undefined ||
-      updateCustomerDto.smsServiceUpdates !== undefined ||
-      updateCustomerDto.smsPromotional !== undefined
-    )) {
+    if (
+      updatedCustomer.phone &&
+      (updateCustomerDto.smsOptedIn !== undefined ||
+        updateCustomerDto.smsAppointmentReminders !== undefined ||
+        updateCustomerDto.smsServiceUpdates !== undefined ||
+        updateCustomerDto.smsPromotional !== undefined)
+    ) {
       // Check if SMS preferences exist
       const existingPrefs = await this.prisma.smsPreference.findUnique({
         where: { customerId: id },
@@ -161,32 +200,45 @@ export class CustomersService {
 
       if (existingPrefs) {
         // Update existing preferences
-        await this.prisma.smsPreference.update({
-          where: { customerId: id },
-          data: {
-            ...(updateCustomerDto.smsOptedIn !== undefined && { optedIn: updateCustomerDto.smsOptedIn }),
-            ...(updateCustomerDto.smsAppointmentReminders !== undefined && { appointmentReminders: updateCustomerDto.smsAppointmentReminders }),
-            ...(updateCustomerDto.smsServiceUpdates !== undefined && { serviceUpdates: updateCustomerDto.smsServiceUpdates }),
-            ...(updateCustomerDto.smsPromotional !== undefined && { promotional: updateCustomerDto.smsPromotional }),
-          },
-        }).catch(err => {
-          console.error('Failed to update SMS preferences:', err);
-        });
+        await this.prisma.smsPreference
+          .update({
+            where: { customerId: id },
+            data: {
+              ...(updateCustomerDto.smsOptedIn !== undefined && {
+                optedIn: updateCustomerDto.smsOptedIn,
+              }),
+              ...(updateCustomerDto.smsAppointmentReminders !== undefined && {
+                appointmentReminders: updateCustomerDto.smsAppointmentReminders,
+              }),
+              ...(updateCustomerDto.smsServiceUpdates !== undefined && {
+                serviceUpdates: updateCustomerDto.smsServiceUpdates,
+              }),
+              ...(updateCustomerDto.smsPromotional !== undefined && {
+                promotional: updateCustomerDto.smsPromotional,
+              }),
+            },
+          })
+          .catch((err) => {
+            console.error('Failed to update SMS preferences:', err);
+          });
       } else {
         // Create new preferences
-        await this.prisma.smsPreference.create({
-          data: {
-            customer: {
-              connect: { id },
+        await this.prisma.smsPreference
+          .create({
+            data: {
+              customer: {
+                connect: { id },
+              },
+              optedIn: updateCustomerDto.smsOptedIn ?? true,
+              appointmentReminders:
+                updateCustomerDto.smsAppointmentReminders ?? true,
+              serviceUpdates: updateCustomerDto.smsServiceUpdates ?? true,
+              promotional: updateCustomerDto.smsPromotional ?? false,
             },
-            optedIn: updateCustomerDto.smsOptedIn ?? true,
-            appointmentReminders: updateCustomerDto.smsAppointmentReminders ?? true,
-            serviceUpdates: updateCustomerDto.smsServiceUpdates ?? true,
-            promotional: updateCustomerDto.smsPromotional ?? false,
-          },
-        }).catch(err => {
-          console.error('Failed to create SMS preferences:', err);
-        });
+          })
+          .catch((err) => {
+            console.error('Failed to create SMS preferences:', err);
+          });
       }
     }
 
@@ -220,7 +272,7 @@ export class CustomersService {
 
     if (hasInvoices > 0 || hasAppointments > 0) {
       throw new BadRequestException(
-        'Cannot delete customer with existing invoices or appointments.',
+        'Cannot delete customer with existing invoices or appointments.'
       );
     }
 
@@ -244,5 +296,4 @@ export class CustomersService {
   async search(searchTerm: string, userId: string, userRole: string) {
     return this.customerRepository.search(searchTerm);
   }
-
 }

--- a/server/src/email/email.service.ts
+++ b/server/src/email/email.service.ts
@@ -17,17 +17,30 @@ export class EmailService {
 
   constructor(private readonly prisma: PrismaService) {
     this.enabled = process.env.EMAIL_ENABLED === 'true';
-    this.senderEmail = process.env.BREVO_SENDER_EMAIL || 'gt-automotives@outlook.com';
+    this.senderEmail =
+      process.env.BREVO_SENDER_EMAIL || 'gt-automotives@outlook.com';
     this.senderName = process.env.BREVO_SENDER_NAME || 'GT Automotives';
 
     // Load logo as base64 for email embedding
     try {
-      const logoPath = path.join(process.cwd(), 'apps', 'webApp', 'public', 'logo-email.png');
+      const logoPath = path.join(
+        process.cwd(),
+        'apps',
+        'webApp',
+        'public',
+        'logo-email.png'
+      );
       if (fs.existsSync(logoPath)) {
         const logoBuffer = fs.readFileSync(logoPath);
-        this.logoBase64 = `data:image/png;base64,${logoBuffer.toString('base64')}`;
-        this.logger.log(`✅ Logo loaded for email embedding (${logoBuffer.length} bytes, base64: ${this.logoBase64.length} chars)`);
-        this.logger.log(`📸 Logo preview: ${this.logoBase64.substring(0, 100)}...`);
+        this.logoBase64 = `data:image/png;base64,${logoBuffer.toString(
+          'base64'
+        )}`;
+        this.logger.log(
+          `✅ Logo loaded for email embedding (${logoBuffer.length} bytes, base64: ${this.logoBase64.length} chars)`
+        );
+        this.logger.log(
+          `📸 Logo preview: ${this.logoBase64.substring(0, 100)}...`
+        );
       } else {
         // Fallback: use production URL
         this.logoBase64 = '';
@@ -42,7 +55,9 @@ export class EmailService {
       try {
         const apiKey = process.env.BREVO_API_KEY;
         if (!apiKey) {
-          this.logger.error('BREVO_API_KEY is not set - Email will be disabled');
+          this.logger.error(
+            'BREVO_API_KEY is not set - Email will be disabled'
+          );
           (this as any).enabled = false;
           return;
         }
@@ -56,11 +71,16 @@ export class EmailService {
         this.logger.log('✅ Email Service initialized with Brevo');
         this.logger.log(`📧 Sender: ${this.senderName} <${this.senderEmail}>`);
       } catch (error) {
-        this.logger.error('Failed to initialize Brevo SDK - Email will be disabled:', error);
+        this.logger.error(
+          'Failed to initialize Brevo SDK - Email will be disabled:',
+          error
+        );
         (this as any).enabled = false;
       }
     } else {
-      this.logger.warn('⚠️ Email Service is disabled (EMAIL_ENABLED is not true)');
+      this.logger.warn(
+        '⚠️ Email Service is disabled (EMAIL_ENABLED is not true)'
+      );
     }
   }
 
@@ -88,11 +108,19 @@ export class EmailService {
     customerId?: string;
     attachments?: Array<{ name: string; content: string }>; // Base64 encoded
   }): Promise<{ success: boolean; messageId?: string; error?: string }> {
-    this.logger.log(`[EMAIL] sendEmail called - enabled: ${this.enabled}, to: ${params.to}, type: ${params.type}`);
+    this.logger.log(
+      `[EMAIL] sendEmail called - enabled: ${this.enabled}, to: ${params.to}, type: ${params.type}`
+    );
 
     if (!this.enabled) {
-      this.logger.warn('[EMAIL] Email Service is DISABLED. Set EMAIL_ENABLED=true to enable.');
-      this.logger.warn('[EMAIL] Would send:', { to: params.to, subject: params.subject, type: params.type });
+      this.logger.warn(
+        '[EMAIL] Email Service is DISABLED. Set EMAIL_ENABLED=true to enable.'
+      );
+      this.logger.warn('[EMAIL] Would send:', {
+        to: params.to,
+        subject: params.subject,
+        type: params.type,
+      });
       return { success: false, error: 'Email service is disabled' };
     }
 
@@ -148,9 +176,9 @@ export class EmailService {
 
       this.logger.log(`✅ Email sent successfully: ${messageId}`);
       return { success: true, messageId };
-
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
       const errorStack = error instanceof Error ? error.stack : undefined;
       this.logger.error(`❌ Failed to send email: ${errorMessage}`, errorStack);
 
@@ -169,9 +197,13 @@ export class EmailService {
   /**
    * Send a simple test email
    */
-  async sendTestEmail(to: string): Promise<{ success: boolean; messageId?: string; error?: string }> {
+  async sendTestEmail(
+    to: string
+  ): Promise<{ success: boolean; messageId?: string; error?: string }> {
     const logoSrc = this.getLogoSrc();
-    this.logger.log(`📧 Sending test email with logo src length: ${logoSrc.length} chars`);
+    this.logger.log(
+      `📧 Sending test email with logo src length: ${logoSrc.length} chars`
+    );
 
     const htmlContent = `
       <!DOCTYPE html>
@@ -224,7 +256,9 @@ export class EmailService {
    * Send appointment confirmation email
    */
   async sendAppointmentConfirmation(appointmentId: string): Promise<void> {
-    this.logger.log(`[EMAIL] sendAppointmentConfirmation called for appointment: ${appointmentId}`);
+    this.logger.log(
+      `[EMAIL] sendAppointmentConfirmation called for appointment: ${appointmentId}`
+    );
 
     const appointment = await this.prisma.appointment.findUnique({
       where: { id: appointmentId },
@@ -241,22 +275,45 @@ export class EmailService {
     }
 
     if (!appointment.customer.email) {
-      this.logger.warn(`[EMAIL] Customer ${appointment.customer.id} has no email address. Skipping email.`);
+      this.logger.warn(
+        `[EMAIL] Customer ${appointment.customer.id} has no email address. Skipping email.`
+      );
       return;
     }
 
-    const employeeNames = appointment.employees
-      .map(ae => `${ae.employee.firstName} ${ae.employee.lastName}`)
-      .join(', ') || 'TBD';
+    const employeeNames =
+      appointment.employees
+        .map((ae) => `${ae.employee.firstName} ${ae.employee.lastName}`)
+        .join(', ') || 'TBD';
 
     // Format date correctly using timezone-aware utility
     const businessDate = extractBusinessDate(appointment.scheduledDate);
 
     // CRITICAL: Format date from business date string directly to avoid timezone issues
     // Creating a Date object causes UTC conversion which shifts dates after 5 PM PST
-    const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
-      'July', 'August', 'September', 'October', 'November', 'December'];
-    const weekdayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const monthNames = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+    const weekdayNames = [
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ];
 
     const [year, month, day] = businessDate.split('-').map(Number);
     const dateForWeekday = new Date(Date.UTC(year, month - 1, day));
@@ -299,12 +356,24 @@ export class EmailService {
             <p><strong>Service:</strong> ${appointment.serviceType}</p>
             <p><strong>Date:</strong> ${formattedDate}</p>
             <p><strong>Time:</strong> ${formattedTime}</p>
-            ${appointment.vehicle ? `<p><strong>Vehicle:</strong> ${appointment.vehicle.year} ${appointment.vehicle.make} ${appointment.vehicle.model}</p>` : ''}
+            ${
+              appointment.vehicle
+                ? `<p><strong>Vehicle:</strong> ${appointment.vehicle.year} ${appointment.vehicle.make} ${appointment.vehicle.model}</p>`
+                : ''
+            }
             <p><strong>Technician(s):</strong> ${employeeNames}</p>
-            <p><strong>Location:</strong> ${appointment.appointmentType === 'AT_GARAGE' ? 'GT Automotives Shop' : 'Mobile Service'}</p>
+            <p><strong>Location:</strong> ${
+              appointment.appointmentType === 'AT_GARAGE'
+                ? 'GT Automotives Shop'
+                : 'Mobile Service'
+            }</p>
           </div>
 
-          ${appointment.notes ? `<p><strong>Notes:</strong> ${appointment.notes}</p>` : ''}
+          ${
+            appointment.notes
+              ? `<p><strong>Notes:</strong> ${appointment.notes}</p>`
+              : ''
+          }
 
           <p>Need to reschedule? Call us at <strong>(250) 986-9191</strong></p>
         </div>
@@ -346,7 +415,10 @@ export class EmailService {
     totalEmployeePayments?: number;
     employeePaymentsCount?: number;
     employeePaymentsByMethod?: Record<string, number>;
-    employeePaymentsByPerson?: Record<string, { name: string; amount: number; count: number }>;
+    employeePaymentsByPerson?: Record<
+      string,
+      { name: string; amount: number; count: number }
+    >;
     totalCashCollected?: number;
     adjustedCash?: number;
   }): Promise<{ success: boolean; sent: number; failed: number }> {
@@ -365,7 +437,9 @@ export class EmailService {
     });
 
     // Filter for users with email addresses
-    const adminUsers = allAdminUsers.filter(user => user.email != null && user.email !== '');
+    const adminUsers = allAdminUsers.filter(
+      (user) => user.email != null && user.email !== ''
+    );
 
     if (adminUsers.length === 0) {
       this.logger.warn('[EMAIL] No admin users with email addresses found');
@@ -375,7 +449,10 @@ export class EmailService {
     // Format payment methods
     const formatPaymentMethods = (methods: Record<string, number>): string => {
       return Object.entries(methods)
-        .map(([method, amount]) => `<li><strong>${method}</strong>: $${amount.toFixed(2)}</li>`)
+        .map(
+          ([method, amount]) =>
+            `<li><strong>${method}</strong>: $${amount.toFixed(2)}</li>`
+        )
         .join('');
     };
 
@@ -404,11 +481,15 @@ export class EmailService {
             <table style="width: 100%; border-collapse: collapse;">
               <tr>
                 <td style="padding: 8px 0;"><strong>Total Payments Collected:</strong></td>
-                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-size: 18px; font-weight: bold;">$${data.totalPayments.toFixed(2)}</td>
+                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-size: 18px; font-weight: bold;">$${data.totalPayments.toFixed(
+                  2
+                )}</td>
               </tr>
               <tr>
                 <td style="padding: 8px 0;"><strong>Total Amount Owed:</strong></td>
-                <td style="padding: 8px 0; text-align: right; color: #f44336; font-size: 18px; font-weight: bold;">$${data.totalOwed.toFixed(2)}</td>
+                <td style="padding: 8px 0; text-align: right; color: #f44336; font-size: 18px; font-weight: bold;">$${data.totalOwed.toFixed(
+                  2
+                )}</td>
               </tr>
             </table>
 
@@ -424,20 +505,28 @@ export class EmailService {
             <table style="width: 100%; border-collapse: collapse;">
               <tr>
                 <td style="padding: 8px 0;"><strong>Completed Jobs:</strong></td>
-                <td style="padding: 8px 0; text-align: right; font-weight: bold;">${data.atGarageCount}</td>
+                <td style="padding: 8px 0; text-align: right; font-weight: bold;">${
+                  data.atGarageCount
+                }</td>
               </tr>
               <tr>
                 <td style="padding: 8px 0;"><strong>Total Collected:</strong></td>
-                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-weight: bold;">$${data.atGaragePayments.toFixed(2)}</td>
+                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-weight: bold;">$${data.atGaragePayments.toFixed(
+                  2
+                )}</td>
               </tr>
             </table>
 
-            ${Object.keys(data.atGaragePaymentsByMethod).length > 0 ? `
+            ${
+              Object.keys(data.atGaragePaymentsByMethod).length > 0
+                ? `
               <h4 style="margin-top: 20px; margin-bottom: 10px;">Payment Methods:</h4>
               <ul style="list-style: none; padding: 0;">
                 ${formatPaymentMethods(data.atGaragePaymentsByMethod)}
               </ul>
-            ` : '<p style="color: #666; margin-top: 10px;">No payments collected</p>'}
+            `
+                : '<p style="color: #666; margin-top: 10px;">No payments collected</p>'
+            }
           </div>
 
           <!-- Mobile Service Stats -->
@@ -446,78 +535,121 @@ export class EmailService {
             <table style="width: 100%; border-collapse: collapse;">
               <tr>
                 <td style="padding: 8px 0;"><strong>Completed Jobs:</strong></td>
-                <td style="padding: 8px 0; text-align: right; font-weight: bold;">${data.mobileServiceCount}</td>
+                <td style="padding: 8px 0; text-align: right; font-weight: bold;">${
+                  data.mobileServiceCount
+                }</td>
               </tr>
               <tr>
                 <td style="padding: 8px 0;"><strong>Total Collected:</strong></td>
-                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-weight: bold;">$${data.mobileServicePayments.toFixed(2)}</td>
+                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-weight: bold;">$${data.mobileServicePayments.toFixed(
+                  2
+                )}</td>
               </tr>
             </table>
 
-            ${Object.keys(data.mobileServicePaymentsByMethod).length > 0 ? `
+            ${
+              Object.keys(data.mobileServicePaymentsByMethod).length > 0
+                ? `
               <h4 style="margin-top: 20px; margin-bottom: 10px;">Payment Methods:</h4>
               <ul style="list-style: none; padding: 0;">
                 ${formatPaymentMethods(data.mobileServicePaymentsByMethod)}
               </ul>
-            ` : '<p style="color: #666; margin-top: 10px;">No payments collected</p>'}
+            `
+                : '<p style="color: #666; margin-top: 10px;">No payments collected</p>'
+            }
           </div>
 
-          ${data.totalEmployeePayments && data.totalEmployeePayments > 0 ? `
+          ${
+            data.totalEmployeePayments && data.totalEmployeePayments > 0
+              ? `
           <!-- Employee Payments Stats -->
           <div style="background-color: #fff3e0; padding: 20px; border-radius: 5px; margin: 20px 0; border-left: 4px solid #ff9800;">
             <h3 style="margin-top: 0; color: #ff9800;">👥 Employee Payments - Cash Given Out</h3>
             <table style="width: 100%; border-collapse: collapse;">
               <tr>
                 <td style="padding: 8px 0;"><strong>Number of Payments:</strong></td>
-                <td style="padding: 8px 0; text-align: right; font-weight: bold;">${data.employeePaymentsCount || 0}</td>
+                <td style="padding: 8px 0; text-align: right; font-weight: bold;">${
+                  data.employeePaymentsCount || 0
+                }</td>
               </tr>
               <tr>
                 <td style="padding: 8px 0;"><strong>Total Cash Given Out:</strong></td>
-                <td style="padding: 8px 0; text-align: right; color: #f44336; font-weight: bold; font-size: 18px;">-$${data.totalEmployeePayments.toFixed(2)}</td>
+                <td style="padding: 8px 0; text-align: right; color: #f44336; font-weight: bold; font-size: 18px;">-$${data.totalEmployeePayments.toFixed(
+                  2
+                )}</td>
               </tr>
             </table>
 
-            ${data.employeePaymentsByPerson && Object.keys(data.employeePaymentsByPerson).length > 0 ? `
+            ${
+              data.employeePaymentsByPerson &&
+              Object.keys(data.employeePaymentsByPerson).length > 0
+                ? `
               <h4 style="margin-top: 20px; margin-bottom: 10px;">Payments by Employee:</h4>
               <ul style="list-style: none; padding: 0;">
-                ${Object.entries(data.employeePaymentsByPerson).map(([empId, empData]) =>
-                  `<li><strong>${empData.name}</strong>: $${empData.amount.toFixed(2)} (${empData.count} payment${empData.count > 1 ? 's' : ''})</li>`
-                ).join('')}
+                ${Object.entries(data.employeePaymentsByPerson)
+                  .map(
+                    ([empId, empData]) =>
+                      `<li><strong>${
+                        empData.name
+                      }</strong>: $${empData.amount.toFixed(2)} (${
+                        empData.count
+                      } payment${empData.count > 1 ? 's' : ''})</li>`
+                  )
+                  .join('')}
               </ul>
-            ` : ''}
+            `
+                : ''
+            }
 
-            ${data.employeePaymentsByMethod && Object.keys(data.employeePaymentsByMethod).length > 0 ? `
+            ${
+              data.employeePaymentsByMethod &&
+              Object.keys(data.employeePaymentsByMethod).length > 0
+                ? `
               <h4 style="margin-top: 20px; margin-bottom: 10px;">Payment Methods Used:</h4>
               <ul style="list-style: none; padding: 0;">
                 ${formatPaymentMethods(data.employeePaymentsByMethod)}
               </ul>
-            ` : ''}
+            `
+                : ''
+            }
           </div>
-          ` : ''}
+          `
+              : ''
+          }
 
-          ${data.adjustedCash !== undefined ? `
+          ${
+            data.adjustedCash !== undefined
+              ? `
           <!-- Net Cash Position -->
           <div style="background-color: #c8e6c9; padding: 20px; border-radius: 5px; margin: 20px 0; border: 3px solid #4caf50;">
             <h3 style="margin-top: 0; color: #2e7d32;">💰 Net Cash Position (Adjusted)</h3>
             <table style="width: 100%; border-collapse: collapse;">
               <tr>
                 <td style="padding: 8px 0;"><strong>Cash from Customers:</strong></td>
-                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-weight: bold;">+$${(data.totalCashCollected || 0).toFixed(2)}</td>
+                <td style="padding: 8px 0; text-align: right; color: #4caf50; font-weight: bold;">+$${(
+                  data.totalCashCollected || 0
+                ).toFixed(2)}</td>
               </tr>
               <tr>
                 <td style="padding: 8px 0;"><strong>Cash to Employees:</strong></td>
-                <td style="padding: 8px 0; text-align: right; color: #f44336; font-weight: bold;">-$${data.totalEmployeePayments?.toFixed(2) || '0.00'}</td>
+                <td style="padding: 8px 0; text-align: right; color: #f44336; font-weight: bold;">-$${
+                  data.totalEmployeePayments?.toFixed(2) || '0.00'
+                }</td>
               </tr>
               <tr style="border-top: 2px solid #4caf50;">
                 <td style="padding: 12px 0;"><strong style="font-size: 16px;">Net Cash on Hand:</strong></td>
-                <td style="padding: 12px 0; text-align: right; color: #2e7d32; font-weight: bold; font-size: 20px;">=$${data.adjustedCash.toFixed(2)}</td>
+                <td style="padding: 12px 0; text-align: right; color: #2e7d32; font-weight: bold; font-size: 20px;">=$${data.adjustedCash.toFixed(
+                  2
+                )}</td>
               </tr>
             </table>
             <p style="color: #666; margin-top: 10px; font-size: 12px;">
               This is the expected cash that should be in the cash drawer at the end of the day (CASH payments only).
             </p>
           </div>
-          ` : ''}
+          `
+              : ''
+          }
 
           <div style="margin-top: 30px; padding: 15px; background-color: #f5f5f5; border-left: 4px solid #1976d2;">
             <p style="margin: 0; color: #666;">
@@ -556,15 +688,22 @@ export class EmailService {
           this.logger.log(`✅ EOD summary sent to ${admin.email}`);
         } else {
           failed++;
-          this.logger.error(`❌ Failed to send EOD summary to ${admin.email}: ${result.error}`);
+          this.logger.error(
+            `❌ Failed to send EOD summary to ${admin.email}: ${result.error}`
+          );
         }
       } catch (error) {
         failed++;
-        this.logger.error(`❌ Error sending EOD summary to ${admin.email}:`, error);
+        this.logger.error(
+          `❌ Error sending EOD summary to ${admin.email}:`,
+          error
+        );
       }
     }
 
-    this.logger.log(`[EMAIL] EOD Summary complete: ${sent} sent, ${failed} failed`);
+    this.logger.log(
+      `[EMAIL] EOD Summary complete: ${sent} sent, ${failed} failed`
+    );
     return { success: sent > 0, sent, failed };
   }
 
@@ -585,7 +724,9 @@ export class EmailService {
       notes?: string;
     }>;
   }): Promise<{ success: boolean; messageId?: string }> {
-    this.logger.log(`[EMAIL] Sending employee day schedule to ${data.employeeEmail}`);
+    this.logger.log(
+      `[EMAIL] Sending employee day schedule to ${data.employeeEmail}`
+    );
 
     if (!this.enabled) {
       this.logger.warn('[EMAIL] Email service is disabled');
@@ -603,9 +744,29 @@ export class EmailService {
 
       // CRITICAL: Format date from business date string directly to avoid timezone issues
       // Creating a Date object causes UTC conversion which shifts dates after 5 PM PST
-      const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
-        'July', 'August', 'September', 'October', 'November', 'December'];
-      const weekdayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+      const monthNames = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ];
+      const weekdayNames = [
+        'Sunday',
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+      ];
 
       const [year, month, day] = businessDate.split('-').map(Number);
       const dateForWeekday = new Date(Date.UTC(year, month - 1, day));
@@ -614,19 +775,28 @@ export class EmailService {
       const formattedDate = `${weekday}, ${monthName} ${day}, ${year}`;
 
       // Build appointments table rows
-      const appointmentsHtml = data.appointments.length > 0
-        ? data.appointments
-            .map(
-              (apt, index) => `
+      const appointmentsHtml =
+        data.appointments.length > 0
+          ? data.appointments
+              .map(
+                (apt, index) => `
           <tr style="border-bottom: 1px solid #e0e0e0;">
-            <td style="padding: 15px 10px; font-weight: 500; color: #1976d2;">${apt.time}</td>
+            <td style="padding: 15px 10px; font-weight: 500; color: #1976d2;">${
+              apt.time
+            }</td>
             <td style="padding: 15px 10px;">
-              <div style="font-weight: 500; margin-bottom: 4px;">${apt.customerName}</div>
-              <div style="color: #666; font-size: 14px;">${apt.vehicleInfo}</div>
+              <div style="font-weight: 500; margin-bottom: 4px;">${
+                apt.customerName
+              }</div>
+              <div style="color: #666; font-size: 14px;">${
+                apt.vehicleInfo
+              }</div>
             </td>
             <td style="padding: 15px 10px;">
               <div style="margin-bottom: 4px;">${apt.serviceType}</div>
-              <div style="color: #666; font-size: 14px;">${apt.duration} min</div>
+              <div style="color: #666; font-size: 14px;">${
+                apt.duration
+              } min</div>
             </td>
             <td style="padding: 15px 10px;">
               <span style="display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 500; ${
@@ -634,7 +804,11 @@ export class EmailService {
                   ? 'background-color: #e3f2fd; color: #1976d2;'
                   : 'background-color: #fff3e0; color: #f57c00;'
               }">
-                ${apt.location === 'At Shop' ? '🏢 At Shop' : '🚗 Mobile Service'}
+                ${
+                  apt.location === 'At Shop'
+                    ? '🏢 At Shop'
+                    : '🚗 Mobile Service'
+                }
               </span>
             </td>
           </tr>
@@ -648,9 +822,9 @@ export class EmailService {
               : ''
           }
         `
-            )
-            .join('')
-        : `
+              )
+              .join('')
+          : `
           <tr>
             <td colspan="4" style="padding: 30px; text-align: center; color: #999;">
               No appointments scheduled for this day
@@ -703,7 +877,9 @@ export class EmailService {
                     <td style="padding: 0 40px 20px 40px;">
                       <div style="background-color: #e3f2fd; border-left: 4px solid #1976d2; padding: 15px 20px; border-radius: 4px;">
                         <p style="margin: 0; color: #1565c0; font-size: 16px;">
-                          <strong>${data.appointments.length} Appointment${data.appointments.length !== 1 ? 's' : ''}</strong> scheduled for today
+                          <strong>${data.appointments.length} Appointment${
+                          data.appointments.length !== 1 ? 's' : ''
+                        }</strong> scheduled for today
                         </p>
                       </div>
                     </td>
@@ -793,7 +969,9 @@ export class EmailService {
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = response.body?.messageId || 'unknown';
 
-      this.logger.log(`[EMAIL] Employee schedule sent successfully. Message ID: ${messageId}`);
+      this.logger.log(
+        `[EMAIL] Employee schedule sent successfully. Message ID: ${messageId}`
+      );
 
       // Log to database
       try {
@@ -837,7 +1015,9 @@ export class EmailService {
     address?: string;
     notes?: string;
   }): Promise<{ success: boolean; messageId?: string }> {
-    this.logger.log(`[EMAIL] Sending appointment assignment to ${data.employeeEmail}`);
+    this.logger.log(
+      `[EMAIL] Sending appointment assignment to ${data.employeeEmail}`
+    );
 
     if (!this.enabled) {
       this.logger.warn('[EMAIL] Email service is disabled');
@@ -855,9 +1035,29 @@ export class EmailService {
 
       // CRITICAL: Format date from business date string directly to avoid timezone issues
       // Creating a Date object causes UTC conversion which shifts dates after 5 PM PST
-      const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
-        'July', 'August', 'September', 'October', 'November', 'December'];
-      const weekdayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+      const monthNames = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+      ];
+      const weekdayNames = [
+        'Sunday',
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+      ];
 
       const [year, month, day] = businessDate.split('-').map(Number);
       const dateForWeekday = new Date(Date.UTC(year, month - 1, day));
@@ -902,10 +1102,16 @@ export class EmailService {
 
                   <!-- Header -->
                   <tr>
-                    <td style="background: linear-gradient(135deg, ${isGarage ? '#1976d2' : '#f57c00'} 0%, ${isGarage ? '#1565c0' : '#ef6c00'} 100%); padding: 30px 40px; text-align: center;">
+                    <td style="background: linear-gradient(135deg, ${
+                      isGarage ? '#1976d2' : '#f57c00'
+                    } 0%, ${
+        isGarage ? '#1565c0' : '#ef6c00'
+      } 100%); padding: 30px 40px; text-align: center;">
                       <img src="${this.getLogoSrc()}" alt="GT Automotives" style="max-width: 180px; height: auto; margin-bottom: 15px;" />
                       <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">🔔 New Appointment</h1>
-                      <p style="margin: 10px 0 0 0; color: #ffffff; font-size: 16px; opacity: 0.9;">You've been assigned to a ${isMobile ? 'mobile service' : 'shop'} appointment</p>
+                      <p style="margin: 10px 0 0 0; color: #ffffff; font-size: 16px; opacity: 0.9;">You've been assigned to a ${
+                        isMobile ? 'mobile service' : 'shop'
+                      } appointment</p>
                     </td>
                   </tr>
 
@@ -924,9 +1130,19 @@ export class EmailService {
                   <!-- Appointment Type Badge -->
                   <tr>
                     <td style="padding: 0 40px 20px 40px;">
-                      <div style="display: inline-block; background-color: ${isGarage ? '#e3f2fd' : '#fff3e0'}; border-left: 4px solid ${isGarage ? '#1976d2' : '#f57c00'}; padding: 12px 20px; border-radius: 4px;">
-                        <p style="margin: 0; color: ${isGarage ? '#1565c0' : '#e65100'}; font-size: 14px; font-weight: 600;">
-                          ${isGarage ? '🏢 AT SHOP APPOINTMENT' : '🚗 MOBILE SERVICE APPOINTMENT'}
+                      <div style="display: inline-block; background-color: ${
+                        isGarage ? '#e3f2fd' : '#fff3e0'
+                      }; border-left: 4px solid ${
+        isGarage ? '#1976d2' : '#f57c00'
+      }; padding: 12px 20px; border-radius: 4px;">
+                        <p style="margin: 0; color: ${
+                          isGarage ? '#1565c0' : '#e65100'
+                        }; font-size: 14px; font-weight: 600;">
+                          ${
+                            isGarage
+                              ? '🏢 AT SHOP APPOINTMENT'
+                              : '🚗 MOBILE SERVICE APPOINTMENT'
+                          }
                         </p>
                       </div>
                     </td>
@@ -944,7 +1160,9 @@ export class EmailService {
                               <span style="font-size: 24px; margin-right: 12px;">📅</span>
                               <div>
                                 <div style="font-weight: 600; color: #333; font-size: 18px; margin-bottom: 4px;">${formattedDate}</div>
-                                <div style="color: #1976d2; font-size: 16px; font-weight: 500;">${startTimeStr} - ${endTimeStr} (${data.duration} minutes)</div>
+                                <div style="color: #1976d2; font-size: 16px; font-weight: 500;">${startTimeStr} - ${endTimeStr} (${
+        data.duration
+      } minutes)</div>
                               </div>
                             </div>
                           </td>
@@ -954,8 +1172,14 @@ export class EmailService {
                         <tr>
                           <td style="padding: 15px 20px; border-bottom: 1px solid #e0e0e0; font-weight: 600; color: #666; width: 140px;">Customer</td>
                           <td style="padding: 15px 20px; border-bottom: 1px solid #e0e0e0;">
-                            <div style="font-weight: 500; color: #333; margin-bottom: 4px;">${data.customerName}</div>
-                            ${data.customerPhone ? `<div style="color: #666; font-size: 14px;">📞 ${data.customerPhone}</div>` : ''}
+                            <div style="font-weight: 500; color: #333; margin-bottom: 4px;">${
+                              data.customerName
+                            }</div>
+                            ${
+                              data.customerPhone
+                                ? `<div style="color: #666; font-size: 14px;">📞 ${data.customerPhone}</div>`
+                                : ''
+                            }
                           </td>
                         </tr>
 
@@ -984,8 +1208,12 @@ export class EmailService {
                         <tr>
                           <td style="padding: 15px 20px; border-bottom: 1px solid #e0e0e0; font-weight: 600; color: #666;">Location</td>
                           <td style="padding: 15px 20px; border-bottom: 1px solid #e0e0e0;">
-                            <div style="color: #333; margin-bottom: 4px;">📍 ${data.address}</div>
-                            <a href="https://maps.google.com/?q=${encodeURIComponent(data.address)}" style="color: #1976d2; text-decoration: none; font-size: 14px;">
+                            <div style="color: #333; margin-bottom: 4px;">📍 ${
+                              data.address
+                            }</div>
+                            <a href="https://maps.google.com/?q=${encodeURIComponent(
+                              data.address
+                            )}" style="color: #1976d2; text-decoration: none; font-size: 14px;">
                               Open in Google Maps →
                             </a>
                           </td>
@@ -1033,10 +1261,22 @@ export class EmailService {
                         <h3 style="margin: 0 0 12px 0; color: #333; font-size: 16px; font-weight: 600;">✓ What to do next:</h3>
                         <ul style="margin: 0; padding-left: 20px; color: #666; font-size: 14px; line-height: 1.8;">
                           <li>Review the appointment details above</li>
-                          ${isMobile ? '<li>Verify the service location and plan your route</li>' : '<li>Prepare the necessary tools and parts</li>'}
-                          ${data.customerPhone ? '<li>Contact the customer if you have any questions</li>' : ''}
+                          ${
+                            isMobile
+                              ? '<li>Verify the service location and plan your route</li>'
+                              : '<li>Prepare the necessary tools and parts</li>'
+                          }
+                          ${
+                            data.customerPhone
+                              ? '<li>Contact the customer if you have any questions</li>'
+                              : ''
+                          }
                           <li>Update the job status in the system when you start and complete the work</li>
-                          ${isMobile ? '<li>Ensure you have all mobile service equipment ready</li>' : '<li>Check the bay availability before the scheduled time</li>'}
+                          ${
+                            isMobile
+                              ? '<li>Ensure you have all mobile service equipment ready</li>'
+                              : '<li>Check the bay availability before the scheduled time</li>'
+                          }
                         </ul>
                       </div>
                     </td>
@@ -1085,14 +1325,18 @@ export class EmailService {
             name: data.employeeName,
           },
         ],
-        subject: `🔔 New ${isMobile ? 'Mobile Service' : 'Shop'} Appointment - ${data.customerName} (${formattedDate})`,
+        subject: `🔔 New ${
+          isMobile ? 'Mobile Service' : 'Shop'
+        } Appointment - ${data.customerName} (${formattedDate})`,
         htmlContent,
       };
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = response.body?.messageId || 'unknown';
 
-      this.logger.log(`[EMAIL] Appointment assignment sent successfully. Message ID: ${messageId}`);
+      this.logger.log(
+        `[EMAIL] Appointment assignment sent successfully. Message ID: ${messageId}`
+      );
 
       // Log to database
       try {
@@ -1100,7 +1344,9 @@ export class EmailService {
           data: {
             to: data.employeeEmail,
             from: this.senderEmail,
-            subject: `New ${isMobile ? 'Mobile Service' : 'Shop'} Appointment - ${data.customerName}`,
+            subject: `New ${
+              isMobile ? 'Mobile Service' : 'Shop'
+            } Appointment - ${data.customerName}`,
             type: 'APPOINTMENT_CONFIRMATION',
             status: 'SENT',
             brevoMessageId: messageId,
@@ -1114,7 +1360,10 @@ export class EmailService {
 
       return { success: true, messageId };
     } catch (error) {
-      this.logger.error('[EMAIL] Failed to send appointment assignment:', error);
+      this.logger.error(
+        '[EMAIL] Failed to send appointment assignment:',
+        error
+      );
       return { success: false };
     }
   }
@@ -1123,17 +1372,35 @@ export class EmailService {
    * Send invoice email with PDF attachment
    */
   async sendInvoiceEmail(
-    customerEmail: string,
+    customerEmail: string | string[],
     invoiceNumber: string,
-    pdfBase64: string,
+    pdfBase64: string
   ): Promise<{ success: boolean; messageId?: string }> {
     if (!this.enabled) {
-      this.logger.warn('[EMAIL] Email service disabled - skipping invoice email');
+      this.logger.warn(
+        '[EMAIL] Email service disabled - skipping invoice email'
+      );
+      return { success: false };
+    }
+
+    // Normalize to a de-duplicated list of recipients
+    const recipients = Array.from(
+      new Set(
+        (Array.isArray(customerEmail) ? customerEmail : [customerEmail])
+          .map((e) => e.trim())
+          .filter((e) => e !== '')
+      )
+    );
+
+    if (recipients.length === 0) {
+      this.logger.warn('[EMAIL] No valid recipients for invoice email');
       return { success: false };
     }
 
     try {
-      this.logger.log(`[EMAIL] Sending invoice ${invoiceNumber} to ${customerEmail}`);
+      this.logger.log(
+        `[EMAIL] Sending invoice ${invoiceNumber} to ${recipients.join(', ')}`
+      );
 
       const logoImg = this.logoBase64
         ? `<img src="${this.logoBase64}" alt="GT Automotives" style="width: 80px; height: 80px; object-fit: contain;" />`
@@ -1196,7 +1463,7 @@ export class EmailService {
 
       const sendSmtpEmail: SendSmtpEmail = {
         sender: { name: this.senderName, email: this.senderEmail },
-        to: [{ email: customerEmail }],
+        to: recipients.map((email) => ({ email })),
         subject: `Invoice ${invoiceNumber} - GT Automotives`,
         htmlContent,
         attachment: [
@@ -1210,14 +1477,16 @@ export class EmailService {
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = (response as any)?.messageId || 'unknown';
 
-      this.logger.log(`[EMAIL] Invoice email sent successfully. Message ID: ${messageId}`);
+      this.logger.log(
+        `[EMAIL] Invoice email sent successfully. Message ID: ${messageId}`
+      );
 
       // Log to database
       try {
         await this.prisma.emailLog.create({
           data: {
             type: EmailType.INVOICE_DELIVERY,
-            to: customerEmail,
+            to: recipients.join(', '),
             from: this.senderEmail,
             subject: `Invoice ${invoiceNumber} - GT Automotives`,
             status: EmailStatus.SENT,
@@ -1225,13 +1494,20 @@ export class EmailService {
           },
         });
       } catch (dbError) {
-        this.logger.error('[EMAIL] Failed to log invoice email to database:', dbError);
+        this.logger.error(
+          '[EMAIL] Failed to log invoice email to database:',
+          dbError
+        );
       }
 
       return { success: true, messageId };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      this.logger.error(`[EMAIL] Failed to send invoice email: ${errorMessage}`, error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `[EMAIL] Failed to send invoice email: ${errorMessage}`,
+        error
+      );
       return { success: false };
     }
   }
@@ -1242,15 +1518,19 @@ export class EmailService {
   async sendQuotationEmail(
     customerEmail: string,
     quotationNumber: string,
-    pdfBase64: string,
+    pdfBase64: string
   ): Promise<{ success: boolean; messageId?: string }> {
     if (!this.enabled) {
-      this.logger.warn('[EMAIL] Email service disabled - skipping quotation email');
+      this.logger.warn(
+        '[EMAIL] Email service disabled - skipping quotation email'
+      );
       return { success: false };
     }
 
     try {
-      this.logger.log(`[EMAIL] Sending quotation ${quotationNumber} to ${customerEmail}`);
+      this.logger.log(
+        `[EMAIL] Sending quotation ${quotationNumber} to ${customerEmail}`
+      );
 
       const logoImg = this.logoBase64
         ? `<img src="${this.logoBase64}" alt="GT Automotives" style="width: 80px; height: 80px; object-fit: contain;" />`
@@ -1331,7 +1611,9 @@ export class EmailService {
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = (response as any)?.messageId || 'unknown';
 
-      this.logger.log(`[EMAIL] Quotation email sent successfully. Message ID: ${messageId}`);
+      this.logger.log(
+        `[EMAIL] Quotation email sent successfully. Message ID: ${messageId}`
+      );
 
       // Log to database
       try {
@@ -1346,7 +1628,10 @@ export class EmailService {
           },
         });
       } catch (dbError) {
-        this.logger.error('[EMAIL] Failed to log quotation email to database:', dbError);
+        this.logger.error(
+          '[EMAIL] Failed to log quotation email to database:',
+          dbError
+        );
       }
 
       return { success: true, messageId };
@@ -1374,7 +1659,9 @@ export class EmailService {
       notes: string;
     };
   }): Promise<{ success: boolean; messageId?: string }> {
-    this.logger.log(`[EMAIL] Sending booking request notification to ${data.recipientEmail}`);
+    this.logger.log(
+      `[EMAIL] Sending booking request notification to ${data.recipientEmail}`
+    );
 
     if (!this.enabled) {
       this.logger.warn('[EMAIL] Email service is disabled');
@@ -1414,18 +1701,37 @@ export class EmailService {
                     </p>
 
                     <p style="margin: 0 0 30px; font-size: 16px; color: #333333; line-height: 1.6;">
-                      A new booking request has been received from <strong>${data.bookingRequest.customerName}</strong>.
+                      A new booking request has been received from <strong>${
+                        data.bookingRequest.customerName
+                      }</strong>.
                     </p>
 
                     <!-- Booking Summary -->
                     <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 30px;">
                       <h3 style="margin: 0 0 15px; color: #1e3a5f; font-size: 16px;">Booking Summary</h3>
                       <p style="margin: 0; color: #666; font-size: 14px; line-height: 1.8;">
-                        <strong>Customer:</strong> ${data.bookingRequest.customerName}<br>
-                        <strong>Service Type:</strong> ${data.bookingRequest.serviceType}<br>
-                        <strong>Service Location:</strong> ${data.bookingRequest.appointmentType === 'AT_GARAGE' ? '🏪 At Shop' : '🚗 Mobile Service'}${data.bookingRequest.address ? ` - ${data.bookingRequest.address}` : ''}<br>
-                        <strong>Requested Date:</strong> ${data.bookingRequest.requestedDate} at ${data.bookingRequest.requestedTime}
-                        ${data.bookingRequest.notes && data.bookingRequest.notes !== 'None' ? `<br><br><strong>Customer Notes:</strong><br><span style="font-style: italic; color: #555;">"${data.bookingRequest.notes}"</span>` : ''}
+                        <strong>Customer:</strong> ${
+                          data.bookingRequest.customerName
+                        }<br>
+                        <strong>Service Type:</strong> ${
+                          data.bookingRequest.serviceType
+                        }<br>
+                        <strong>Service Location:</strong> ${
+                          data.bookingRequest.appointmentType === 'AT_GARAGE'
+                            ? '🏪 At Shop'
+                            : '🚗 Mobile Service'
+                        }${
+      data.bookingRequest.address ? ` - ${data.bookingRequest.address}` : ''
+    }<br>
+                        <strong>Requested Date:</strong> ${
+                          data.bookingRequest.requestedDate
+                        } at ${data.bookingRequest.requestedTime}
+                        ${
+                          data.bookingRequest.notes &&
+                          data.bookingRequest.notes !== 'None'
+                            ? `<br><br><strong>Customer Notes:</strong><br><span style="font-style: italic; color: #555;">"${data.bookingRequest.notes}"</span>`
+                            : ''
+                        }
                       </p>
                     </div>
 
@@ -1475,7 +1781,10 @@ export class EmailService {
 
       return result;
     } catch (error) {
-      this.logger.error('[EMAIL] Failed to send booking request notification:', error);
+      this.logger.error(
+        '[EMAIL] Failed to send booking request notification:',
+        error
+      );
       return { success: false };
     }
   }

--- a/server/src/invoices/invoices.controller.ts
+++ b/server/src/invoices/invoices.controller.ts
@@ -10,7 +10,12 @@ import {
   Query,
 } from '@nestjs/common';
 import { InvoicesService } from './invoices.service';
-import { CreateInvoiceDto, CreateServiceDto, UpdateInvoiceDto, UpdateServiceDto } from '@gt-automotive/data';
+import {
+  CreateInvoiceDto,
+  CreateServiceDto,
+  UpdateInvoiceDto,
+  UpdateServiceDto,
+} from '@gt-automotive/data';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleGuard } from '../auth/guards/role.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -47,7 +52,7 @@ export class InvoicesController {
     @Query('endDate') endDate?: string,
     @Query('status') status?: InvoiceStatus,
     @Query('companyId') companyId?: string,
-    @CurrentUser() user?: any,
+    @CurrentUser() user?: any
   ) {
     return this.invoicesService.searchInvoices(
       {
@@ -58,7 +63,7 @@ export class InvoicesController {
         status,
         companyId,
       },
-      user,
+      user
     );
   }
 
@@ -74,7 +79,10 @@ export class InvoicesController {
   @Get('customer/:customerId')
   @UseGuards(RoleGuard)
   @Roles('ADMIN', 'SUPERVISOR', 'STAFF', 'ACCOUNTANT')
-  getCustomerInvoices(@Param('customerId') customerId: string, @CurrentUser() user: any) {
+  getCustomerInvoices(
+    @Param('customerId') customerId: string,
+    @CurrentUser() user: any
+  ) {
     return this.invoicesService.getCustomerInvoices(customerId, user);
   }
 
@@ -91,7 +99,7 @@ export class InvoicesController {
   update(
     @Param('id') id: string,
     @Body() updateInvoiceDto: UpdateInvoiceDto,
-    @CurrentUser() user: any,
+    @CurrentUser() user: any
   ) {
     return this.invoicesService.update(id, updateInvoiceDto, user.id);
   }
@@ -102,7 +110,7 @@ export class InvoicesController {
   markAsPaid(
     @Param('id') id: string,
     @Body('paymentMethod') paymentMethod: PaymentMethod,
-    @CurrentUser() user: any,
+    @CurrentUser() user: any
   ) {
     return this.invoicesService.markAsPaid(id, paymentMethod, user.id);
   }
@@ -112,10 +120,23 @@ export class InvoicesController {
   @Roles('ADMIN', 'SUPERVISOR', 'STAFF', 'ACCOUNTANT')
   sendEmail(
     @Param('id') id: string,
-    @Body() body: { email?: string; saveToCustomer?: boolean },
-    @CurrentUser() user: any,
+    @Body()
+    body: { email?: string; emails?: string[]; saveToCustomer?: boolean },
+    @CurrentUser() user: any
   ) {
-    return this.invoicesService.sendInvoiceEmail(id, user.id, body.email, body.saveToCustomer);
+    // Accept either a single `email` (legacy) or an `emails` array (multi-recipient)
+    const emails =
+      body.emails && body.emails.length > 0
+        ? body.emails
+        : body.email
+        ? [body.email]
+        : undefined;
+    return this.invoicesService.sendInvoiceEmail(
+      id,
+      user.id,
+      emails,
+      body.saveToCustomer
+    );
   }
 
   @Delete(':id')
@@ -143,7 +164,10 @@ export class InvoicesController {
   @Patch('services/:id')
   @UseGuards(RoleGuard)
   @Roles('ADMIN', 'SUPERVISOR', 'STAFF', 'ACCOUNTANT')
-  updateService(@Param('id') id: string, @Body() updateServiceDto: UpdateServiceDto) {
+  updateService(
+    @Param('id') id: string,
+    @Body() updateServiceDto: UpdateServiceDto
+  ) {
     return this.invoicesService.updateService(id, updateServiceDto);
   }
 

--- a/server/src/invoices/invoices.service.spec.ts
+++ b/server/src/invoices/invoices.service.spec.ts
@@ -24,7 +24,11 @@ describe('InvoicesService.create — totals calculation', () => {
       createWithItems,
     };
     const auditRepository = { create: jest.fn().mockResolvedValue({}) };
-    const customerRepository = { create: jest.fn() };
+    const customerRepository = {
+      create: jest.fn(),
+      // Non-exempt by default so PST is applied in these tests
+      findById: jest.fn().mockResolvedValue({ pstExempt: false }),
+    };
     const serviceRepository = {};
     const pdfService = {};
     const emailService = {};

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -142,6 +142,15 @@ export class InvoicesService {
       taxRate = createInvoiceDto.taxRate ?? 0.0825;
     }
 
+    // PST-exempt customers are charged 0% PST regardless of what the client sent.
+    // This server-side gate is authoritative.
+    const customerForTax = await this.customerRepository.findById(customerId);
+    if (customerForTax?.pstExempt) {
+      pstRate = 0;
+      pstAmount = 0;
+      taxRate = gstRate ?? 0;
+    }
+
     const taxAmount = taxableSubtotal * taxRate;
     const total = subtotal + taxAmount;
 
@@ -250,6 +259,12 @@ export class InvoicesService {
     // Log will track changes for audit purposes
     const oldValue = { ...invoice };
 
+    // PST-exempt customers are always charged 0% PST (authoritative server-side gate)
+    const customerForTax = await this.customerRepository.findById(
+      invoice.customerId
+    );
+    const pstExempt = !!customerForTax?.pstExempt;
+
     // Prepare update data
     const updateData: any = {};
 
@@ -297,10 +312,12 @@ export class InvoicesService {
         updateInvoiceDto.gstRate !== undefined
           ? updateInvoiceDto.gstRate
           : Number(invoice.gstRate || 0);
-      const pstRate =
-        updateInvoiceDto.pstRate !== undefined
-          ? updateInvoiceDto.pstRate
-          : Number(invoice.pstRate || 0);
+      // PST-exempt customers are forced to 0% PST
+      const pstRate = pstExempt
+        ? 0
+        : updateInvoiceDto.pstRate !== undefined
+        ? updateInvoiceDto.pstRate
+        : Number(invoice.pstRate || 0);
       const taxRate = gstRate + pstRate;
       const gstAmount = subtotal * gstRate;
       const pstAmount = subtotal * pstRate;
@@ -320,7 +337,11 @@ export class InvoicesService {
       if (updateInvoiceDto.gstRate !== undefined) {
         updateData.gstRate = new Decimal(updateInvoiceDto.gstRate);
       }
-      if (updateInvoiceDto.pstRate !== undefined) {
+      if (pstExempt) {
+        // PST-exempt customers never carry PST
+        updateData.pstRate = new Decimal(0);
+        updateData.pstAmount = new Decimal(0);
+      } else if (updateInvoiceDto.pstRate !== undefined) {
         updateData.pstRate = new Decimal(updateInvoiceDto.pstRate);
       }
       if (updateInvoiceDto.subtotal !== undefined) {
@@ -536,7 +557,7 @@ export class InvoicesService {
   async sendInvoiceEmail(
     invoiceId: string,
     userId: string,
-    overrideEmail?: string,
+    emails?: string[],
     saveToCustomer?: boolean
   ) {
     // Get invoice with all relations including customer
@@ -548,30 +569,67 @@ export class InvoicesService {
     // Get customer separately to ensure proper typing
     const customer = await this.customerRepository.findById(invoice.customerId);
 
-    // Use override email or customer email
-    const emailToUse = overrideEmail || customer?.email;
+    // Clean + de-duplicate the provided recipients
+    const providedEmails = Array.from(
+      new Set((emails ?? []).map((e) => e.trim()).filter((e) => e !== ''))
+    );
 
-    // Check if we have an email to send to
-    if (!emailToUse) {
+    // Use the explicitly selected recipients, falling back to the customer's primary email
+    const recipients =
+      providedEmails.length > 0
+        ? providedEmails
+        : customer?.email
+        ? [customer.email]
+        : [];
+
+    // Check if we have at least one email to send to
+    if (recipients.length === 0) {
       throw new BadRequestException(
         'No email address provided and customer does not have an email address'
       );
     }
 
-    // If saveToCustomer is true and customer exists, update customer email
-    if (saveToCustomer && customer && overrideEmail && !customer.email) {
-      await this.customerRepository.update(customer.id, {
-        email: overrideEmail,
-      });
+    // If saveToCustomer is true and customer exists, persist any new emails back to the customer
+    if (saveToCustomer && customer) {
+      const knownEmails = [
+        customer.email,
+        ...(customer.additionalEmails ?? []),
+      ].filter((e): e is string => !!e);
+      let primary = customer.email ?? undefined;
+      const additional = [...(customer.additionalEmails ?? [])];
+
+      for (const email of recipients) {
+        if (knownEmails.includes(email)) continue;
+        if (!primary) {
+          primary = email;
+        } else {
+          additional.push(email);
+        }
+        knownEmails.push(email);
+      }
+
+      const dedupedAdditional = Array.from(new Set(additional)).filter(
+        (e) => e !== primary
+      );
+
+      if (
+        primary !== (customer.email ?? undefined) ||
+        dedupedAdditional.length !== (customer.additionalEmails ?? []).length
+      ) {
+        await this.customerRepository.update(customer.id, {
+          email: primary,
+          additionalEmails: dedupedAdditional,
+        });
+      }
     }
 
     try {
       // Generate PDF
       const pdfBase64 = await this.pdfService.generateInvoicePdf(invoice);
 
-      // Send email
+      // Send email to all recipients
       const emailResult = await this.emailService.sendInvoiceEmail(
-        emailToUse,
+        recipients,
         invoice.invoiceNumber,
         pdfBase64
       );
@@ -588,17 +646,17 @@ export class InvoicesService {
         entityType: 'Invoice',
         entityId: invoiceId,
         details: {
-          email: emailToUse,
+          emails: recipients,
           invoiceNumber: invoice.invoiceNumber,
           messageId: emailResult.messageId,
-          emailSavedToCustomer: saveToCustomer && !!overrideEmail,
+          emailsSavedToCustomer: !!saveToCustomer,
         },
       });
 
       return {
         success: true,
         message: 'Invoice email sent successfully',
-        emailUsed: emailToUse,
+        emailUsed: recipients.join(', '),
       };
     } catch (error) {
       throw new BadRequestException(


### PR DESCRIPTION
## Summary
Two customer-facing billing features plus a small bug fix.

### 1. Multiple emails per customer
- New `Customer.additionalEmails` (`String[]`) — managed via Add/Remove rows in both the Edit Customer dialog and the customer form page.
- **Invoice → Send Email** now opens a recipient picker: checkboxes for the customer's primary + additional emails, plus the ability to add ad-hoc addresses. One email is sent to all selected recipients.
- `EmailPromptDialog` gained a multi-recipient mode and a modern "sending" animation (spinning gradient ring + paper-plane + bouncing dots); quotation single-email mode preserved.

### 2. PST-exempt customers
- New `Customer.pstExempt` (`Boolean`). When enabled, the customer's invoices are charged **0% PST** (GST still applies).
- **Authoritative server-side gate** in invoice `create`/`update` and appointment-generated invoices — PST is forced to 0 regardless of client input.
- **PST Exempt** checkbox in the Edit Customer dialog and form; the invoice dialog reflects 0% PST when an exempt customer is selected.

### 3. Bug fix
- Customer Details "Outstanding" card showed `NaN` — fixed by coercing Prisma `Decimal` string values to numbers before arithmetic.

## Database
- Migrations: `add_customer_additional_emails`, `add_customer_pst_exempt` (additive columns, safe defaults).

## Testing
- `data`, `server`, `webApp` typecheck pass.
- Server unit tests: **270/270 pass** (added `findById` mock for the new PST gate).
- Verified end-to-end locally: multi-recipient invoice email delivered to two addresses.

## Notes
- Base is `feature/carfax-integration` so this diff isolates the email/PST work from the CARFAX changes. Retarget to `main` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)