### PR TITLE
GA-22: Inline vehicle management (add/edit/delete) in customer add/edit

### DIFF
--- a/apps/webApp/src/app/components/customers/CustomerDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDialog.tsx
@@ -38,6 +38,7 @@ import {
 import { colors } from '../../theme/colors';
 import { PhoneInput } from '../common/PhoneInput';
 import { AddressAutocomplete } from '../common/AddressAutocomplete';
+import { CustomerVehiclesSection } from './CustomerVehiclesSection';
 import axios from 'axios';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
@@ -504,6 +505,29 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
               </Grid>
             </Grid>
           </form>
+        )}
+
+        {/* Inline vehicle management (available once the customer exists) */}
+        {!loading && isEdit && customerId && (
+          <Box sx={{ mt: 3 }}>
+            <CustomerVehiclesSection
+              customerId={customerId}
+              customerName={
+                formData.businessName ||
+                `${formData.firstName} ${formData.lastName}`.trim() ||
+                'this customer'
+              }
+            />
+          </Box>
+        )}
+        {!loading && !isEdit && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mt: 2 }}
+          >
+            Save the customer first to add their vehicles.
+          </Typography>
         )}
       </DialogContent>
 

--- a/apps/webApp/src/app/components/customers/CustomerDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDialog.tsx
@@ -443,6 +443,42 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
                 />
               </Grid>
 
+              {/* Inline vehicle management (available once the customer exists) */}
+              <Grid size={{ xs: 12 }}>
+                {(() => {
+                  const editCustomerId = customerId || initialCustomer?.id;
+                  if (editCustomerId) {
+                    return (
+                      <Box
+                        sx={{
+                          py: 2,
+                          borderTop: `1px solid ${colors.neutral[200]}`,
+                          borderBottom: `1px solid ${colors.neutral[200]}`,
+                        }}
+                      >
+                        <CustomerVehiclesSection
+                          customerId={editCustomerId}
+                          customerName={
+                            formData.businessName ||
+                            `${formData.firstName} ${formData.lastName}`.trim() ||
+                            'this customer'
+                          }
+                        />
+                      </Box>
+                    );
+                  }
+                  return (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block' }}
+                    >
+                      Save the customer first to add their vehicles.
+                    </Typography>
+                  );
+                })()}
+              </Grid>
+
               {/* PST Exempt */}
               <Grid size={{ xs: 12 }}>
                 <FormControlLabel
@@ -506,41 +542,6 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
             </Grid>
           </form>
         )}
-
-        {/* Inline vehicle management (available once the customer exists) */}
-        {(() => {
-          const editCustomerId = customerId || initialCustomer?.id;
-          if (loading) return null;
-          if (editCustomerId) {
-            return (
-              <Box
-                sx={{
-                  mt: 3,
-                  pt: 2,
-                  borderTop: `1px solid ${colors.neutral[200]}`,
-                }}
-              >
-                <CustomerVehiclesSection
-                  customerId={editCustomerId}
-                  customerName={
-                    formData.businessName ||
-                    `${formData.firstName} ${formData.lastName}`.trim() ||
-                    'this customer'
-                  }
-                />
-              </Box>
-            );
-          }
-          return (
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ display: 'block', mt: 2 }}
-            >
-              Save the customer first to add their vehicles.
-            </Typography>
-          );
-        })()}
       </DialogContent>
 
       <DialogActions

--- a/apps/webApp/src/app/components/customers/CustomerDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDialog.tsx
@@ -449,13 +449,7 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
                   const editCustomerId = customerId || initialCustomer?.id;
                   if (editCustomerId) {
                     return (
-                      <Box
-                        sx={{
-                          py: 2,
-                          borderTop: `1px solid ${colors.neutral[200]}`,
-                          borderBottom: `1px solid ${colors.neutral[200]}`,
-                        }}
-                      >
+                      <Box sx={{ py: 1 }}>
                         <CustomerVehiclesSection
                           customerId={editCustomerId}
                           customerName={

--- a/apps/webApp/src/app/components/customers/CustomerDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDialog.tsx
@@ -508,27 +508,39 @@ export const CustomerDialog: React.FC<CustomerDialogProps> = ({
         )}
 
         {/* Inline vehicle management (available once the customer exists) */}
-        {!loading && isEdit && customerId && (
-          <Box sx={{ mt: 3 }}>
-            <CustomerVehiclesSection
-              customerId={customerId}
-              customerName={
-                formData.businessName ||
-                `${formData.firstName} ${formData.lastName}`.trim() ||
-                'this customer'
-              }
-            />
-          </Box>
-        )}
-        {!loading && !isEdit && (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ display: 'block', mt: 2 }}
-          >
-            Save the customer first to add their vehicles.
-          </Typography>
-        )}
+        {(() => {
+          const editCustomerId = customerId || initialCustomer?.id;
+          if (loading) return null;
+          if (editCustomerId) {
+            return (
+              <Box
+                sx={{
+                  mt: 3,
+                  pt: 2,
+                  borderTop: `1px solid ${colors.neutral[200]}`,
+                }}
+              >
+                <CustomerVehiclesSection
+                  customerId={editCustomerId}
+                  customerName={
+                    formData.businessName ||
+                    `${formData.firstName} ${formData.lastName}`.trim() ||
+                    'this customer'
+                  }
+                />
+              </Box>
+            );
+          }
+          return (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: 'block', mt: 2 }}
+            >
+              Save the customer first to add their vehicles.
+            </Typography>
+          );
+        })()}
       </DialogContent>
 
       <DialogActions

--- a/apps/webApp/src/app/components/customers/CustomerVehiclesSection.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerVehiclesSection.tsx
@@ -47,6 +47,9 @@ export function CustomerVehiclesSection({
   const [editingVehicle, setEditingVehicle] = useState<Vehicle | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
+  // Note: intentionally depends only on customerId. `showApiError` from
+  // useErrorHelpers() is a fresh function each render, so including it would
+  // re-create this callback every render and put the load effect in a loop.
   const loadVehicles = useCallback(async () => {
     if (!customerId) return;
     setLoading(true);
@@ -58,7 +61,8 @@ export function CustomerVehiclesSection({
     } finally {
       setLoading(false);
     }
-  }, [customerId, showApiError]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customerId]);
 
   useEffect(() => {
     loadVehicles();

--- a/apps/webApp/src/app/components/customers/CustomerVehiclesSection.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerVehiclesSection.tsx
@@ -8,7 +8,6 @@ import {
   IconButton,
   CircularProgress,
   Tooltip,
-  Divider,
 } from '@mui/material';
 import {
   DirectionsCar,
@@ -185,8 +184,6 @@ export function CustomerVehiclesSection({
           ))}
         </Stack>
       )}
-
-      <Divider sx={{ mt: 2 }} />
 
       <AddVehicleDialog
         open={dialogOpen}

--- a/apps/webApp/src/app/components/customers/CustomerVehiclesSection.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerVehiclesSection.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Stack,
+  Typography,
+  Paper,
+  IconButton,
+  CircularProgress,
+  Tooltip,
+  Divider,
+} from '@mui/material';
+import {
+  DirectionsCar,
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+} from '@mui/icons-material';
+import { vehicleService, Vehicle } from '../../requests/vehicle.requests';
+import { AddVehicleDialog } from '../repair-orders/AddVehicleDialog';
+import { useErrorHelpers } from '../../contexts/ErrorContext';
+import { useConfirmation } from '../../contexts/ConfirmationContext';
+import { useAuth } from '../../hooks/useAuth';
+
+interface CustomerVehiclesSectionProps {
+  customerId: string;
+  customerName: string;
+}
+
+/**
+ * Inline vehicle management for the customer add/edit experience: lists the
+ * customer's vehicles with full details and supports add / edit / delete.
+ * Delete is admin-only and may be blocked server-side by service history.
+ */
+export function CustomerVehiclesSection({
+  customerId,
+  customerName,
+}: CustomerVehiclesSectionProps) {
+  const { showApiError } = useErrorHelpers();
+  const { confirm } = useConfirmation();
+  const { role } = useAuth();
+  const isAdmin = role === 'admin';
+
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingVehicle, setEditingVehicle] = useState<Vehicle | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const loadVehicles = useCallback(async () => {
+    if (!customerId) return;
+    setLoading(true);
+    try {
+      const data = await vehicleService.getCustomerVehicles(customerId);
+      setVehicles(data);
+    } catch (error) {
+      showApiError(error, 'Failed to load vehicles.');
+    } finally {
+      setLoading(false);
+    }
+  }, [customerId, showApiError]);
+
+  useEffect(() => {
+    loadVehicles();
+  }, [loadVehicles]);
+
+  const handleAdd = () => {
+    setEditingVehicle(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (vehicle: Vehicle) => {
+    setEditingVehicle(vehicle);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async (vehicle: Vehicle) => {
+    const confirmed = await confirm({
+      title: 'Delete Vehicle',
+      message: `Delete ${vehicle.year} ${vehicle.make} ${vehicle.model}? This cannot be undone.`,
+      confirmText: 'Delete',
+      severity: 'error',
+      confirmButtonColor: 'error',
+    });
+    if (!confirmed) return;
+
+    setDeletingId(vehicle.id);
+    try {
+      await vehicleService.deleteVehicle(vehicle.id);
+      await loadVehicles();
+    } catch (error) {
+      // Surfaces the "existing service history" block from the API.
+      showApiError(error, 'Failed to delete vehicle.');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <Box>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ mb: 1 }}
+      >
+        <Stack direction="row" spacing={1} alignItems="center">
+          <DirectionsCar fontSize="small" color="action" />
+          <Typography variant="subtitle1" fontWeight={600}>
+            Vehicles
+          </Typography>
+        </Stack>
+        <Button size="small" startIcon={<AddIcon />} onClick={handleAdd}>
+          Add Vehicle
+        </Button>
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+          <CircularProgress size={22} />
+        </Box>
+      ) : vehicles.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+          No vehicles yet. Use “Add Vehicle” to create one.
+        </Typography>
+      ) : (
+        <Stack spacing={1}>
+          {vehicles.map((vehicle) => (
+            <Paper key={vehicle.id} variant="outlined" sx={{ p: 1.5 }}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                spacing={1}
+              >
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography variant="body2" fontWeight={600} noWrap>
+                    {vehicle.year} {vehicle.make} {vehicle.model}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {vehicle.engineType ? `${vehicle.engineType} · ` : ''}
+                    {vehicle.mileage != null
+                      ? `${vehicle.mileage.toLocaleString()} km · `
+                      : ''}
+                    {vehicle.licensePlate
+                      ? `Plate ${vehicle.licensePlate} · `
+                      : ''}
+                    {`VIN ${vehicle.vin || 'not on file'}`}
+                  </Typography>
+                </Box>
+                <Stack direction="row" spacing={0.5}>
+                  <Tooltip title="Edit vehicle">
+                    <IconButton
+                      size="small"
+                      onClick={() => handleEdit(vehicle)}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  {isAdmin && (
+                    <Tooltip title="Delete vehicle">
+                      <span>
+                        <IconButton
+                          size="small"
+                          color="error"
+                          onClick={() => handleDelete(vehicle)}
+                          disabled={deletingId === vehicle.id}
+                        >
+                          {deletingId === vehicle.id ? (
+                            <CircularProgress size={16} color="inherit" />
+                          ) : (
+                            <DeleteIcon fontSize="small" />
+                          )}
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
+                </Stack>
+              </Stack>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+
+      <Divider sx={{ mt: 2 }} />
+
+      <AddVehicleDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        customerId={customerId}
+        customerName={customerName}
+        requireVin={false}
+        vehicle={editingVehicle}
+        onAdded={async () => {
+          setDialogOpen(false);
+          await loadVehicles();
+        }}
+      />
+    </Box>
+  );
+}

--- a/apps/webApp/src/app/components/repair-orders/AddVehicleDialog.tsx
+++ b/apps/webApp/src/app/components/repair-orders/AddVehicleDialog.tsx
@@ -45,6 +45,11 @@ interface AddVehicleDialogProps {
    * VIN can be captured later and mileage is optional.
    */
   requireVin?: boolean;
+  /**
+   * When provided the dialog edits this existing vehicle instead of creating a
+   * new one. The same form is reused; on save the vehicle is updated.
+   */
+  vehicle?: Vehicle | null;
 }
 
 export function AddVehicleDialog({
@@ -54,7 +59,9 @@ export function AddVehicleDialog({
   customerName,
   onAdded,
   requireVin = true,
+  vehicle: editVehicle = null,
 }: AddVehicleDialogProps) {
+  const isEdit = !!editVehicle;
   const { showApiError, showValidationError } = useErrorHelpers();
   const [make, setMake] = useState('');
   const [model, setModel] = useState('');
@@ -76,6 +83,26 @@ export function AddVehicleDialog({
       .then(setMakesData)
       .catch(() => setMakesData([]));
   }, [open, makesData.length]);
+
+  // When opened for editing, prefill the form from the existing vehicle.
+  useEffect(() => {
+    if (!open) return;
+    if (editVehicle) {
+      setMake(editVehicle.make ?? '');
+      setModel(editVehicle.model ?? '');
+      setYear(editVehicle.year ?? new Date().getFullYear());
+      setVin(editVehicle.vin ? normalizeVin(editVehicle.vin) : '');
+      setLicensePlate(editVehicle.licensePlate ?? '');
+      setColor(editVehicle.color ?? '');
+      setMileage(
+        editVehicle.mileage != null ? String(editVehicle.mileage) : ''
+      );
+      setEngineType(editVehicle.engineType ?? '');
+    } else {
+      reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, editVehicle?.id]);
 
   const makeOptions = useMemo(() => makesData.map((m) => m.name), [makesData]);
   const modelOptions = useMemo(
@@ -149,21 +176,38 @@ export function AddVehicleDialog({
     }
     setSaving(true);
     try {
-      const vehicle = await vehicleService.createVehicle({
-        customerId,
-        make: make.trim(),
-        model: model.trim(),
-        year: Number(year),
-        vin: vin.trim() || undefined,
-        licensePlate: licensePlate.trim() || undefined,
-        color: color.trim() || undefined,
-        mileage: mileage ? Number(mileage) : undefined,
-        engineType: engineType.trim() || undefined,
-      });
+      let vehicle: Vehicle;
+      if (editVehicle) {
+        vehicle = await vehicleService.updateVehicle(editVehicle.id, {
+          make: make.trim(),
+          model: model.trim(),
+          year: Number(year),
+          vin: vin.trim() || null,
+          licensePlate: licensePlate.trim() || null,
+          color: color.trim() || undefined,
+          mileage: mileage ? Number(mileage) : undefined,
+          engineType: engineType.trim() || undefined,
+        });
+      } else {
+        vehicle = await vehicleService.createVehicle({
+          customerId,
+          make: make.trim(),
+          model: model.trim(),
+          year: Number(year),
+          vin: vin.trim() || undefined,
+          licensePlate: licensePlate.trim() || undefined,
+          color: color.trim() || undefined,
+          mileage: mileage ? Number(mileage) : undefined,
+          engineType: engineType.trim() || undefined,
+        });
+      }
       onAdded(vehicle);
       reset();
     } catch (error) {
-      showApiError(error, 'Failed to add vehicle.');
+      showApiError(
+        error,
+        isEdit ? 'Failed to update vehicle.' : 'Failed to add vehicle.'
+      );
     } finally {
       setSaving(false);
     }
@@ -172,11 +216,13 @@ export function AddVehicleDialog({
   return (
     <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <DirectionsCar color="action" /> Add Vehicle
+        <DirectionsCar color="action" />{' '}
+        {isEdit ? 'Edit Vehicle' : 'Add Vehicle'}
       </DialogTitle>
       <DialogContent>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Adding a vehicle for <strong>{customerName}</strong>.
+          {isEdit ? 'Editing a vehicle for ' : 'Adding a vehicle for '}
+          <strong>{customerName}</strong>.
         </Typography>
 
         <Stack spacing={2}>
@@ -339,7 +385,7 @@ export function AddVehicleDialog({
                 )
               }
             >
-              Add Vehicle
+              {isEdit ? 'Save Vehicle' : 'Add Vehicle'}
             </Button>
           );
         })()}

--- a/apps/webApp/src/app/pages/customers/CustomerForm.tsx
+++ b/apps/webApp/src/app/pages/customers/CustomerForm.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../requests/customer.requests';
 import { PhoneInput } from '../../components/common/PhoneInput';
 import { AddressAutocomplete } from '../../components/common/AddressAutocomplete';
+import { CustomerVehiclesSection } from '../../components/customers/CustomerVehiclesSection';
 import axios from 'axios';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
@@ -390,6 +391,22 @@ export function CustomerForm() {
           </form>
         </CardContent>
       </Card>
+
+      {/* Inline vehicle management (available once the customer exists) */}
+      {isEdit && id && (
+        <Card sx={{ mt: 3 }}>
+          <CardContent>
+            <CustomerVehiclesSection
+              customerId={id}
+              customerName={
+                formData.businessName ||
+                `${formData.firstName} ${formData.lastName}`.trim() ||
+                'this customer'
+              }
+            />
+          </CardContent>
+        </Card>
+      )}
     </Box>
   );
 }

--- a/server/src/vehicles/vehicles.service.spec.ts
+++ b/server/src/vehicles/vehicles.service.spec.ts
@@ -35,6 +35,8 @@ describe('VehiclesService', () => {
       vehicleMake: { findMany: jest.fn() },
       invoice: { count: jest.fn() },
       appointment: { count: jest.fn() },
+      repairOrder: { count: jest.fn() },
+      inspection: { count: jest.fn() },
     };
 
     service = new VehiclesService(
@@ -274,6 +276,21 @@ describe('VehiclesService', () => {
       vehicleRepository.findById.mockResolvedValue({ id: 'v1' });
       prisma.invoice.count.mockResolvedValue(1);
       prisma.appointment.count.mockResolvedValue(0);
+      prisma.repairOrder.count.mockResolvedValue(0);
+      prisma.inspection.count.mockResolvedValue(0);
+
+      await expect(
+        service.remove('v1', 'user-1', 'ADMIN')
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(vehicleRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when the vehicle has repair orders or inspections', async () => {
+      vehicleRepository.findById.mockResolvedValue({ id: 'v1' });
+      prisma.invoice.count.mockResolvedValue(0);
+      prisma.appointment.count.mockResolvedValue(0);
+      prisma.repairOrder.count.mockResolvedValue(2);
+      prisma.inspection.count.mockResolvedValue(0);
 
       await expect(
         service.remove('v1', 'user-1', 'ADMIN')
@@ -285,6 +302,8 @@ describe('VehiclesService', () => {
       vehicleRepository.findById.mockResolvedValue({ id: 'v1' });
       prisma.invoice.count.mockResolvedValue(0);
       prisma.appointment.count.mockResolvedValue(0);
+      prisma.repairOrder.count.mockResolvedValue(0);
+      prisma.inspection.count.mockResolvedValue(0);
       vehicleRepository.delete.mockResolvedValue({});
 
       const result = await service.remove('v1', 'user-1', 'ADMIN');

--- a/server/src/vehicles/vehicles.service.ts
+++ b/server/src/vehicles/vehicles.service.ts
@@ -223,16 +223,22 @@ export class VehiclesService {
       throw new ForbiddenException('Only administrators can delete vehicles');
     }
 
-    // Check for existing invoices or appointments
-    const hasInvoices = await this.prisma.invoice.count({
-      where: { vehicleId: id },
-    });
+    // Block deletion when the vehicle has any service history so it can't be
+    // orphaned: invoices, appointments, repair orders, or inspections.
+    const [hasInvoices, hasAppointments, hasRepairOrders, hasInspections] =
+      await Promise.all([
+        this.prisma.invoice.count({ where: { vehicleId: id } }),
+        this.prisma.appointment.count({ where: { vehicleId: id } }),
+        this.prisma.repairOrder.count({ where: { vehicleId: id } }),
+        this.prisma.inspection.count({ where: { vehicleId: id } }),
+      ]);
 
-    const hasAppointments = await this.prisma.appointment.count({
-      where: { vehicleId: id },
-    });
-
-    if (hasInvoices > 0 || hasAppointments > 0) {
+    if (
+      hasInvoices > 0 ||
+      hasAppointments > 0 ||
+      hasRepairOrders > 0 ||
+      hasInspections > 0
+    ) {
       throw new BadRequestException(
         'Cannot delete vehicle with existing service history. Please contact an administrator.'
       );


### PR DESCRIPTION
Implements **GA-22**. Stacked on **GA-21** (#69) — base is the GA-21 branch so this diff shows only GA-22's changes. Retarget to `main` once #69 merges.

## Summary
Adds inline add / edit / delete of a customer's vehicles directly in the customer add/edit experience.

## Changes
- **`CustomerVehiclesSection`** (new): lists the customer's vehicles with full details (engine type, mileage, plate, VIN) and provides Add / Edit / Delete.
- **`AddVehicleDialog`**: extended with an **edit mode** (`vehicle` prop) — prefills and updates an existing vehicle — reused as the single shared form for add and edit.
- Embedded the section in **`CustomerDialog`** and the **`CustomerForm`** page. Shown in edit mode; for a brand-new customer a hint prompts saving first (the "save customer first" approach).
- **Delete is admin-only in the UI** (hidden for non-admins) and uses the custom confirmation dialog; the server-side "existing service history" block is surfaced via ErrorContext.
- **Backend guard extended**: vehicle deletion now also blocks on **repair orders** and **inspections** (previously only invoices/appointments). Added unit tests.

## Acceptance criteria
- [x] Customer add/edit shows a Vehicles section with full details incl. VIN.
- [x] Add a vehicle from the customer screen (VIN optional, decode works).
- [x] Edit an existing vehicle from the customer screen.
- [x] Delete (admin) with custom confirmation; blocked with a clear message when service history exists.
- [x] Delete hidden/disabled for non-admin roles.
- [x] Deletion guard covers repair orders and inspections.

## Notes
- New-customer flow uses **save-first**, then enables vehicle management (the open question in the ticket).
- Reuses existing `/vehicles` endpoints; vehicles stay managed via `VehicleService` (not nested in the customer DTO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)