### PR TITLE
feat(GA-35): reusable NumberInput that supports empty value (no forced 0)

### DIFF
--- a/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
+++ b/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
@@ -586,7 +586,10 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
                 setFormData((prev) => ({ ...prev, serviceType }))
               }
               onDurationChange={(duration) =>
-                setFormData((prev) => ({ ...prev, duration }))
+                setFormData((prev) => ({
+                  ...prev,
+                  duration: (duration ?? '') as unknown as number,
+                }))
               }
             />
 

--- a/apps/webApp/src/app/components/appointments/PaymentDialog.tsx
+++ b/apps/webApp/src/app/components/appointments/PaymentDialog.tsx
@@ -42,6 +42,7 @@ import {
   Person as PersonIcon,
 } from '@mui/icons-material';
 import { ServiceAmountInput } from './ServiceAmountInput';
+import { NumberInput } from '../common';
 import { AppointmentSquarePaymentForm } from './AppointmentSquarePaymentForm';
 import { appointmentService } from '../../requests/appointment.requests';
 import { userService, User } from '../../requests/user.requests';
@@ -90,13 +91,29 @@ interface PaymentDialogProps {
 }
 
 // Payment method options
-type PaymentMethodType = 'CASH' | 'E_TRANSFER' | 'SQUARE_ONLINE' | 'SQUARE_DEVICE';
+type PaymentMethodType =
+  | 'CASH'
+  | 'E_TRANSFER'
+  | 'SQUARE_ONLINE'
+  | 'SQUARE_DEVICE';
 
-const PAYMENT_METHODS: { value: PaymentMethodType; label: string; icon: React.ReactNode }[] = [
+const PAYMENT_METHODS: {
+  value: PaymentMethodType;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
   { value: 'CASH', label: 'Cash Payment', icon: <MoneyIcon /> },
   { value: 'E_TRANSFER', label: 'E-Transfer', icon: <ReceiptIcon /> },
-  { value: 'SQUARE_ONLINE', label: 'Pay with Square (Online)', icon: <CreditCardIcon /> },
-  { value: 'SQUARE_DEVICE', label: 'Square Device (Terminal)', icon: <PointOfSaleIcon /> },
+  {
+    value: 'SQUARE_ONLINE',
+    label: 'Pay with Square (Online)',
+    icon: <CreditCardIcon />,
+  },
+  {
+    value: 'SQUARE_DEVICE',
+    label: 'Square Device (Terminal)',
+    icon: <PointOfSaleIcon />,
+  },
 ];
 
 export const PaymentDialog: React.FC<PaymentDialogProps> = ({
@@ -127,8 +144,12 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
   const [squareDeviceAmount, setSquareDeviceAmount] = useState(0);
   const [squareDeviceTip, setSquareDeviceTip] = useState(0);
   const [squareDeviceProcessing, setSquareDeviceProcessing] = useState(false);
-  const [squareDeviceError, setSquareDeviceError] = useState<string | null>(null);
-  const [squareDeviceCardType, setSquareDeviceCardType] = useState<'CREDIT_CARD' | 'DEBIT_CARD'>('CREDIT_CARD');
+  const [squareDeviceError, setSquareDeviceError] = useState<string | null>(
+    null
+  );
+  const [squareDeviceCardType, setSquareDeviceCardType] = useState<
+    'CREDIT_CARD' | 'DEBIT_CARD'
+  >('CREDIT_CARD');
 
   // Manual payment state
   const [payments, setPayments] = useState<PaymentEntry[]>(
@@ -142,7 +163,8 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
 
   // "Completed by" multi-select state for auto-creating payroll jobs
   const [employees, setEmployees] = useState<User[]>([]);
-  const [selectedCompletionEmployees, setSelectedCompletionEmployees] = useState<User[]>([]);
+  const [selectedCompletionEmployees, setSelectedCompletionEmployees] =
+    useState<User[]>([]);
   const [payoutRules, setPayoutRules] = useState<PayoutRule[]>([]);
   const [hasProductSale, setHasProductSale] = useState(false);
   const [productSaleAmount, setProductSaleAmount] = useState<number>(0);
@@ -168,16 +190,16 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
             u.isActive &&
             (u.role?.name === 'STAFF' ||
               u.role?.name === 'ADMIN' ||
-              u.role?.name === 'SUPERVISOR'),
+              u.role?.name === 'SUPERVISOR')
         );
         const unique = staff.filter(
-          (u, i, arr) => i === arr.findIndex((x) => x.id === u.id),
+          (u, i, arr) => i === arr.findIndex((x) => x.id === u.id)
         );
         setEmployees(unique);
         setPayoutRules(rules);
         if (assignedEmployeeIds && assignedEmployeeIds.length > 0) {
           setSelectedCompletionEmployees(
-            unique.filter((u) => assignedEmployeeIds.includes(u.id)),
+            unique.filter((u) => assignedEmployeeIds.includes(u.id))
           );
         }
       } catch (e) {
@@ -196,8 +218,10 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
   const [squareFormOpen, setSquareFormOpen] = useState(false);
 
   const totalAmount = payments.reduce((sum, p) => sum + (p.amount || 0), 0);
-  const remainingBalance = expectedAmount - totalAmount;
-  const isPartialPayment = expectedAmount > 0 && totalAmount < expectedAmount;
+  const expectedAmountNum = Number(expectedAmount) || 0;
+  const remainingBalance = expectedAmountNum - totalAmount;
+  const isPartialPayment =
+    expectedAmountNum > 0 && totalAmount < expectedAmountNum;
   const nonCashAmount =
     paymentMethod === 'E_TRANSFER'
       ? eTransferAmount + eTransferTip
@@ -208,8 +232,8 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
       : 0;
   const paymentClearsBalance =
     paymentMethod === 'CASH'
-      ? expectedAmount > 0
-        ? totalAmount + 0.005 >= expectedAmount
+      ? expectedAmountNum > 0
+        ? totalAmount + 0.005 >= expectedAmountNum
         : totalAmount > 0
       : nonCashAmount > 0;
 
@@ -246,7 +270,9 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
   })();
 
   // Handle payment method change - reset amounts when switching
-  const handlePaymentMethodChange = (event: SelectChangeEvent<PaymentMethodType>) => {
+  const handlePaymentMethodChange = (
+    event: SelectChangeEvent<PaymentMethodType>
+  ) => {
     const newMethod = event.target.value as PaymentMethodType;
     setPaymentMethod(newMethod);
 
@@ -300,7 +326,9 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
           : undefined,
       productSaleAmount: productAmount > 0 ? productAmount : undefined,
       productSaleItems:
-        hasProductSale && productSaleItems.length > 0 ? productSaleItems : undefined,
+        hasProductSale && productSaleItems.length > 0
+          ? productSaleItems
+          : undefined,
     };
   };
 
@@ -319,7 +347,7 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
         appointmentId,
         eTransferAmount,
         eTransferTip > 0 ? eTransferTip : undefined,
-        buildCompletionExtras(),
+        buildCompletionExtras()
       );
       // Backend already created invoice + updated appointment to COMPLETED
       // Just close dialog and refresh data (don't trigger another status update)
@@ -329,8 +357,8 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
       console.error('E-Transfer invoice creation failed:', err);
       setETransferError(
         err.response?.data?.message ||
-        err.message ||
-        'Failed to create invoice. Please try again.'
+          err.message ||
+          'Failed to create invoice. Please try again.'
       );
     } finally {
       setETransferProcessing(false);
@@ -353,7 +381,7 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
         squareDeviceAmount,
         squareDeviceTip > 0 ? squareDeviceTip : undefined,
         squareDeviceCardType,
-        buildCompletionExtras(),
+        buildCompletionExtras()
       );
       // Backend already created invoice + updated appointment to COMPLETED
       // Just close dialog and refresh data (don't trigger another status update)
@@ -363,8 +391,8 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
       console.error('Square Device invoice creation failed:', err);
       setSquareDeviceError(
         err.response?.data?.message ||
-        err.message ||
-        'Failed to create invoice. Please try again.'
+          err.message ||
+          'Failed to create invoice. Please try again.'
       );
     } finally {
       setSquareDeviceProcessing(false);
@@ -406,14 +434,13 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
   const handlePaymentChange = (
     id: string,
     field: 'method' | 'amount',
-    value: string | number
+    value: string | number | undefined
   ) => {
     setPayments(
       payments.map((p) => {
         if (p.id === id) {
           if (field === 'amount') {
-            const numValue = typeof value === 'string' ? parseFloat(value) : value;
-            return { ...p, amount: isNaN(numValue) ? 0 : numValue };
+            return { ...p, amount: (value ?? '') as unknown as number };
           }
           return { ...p, method: String(value) };
         }
@@ -430,7 +457,11 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
     let hasError = false;
 
     payments.forEach((payment) => {
-      if (payment.amount === null || payment.amount === undefined || payment.amount < 0) {
+      if (
+        payment.amount === null ||
+        payment.amount === undefined ||
+        payment.amount < 0
+      ) {
         newErrors[payment.id] = 'Amount cannot be negative';
         hasError = true;
       }
@@ -449,12 +480,15 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
 
     // Submit
     const shouldSendCompletion = completionEnabled && paymentClearsBalance;
-    const productAmount = shouldSendCompletion && hasProductSale ? Math.max(0, productSaleAmount) : 0;
+    const productAmount =
+      shouldSendCompletion && hasProductSale
+        ? Math.max(0, Number(productSaleAmount) || 0)
+        : 0;
     const paymentData: PaymentData = {
       totalAmount,
       payments,
       paymentNotes,
-      expectedAmount: expectedAmount > 0 ? expectedAmount : undefined,
+      expectedAmount: expectedAmountNum > 0 ? expectedAmountNum : undefined,
       completionEmployeeIds:
         shouldSendCompletion && selectedCompletionEmployees.length > 0
           ? selectedCompletionEmployees.map((e) => e.id)
@@ -496,10 +530,18 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <MoneyIcon sx={{ fontSize: isMobile ? 20 : 24 }} />
-          <Typography variant={isMobile ? 'subtitle1' : 'h6'} component="div" sx={{ fontWeight: 600 }}>
+          <Typography
+            variant={isMobile ? 'subtitle1' : 'h6'}
+            component="div"
+            sx={{ fontWeight: 600 }}
+          >
             {isEditMode
-              ? isMobile ? 'Edit Payment' : 'Edit Payment Details'
-              : isMobile ? 'Payment Details' : 'Complete Appointment - Payment Details'}
+              ? isMobile
+                ? 'Edit Payment'
+                : 'Edit Payment Details'
+              : isMobile
+              ? 'Payment Details'
+              : 'Complete Appointment - Payment Details'}
           </Typography>
         </Box>
         <IconButton onClick={handleClose} size="small" sx={{ color: 'white' }}>
@@ -532,7 +574,16 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
         {/* Completed By — Auto-creates payroll jobs when this payment clears the balance */}
         {completionEnabled && paymentClearsBalance && (
           <Box sx={{ mb: 3 }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Typography
+              variant="subtitle2"
+              sx={{
+                fontWeight: 600,
+                mb: 1,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+              }}
+            >
               <PersonIcon fontSize="small" /> Completed By
             </Typography>
             <Autocomplete
@@ -540,27 +591,44 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
               options={employees}
               value={selectedCompletionEmployees}
               onChange={(_e, value) => setSelectedCompletionEmployees(value)}
-              getOptionLabel={(option) => `${option.firstName || ''} ${option.lastName || ''}`.trim() || option.email}
+              getOptionLabel={(option) =>
+                `${option.firstName || ''} ${option.lastName || ''}`.trim() ||
+                option.email
+              }
               isOptionEqualToValue={(opt, val) => opt.id === val.id}
               renderOption={(props, option) => {
                 const { key: _key, ...rest } = props as any;
                 return (
                   <li key={option.id} {...rest}>
-                    {`${option.firstName || ''} ${option.lastName || ''}`.trim() || option.email}
+                    {`${option.firstName || ''} ${
+                      option.lastName || ''
+                    }`.trim() || option.email}
                   </li>
                 );
               }}
               renderInput={(params) => (
                 <TextField
                   {...params}
-                  placeholder={selectedCompletionEmployees.length === 0 ? 'Select employee(s) who completed the job' : ''}
+                  placeholder={
+                    selectedCompletionEmployees.length === 0
+                      ? 'Select employee(s) who completed the job'
+                      : ''
+                  }
                   size="small"
                 />
               )}
             />
 
             {/* Product Sale */}
-            <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap' }}>
+            <Box
+              sx={{
+                mt: 1.5,
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 1.5,
+                flexWrap: 'wrap',
+              }}
+            >
               <FormControlLabel
                 control={
                   <Checkbox
@@ -574,13 +642,19 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                     }}
                   />
                 }
-                label={<Typography variant="body2">Includes a product sale</Typography>}
+                label={
+                  <Typography variant="body2">
+                    Includes a product sale
+                  </Typography>
+                }
                 sx={{ mr: 0 }}
               />
               {hasProductSale && (
                 <>
                   <FormControl size="small" sx={{ minWidth: 220, flex: 1 }}>
-                    <InputLabel id="product-sale-items-label">Products Sold</InputLabel>
+                    <InputLabel id="product-sale-items-label">
+                      Products Sold
+                    </InputLabel>
                     <Select
                       labelId="product-sale-items-label"
                       multiple
@@ -589,17 +663,20 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                         setProductSaleItems(
                           typeof e.target.value === 'string'
                             ? e.target.value.split(',')
-                            : (e.target.value as string[]),
+                            : (e.target.value as string[])
                         )
                       }
                       input={<OutlinedInput label="Products Sold" />}
                       renderValue={(selected) => (
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                        <Box
+                          sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}
+                        >
                           {(selected as string[]).map((value) => (
                             <Chip
                               key={value}
                               label={
-                                PRODUCT_OPTIONS.find((p) => p.value === value)?.label ?? value
+                                PRODUCT_OPTIONS.find((p) => p.value === value)
+                                  ?.label ?? value
                               }
                               size="small"
                             />
@@ -609,58 +686,111 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                     >
                       {PRODUCT_OPTIONS.map((option) => (
                         <MenuItem key={option.value} value={option.value}>
-                          <Checkbox checked={productSaleItems.includes(option.value)} />
-                          <Typography variant="body2">{option.label}</Typography>
+                          <Checkbox
+                            checked={productSaleItems.includes(option.value)}
+                          />
+                          <Typography variant="body2">
+                            {option.label}
+                          </Typography>
                         </MenuItem>
                       ))}
                     </Select>
                   </FormControl>
-                  <TextField
-                    type="number"
+                  <NumberInput
+                    allowDecimals
+                    min={0}
                     size="small"
                     label="Product Sale Amount"
                     value={productSaleAmount || ''}
-                    onChange={(e) => setProductSaleAmount(parseFloat(e.target.value) || 0)}
-                    InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+                    onChange={(v) =>
+                      setProductSaleAmount((v ?? '') as unknown as number)
+                    }
+                    InputProps={{
+                      startAdornment: (
+                        <InputAdornment position="start">$</InputAdornment>
+                      ),
+                    }}
                     sx={{ width: 200 }}
-                    helperText={`Service portion: $${Math.max(0, payoutBaseAmount - productSaleAmount).toFixed(2)}`}
+                    helperText={`Service portion: $${Math.max(
+                      0,
+                      payoutBaseAmount - (Number(productSaleAmount) || 0)
+                    ).toFixed(2)}`}
                   />
                 </>
               )}
             </Box>
 
-            {selectedCompletionEmployees.length > 0 && (payoutBaseAmount > 0 || payoutTipAmount > 0) && (() => {
-              const productAmount = hasProductSale ? Math.max(0, productSaleAmount) : 0;
-              const svcAmount = Math.max(0, payoutBaseAmount - productAmount);
-              const rulePayout = svcAmount > 0 ? calculatePayoutPreview(svcAmount, payoutRules) : 0;
-              const totalPayout = rulePayout + payoutTipAmount;
-              if (totalPayout <= 0) {
+            {selectedCompletionEmployees.length > 0 &&
+              (payoutBaseAmount > 0 || payoutTipAmount > 0) &&
+              (() => {
+                const productAmount = hasProductSale
+                  ? Math.max(0, productSaleAmount)
+                  : 0;
+                const svcAmount = Math.max(0, payoutBaseAmount - productAmount);
+                const rulePayout =
+                  svcAmount > 0
+                    ? calculatePayoutPreview(svcAmount, payoutRules)
+                    : 0;
+                const totalPayout = rulePayout + payoutTipAmount;
+                if (totalPayout <= 0) {
+                  return (
+                    <Box
+                      sx={{
+                        mt: 1,
+                        p: 1.5,
+                        bgcolor: 'warning.50',
+                        borderRadius: 1,
+                        border: 1,
+                        borderColor: 'warning.light',
+                      }}
+                    >
+                      <Typography variant="caption" color="text.secondary">
+                        No payout amount — no payroll job will be created.
+                      </Typography>
+                    </Box>
+                  );
+                }
+                const perEmployee =
+                  Math.round(
+                    (totalPayout / selectedCompletionEmployees.length) * 100
+                  ) / 100;
+                const exact = payoutRules.find(
+                  (r) =>
+                    r.isActive && Number(r.triggerAmount) === Number(svcAmount)
+                );
                 return (
-                  <Box sx={{ mt: 1, p: 1.5, bgcolor: 'warning.50', borderRadius: 1, border: 1, borderColor: 'warning.light' }}>
+                  <Box
+                    sx={{
+                      mt: 1,
+                      p: 1.5,
+                      bgcolor: 'success.50',
+                      borderRadius: 1,
+                      border: 1,
+                      borderColor: 'success.light',
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      display="block"
+                    >
+                      Payroll preview: ${rulePayout.toFixed(2)} (
+                      {exact ? 'lookup rule' : '30% default'} on $
+                      {svcAmount.toFixed(2)} service)
+                      {payoutTipAmount > 0
+                        ? ` + $${payoutTipAmount.toFixed(2)} tip (100%)`
+                        : ''}
+                    </Typography>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      ${totalPayout.toFixed(2)} total · $
+                      {perEmployee.toFixed(2)} per employee
+                    </Typography>
                     <Typography variant="caption" color="text.secondary">
-                      No payout amount — no payroll job will be created.
+                      A pending job will be created for each selected employee.
                     </Typography>
                   </Box>
                 );
-              }
-              const perEmployee = Math.round((totalPayout / selectedCompletionEmployees.length) * 100) / 100;
-              const exact = payoutRules.find((r) => r.isActive && Number(r.triggerAmount) === Number(svcAmount));
-              return (
-                <Box sx={{ mt: 1, p: 1.5, bgcolor: 'success.50', borderRadius: 1, border: 1, borderColor: 'success.light' }}>
-                  <Typography variant="caption" color="text.secondary" display="block">
-                    Payroll preview: ${rulePayout.toFixed(2)} ({exact ? 'lookup rule' : '30% default'} on $
-                    {svcAmount.toFixed(2)} service)
-                    {payoutTipAmount > 0 ? ` + $${payoutTipAmount.toFixed(2)} tip (100%)` : ''}
-                  </Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    ${totalPayout.toFixed(2)} total · ${perEmployee.toFixed(2)} per employee
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    A pending job will be created for each selected employee.
-                  </Typography>
-                </Box>
-              );
-            })()}
+              })()}
           </Box>
         )}
 
@@ -668,23 +798,19 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
         {paymentMethod === 'CASH' && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             {/* Expected Amount Field */}
-            <TextField
+            <NumberInput
               label="Expected Amount (Optional)"
-              type="number"
+              allowDecimals
+              min={0}
               value={expectedAmount || ''}
-              onChange={(e) => setExpectedAmount(e.target.value === '' ? 0 : parseFloat(e.target.value) || 0)}
-              onKeyDown={(e) => {
-                if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                  e.preventDefault();
-                }
-              }}
+              onChange={(v) =>
+                setExpectedAmount((v ?? '') as unknown as number)
+              }
               fullWidth
               InputProps={{
-                startAdornment: <InputAdornment position="start">$</InputAdornment>,
-              }}
-              inputProps={{
-                min: 0,
-                step: 0.01,
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
               }}
               helperText="Enter the expected total amount to track partial payments"
               autoComplete="off"
@@ -729,10 +855,18 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                       borderColor: 'divider',
                     }}
                   >
-                    <Typography variant="body2" color="warning.dark" fontWeight="medium">
+                    <Typography
+                      variant="body2"
+                      color="warning.dark"
+                      fontWeight="medium"
+                    >
                       Remaining Balance Owed
                     </Typography>
-                    <Typography variant="h5" fontWeight="bold" color="warning.dark">
+                    <Typography
+                      variant="h5"
+                      fontWeight="bold"
+                      color="warning.dark"
+                    >
                       ${remainingBalance.toFixed(2)}
                     </Typography>
                   </Box>
@@ -757,7 +891,10 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                   gap: isMobile ? 1 : 0,
                 }}
               >
-                <Typography variant={isMobile ? 'subtitle1' : 'h6'} sx={{ fontWeight: 600 }}>
+                <Typography
+                  variant={isMobile ? 'subtitle1' : 'h6'}
+                  sx={{ fontWeight: 600 }}
+                >
                   Cash Payment Entries
                 </Typography>
                 <Button
@@ -779,10 +916,17 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                     variant="outlined"
                     sx={{
                       borderRadius: 2,
-                      borderColor: errors[payment.id] ? 'error.main' : 'divider',
+                      borderColor: errors[payment.id]
+                        ? 'error.main'
+                        : 'divider',
                     }}
                   >
-                    <CardContent sx={{ p: isMobile ? 1.5 : 2, '&:last-child': { pb: isMobile ? 1.5 : 2 } }}>
+                    <CardContent
+                      sx={{
+                        p: isMobile ? 1.5 : 2,
+                        '&:last-child': { pb: isMobile ? 1.5 : 2 },
+                      }}
+                    >
                       <Box
                         sx={{
                           display: 'flex',
@@ -791,7 +935,14 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                           gap: isMobile ? 1.5 : 2,
                         }}
                       >
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            flex: 1,
+                          }}
+                        >
                           <Chip
                             label={`#${index + 1}`}
                             size="small"
@@ -818,18 +969,14 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                         </Box>
 
                         {/* Amount */}
-                        <TextField
+                        <NumberInput
                           label="Cash Amount"
-                          type="number"
+                          allowDecimals
+                          min={0}
                           value={payment.amount || ''}
-                          onChange={(e) =>
-                            handlePaymentChange(payment.id, 'amount', e.target.value)
+                          onChange={(v) =>
+                            handlePaymentChange(payment.id, 'amount', v)
                           }
-                          onKeyDown={(e) => {
-                            if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                              e.preventDefault();
-                            }
-                          }}
                           error={!!errors[payment.id]}
                           helperText={errors[payment.id]}
                           size="small"
@@ -837,12 +984,10 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                           fullWidth={isMobile}
                           InputProps={{
                             startAdornment: (
-                              <InputAdornment position="start">$</InputAdornment>
+                              <InputAdornment position="start">
+                                $
+                              </InputAdornment>
                             ),
-                          }}
-                          inputProps={{
-                            min: 0,
-                            step: 0.01,
                           }}
                           autoComplete="off"
                         />
@@ -888,7 +1033,9 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                 E-Transfer with Invoice
               </Typography>
               <Typography variant="caption">
-                Enter the service amount to calculate taxes (GST + PST). An invoice will be automatically created and marked as PAID, and the appointment will be marked as completed.
+                Enter the service amount to calculate taxes (GST + PST). An
+                invoice will be automatically created and marked as PAID, and
+                the appointment will be marked as completed.
               </Typography>
             </Alert>
 
@@ -903,11 +1050,25 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                 }}
               >
                 <CardContent sx={{ py: 1.5 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Typography variant="body2" color="info.dark" fontWeight="medium">
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      color="info.dark"
+                      fontWeight="medium"
+                    >
                       Expected Amount (Reference)
                     </Typography>
-                    <Typography variant="h6" fontWeight="bold" color="info.dark">
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="info.dark"
+                    >
                       ${defaultExpectedAmount.toFixed(2)}
                     </Typography>
                   </Box>
@@ -925,9 +1086,13 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
             {/* Service Amount Input with Tax Calculation */}
             <ServiceAmountInput
               value={eTransferAmount}
-              onChange={setETransferAmount}
+              onChange={(v) =>
+                setETransferAmount((v ?? '') as unknown as number)
+              }
               tipAmount={eTransferTip}
-              onTipChange={setETransferTip}
+              onTipChange={(v) =>
+                setETransferTip((v ?? '') as unknown as number)
+              }
               showTip={true}
               disabled={eTransferProcessing}
             />
@@ -965,7 +1130,11 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                 Pay with Card (Square)
               </Typography>
               <Typography variant="caption">
-                Enter the service amount and click "Pay with Card" to open a secure payment form. The customer can pay with credit card, debit card, Apple Pay, or Google Pay. Once payment is successful, the appointment will be automatically marked as completed and an invoice will be created.
+                Enter the service amount and click "Pay with Card" to open a
+                secure payment form. The customer can pay with credit card,
+                debit card, Apple Pay, or Google Pay. Once payment is
+                successful, the appointment will be automatically marked as
+                completed and an invoice will be created.
               </Typography>
             </Alert>
 
@@ -980,11 +1149,25 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                 }}
               >
                 <CardContent sx={{ py: 1.5 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Typography variant="body2" color="info.dark" fontWeight="medium">
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      color="info.dark"
+                      fontWeight="medium"
+                    >
                       Expected Amount (Reference)
                     </Typography>
-                    <Typography variant="h6" fontWeight="bold" color="info.dark">
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="info.dark"
+                    >
                       ${defaultExpectedAmount.toFixed(2)}
                     </Typography>
                   </Box>
@@ -995,9 +1178,11 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
             {/* Service Amount Input with Tax Calculation */}
             <ServiceAmountInput
               value={serviceAmount}
-              onChange={setServiceAmount}
+              onChange={(v) => setServiceAmount((v ?? '') as unknown as number)}
               tipAmount={squareOnlineTip}
-              onTipChange={setSquareOnlineTip}
+              onTipChange={(v) =>
+                setSquareOnlineTip((v ?? '') as unknown as number)
+              }
               showTip={true}
               disabled={false}
             />
@@ -1016,7 +1201,8 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                     Customer enters card details (never stored on our servers)
                   </Typography>
                   <Typography component="li" variant="body2" sx={{ mb: 0.5 }}>
-                    Invoice is automatically created with tip (if any) - no tax on tips
+                    Invoice is automatically created with tip (if any) - no tax
+                    on tips
                   </Typography>
                   <Typography component="li" variant="body2">
                     Appointment is marked as COMPLETED
@@ -1035,7 +1221,10 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                 Square Device Payment
               </Typography>
               <Typography variant="caption">
-                Use this option when the customer has already paid via the physical Square terminal device. Enter the service amount to calculate taxes (GST + PST). An invoice will be automatically created and marked as PAID with Credit Card payment method.
+                Use this option when the customer has already paid via the
+                physical Square terminal device. Enter the service amount to
+                calculate taxes (GST + PST). An invoice will be automatically
+                created and marked as PAID with Credit Card payment method.
               </Typography>
             </Alert>
 
@@ -1050,11 +1239,25 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                 }}
               >
                 <CardContent sx={{ py: 1.5 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                    <Typography variant="body2" color="info.dark" fontWeight="medium">
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      color="info.dark"
+                      fontWeight="medium"
+                    >
                       Expected Amount (Reference)
                     </Typography>
-                    <Typography variant="h6" fontWeight="bold" color="info.dark">
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="info.dark"
+                    >
                       ${defaultExpectedAmount.toFixed(2)}
                     </Typography>
                   </Box>
@@ -1064,20 +1267,30 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
 
             {/* Error Message */}
             {squareDeviceError && (
-              <Alert severity="error" onClose={() => setSquareDeviceError(null)}>
+              <Alert
+                severity="error"
+                onClose={() => setSquareDeviceError(null)}
+              >
                 {squareDeviceError}
               </Alert>
             )}
 
             {/* Card Type Selection */}
             <FormControl component="fieldset" sx={{ mb: 1 }}>
-              <FormLabel component="legend" sx={{ fontSize: '0.875rem', fontWeight: 500 }}>
+              <FormLabel
+                component="legend"
+                sx={{ fontSize: '0.875rem', fontWeight: 500 }}
+              >
                 Card Type
               </FormLabel>
               <RadioGroup
                 row
                 value={squareDeviceCardType}
-                onChange={(e) => setSquareDeviceCardType(e.target.value as 'CREDIT_CARD' | 'DEBIT_CARD')}
+                onChange={(e) =>
+                  setSquareDeviceCardType(
+                    e.target.value as 'CREDIT_CARD' | 'DEBIT_CARD'
+                  )
+                }
               >
                 <FormControlLabel
                   value="CREDIT_CARD"
@@ -1097,9 +1310,13 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
             {/* Service Amount Input with Tax Calculation */}
             <ServiceAmountInput
               value={squareDeviceAmount}
-              onChange={setSquareDeviceAmount}
+              onChange={(v) =>
+                setSquareDeviceAmount((v ?? '') as unknown as number)
+              }
               tipAmount={squareDeviceTip}
-              onTipChange={setSquareDeviceTip}
+              onTipChange={(v) =>
+                setSquareDeviceTip((v ?? '') as unknown as number)
+              }
               showTip={true}
               disabled={squareDeviceProcessing}
             />
@@ -1118,7 +1335,11 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
                     Tip (if any) is added as a separate line item (no tax)
                   </Typography>
                   <Typography component="li" variant="body2" sx={{ mb: 0.5 }}>
-                    Invoice is marked as PAID with {squareDeviceCardType === 'CREDIT_CARD' ? 'Credit Card' : 'Debit Card'} payment method
+                    Invoice is marked as PAID with{' '}
+                    {squareDeviceCardType === 'CREDIT_CARD'
+                      ? 'Credit Card'
+                      : 'Debit Card'}{' '}
+                    payment method
                   </Typography>
                   <Typography component="li" variant="body2">
                     Appointment is marked as COMPLETED
@@ -1168,20 +1389,32 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
             onClick={handleETransferSubmit}
             variant={eTransferAmount <= 0 ? 'outlined' : 'contained'}
             color="warning"
-            startIcon={eTransferProcessing ? <CircularProgress size={20} color="inherit" /> : <ReceiptIcon />}
+            startIcon={
+              eTransferProcessing ? (
+                <CircularProgress size={20} color="inherit" />
+              ) : (
+                <ReceiptIcon />
+              )
+            }
             disabled={eTransferAmount <= 0 || eTransferProcessing}
             fullWidth={isMobile}
             size={isMobile ? 'large' : 'medium'}
-            sx={eTransferAmount <= 0 ? {
-              borderColor: 'grey.400',
-              color: 'grey.500',
-              '&.Mui-disabled': {
-                borderColor: 'grey.400',
-                color: 'grey.500',
-              },
-            } : {}}
+            sx={
+              eTransferAmount <= 0
+                ? {
+                    borderColor: 'grey.400',
+                    color: 'grey.500',
+                    '&.Mui-disabled': {
+                      borderColor: 'grey.400',
+                      color: 'grey.500',
+                    },
+                  }
+                : {}
+            }
           >
-            {eTransferProcessing ? 'Creating Invoice...' : 'Create Invoice & Complete'}
+            {eTransferProcessing
+              ? 'Creating Invoice...'
+              : 'Create Invoice & Complete'}
           </Button>
         )}
 
@@ -1195,14 +1428,18 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
             disabled={serviceAmount <= 0}
             fullWidth={isMobile}
             size={isMobile ? 'large' : 'medium'}
-            sx={serviceAmount <= 0 ? {
-              borderColor: 'grey.400',
-              color: 'grey.500',
-              '&.Mui-disabled': {
-                borderColor: 'grey.400',
-                color: 'grey.500',
-              },
-            } : {}}
+            sx={
+              serviceAmount <= 0
+                ? {
+                    borderColor: 'grey.400',
+                    color: 'grey.500',
+                    '&.Mui-disabled': {
+                      borderColor: 'grey.400',
+                      color: 'grey.500',
+                    },
+                  }
+                : {}
+            }
           >
             Pay with Card
           </Button>
@@ -1214,20 +1451,32 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
             onClick={handleSquareDeviceSubmit}
             variant={squareDeviceAmount <= 0 ? 'outlined' : 'contained'}
             color="secondary"
-            startIcon={squareDeviceProcessing ? <CircularProgress size={20} color="inherit" /> : <PointOfSaleIcon />}
+            startIcon={
+              squareDeviceProcessing ? (
+                <CircularProgress size={20} color="inherit" />
+              ) : (
+                <PointOfSaleIcon />
+              )
+            }
             disabled={squareDeviceAmount <= 0 || squareDeviceProcessing}
             fullWidth={isMobile}
             size={isMobile ? 'large' : 'medium'}
-            sx={squareDeviceAmount <= 0 ? {
-              borderColor: 'grey.400',
-              color: 'grey.500',
-              '&.Mui-disabled': {
-                borderColor: 'grey.400',
-                color: 'grey.500',
-              },
-            } : {}}
+            sx={
+              squareDeviceAmount <= 0
+                ? {
+                    borderColor: 'grey.400',
+                    color: 'grey.500',
+                    '&.Mui-disabled': {
+                      borderColor: 'grey.400',
+                      color: 'grey.500',
+                    },
+                  }
+                : {}
+            }
           >
-            {squareDeviceProcessing ? 'Creating Invoice...' : 'Create Invoice & Complete'}
+            {squareDeviceProcessing
+              ? 'Creating Invoice...'
+              : 'Create Invoice & Complete'}
           </Button>
         )}
       </DialogActions>

--- a/apps/webApp/src/app/components/appointments/ServiceAmountInput.tsx
+++ b/apps/webApp/src/app/components/appointments/ServiceAmountInput.tsx
@@ -1,19 +1,13 @@
 import React, { useMemo } from 'react';
-import {
-  Box,
-  TextField,
-  Typography,
-  Divider,
-  Paper,
-  InputAdornment,
-} from '@mui/material';
+import { Box, Typography, Divider, Paper, InputAdornment } from '@mui/material';
 import { AttachMoney as MoneyIcon } from '@mui/icons-material';
+import { NumberInput } from '../common';
 
 interface ServiceAmountInputProps {
   value: number;
-  onChange: (value: number) => void;
+  onChange: (value: number | undefined) => void;
   tipAmount?: number;
-  onTipChange?: (value: number) => void;
+  onTipChange?: (value: number | undefined) => void;
   showTip?: boolean;
   error?: string;
   disabled?: boolean;
@@ -56,56 +50,30 @@ export const ServiceAmountInput: React.FC<ServiceAmountInputProps> = ({
     };
   }, [value, tipAmount]);
 
-  const handleAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const inputValue = event.target.value;
-
-    // Allow empty string
-    if (inputValue === '') {
-      onChange(0);
-      return;
-    }
-
-    // Parse as float and validate
-    const numValue = parseFloat(inputValue);
-    if (!isNaN(numValue) && numValue >= 0) {
-      onChange(numValue);
-    }
+  const handleAmountChange = (v: number | undefined) => {
+    onChange(v);
   };
 
-  const handleTipChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTipChange = (v: number | undefined) => {
     if (!onTipChange) return;
-
-    const inputValue = event.target.value;
-
-    // Allow empty string
-    if (inputValue === '') {
-      onTipChange(0);
-      return;
-    }
-
-    // Parse as float and validate
-    const numValue = parseFloat(inputValue);
-    if (!isNaN(numValue) && numValue >= 0) {
-      onTipChange(numValue);
-    }
+    onTipChange(v);
   };
 
   return (
     <Box>
       {/* Service Amount Input */}
-      <TextField
+      <NumberInput
         fullWidth
         label="Service Amount (before taxes)"
-        type="number"
+        allowDecimals
+        min={0}
         value={value || ''}
         onChange={handleAmountChange}
-        onKeyDown={(e) => {
-          if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-            e.preventDefault();
-          }
-        }}
         error={!!error}
-        helperText={error || 'Enter the base service amount (GST and PST will be calculated automatically)'}
+        helperText={
+          error ||
+          'Enter the base service amount (GST and PST will be calculated automatically)'
+        }
         disabled={disabled}
         InputProps={{
           startAdornment: (
@@ -114,27 +82,19 @@ export const ServiceAmountInput: React.FC<ServiceAmountInputProps> = ({
             </InputAdornment>
           ),
         }}
-        inputProps={{
-          min: 0,
-          step: 0.01,
-        }}
         autoComplete="off"
         sx={{ mb: 2 }}
       />
 
       {/* Tip Amount Input - Optional */}
       {showTip && onTipChange && (
-        <TextField
+        <NumberInput
           fullWidth
           label="Tips (Optional)"
-          type="number"
+          allowDecimals
+          min={0}
           value={tipAmount || ''}
           onChange={handleTipChange}
-          onKeyDown={(e) => {
-            if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-              e.preventDefault();
-            }
-          }}
           disabled={disabled}
           InputProps={{
             startAdornment: (
@@ -142,10 +102,6 @@ export const ServiceAmountInput: React.FC<ServiceAmountInputProps> = ({
                 <MoneyIcon color="action" />
               </InputAdornment>
             ),
-          }}
-          inputProps={{
-            min: 0,
-            step: 0.01,
           }}
           autoComplete="off"
           helperText="Tips are not subject to GST or PST"
@@ -203,7 +159,11 @@ export const ServiceAmountInput: React.FC<ServiceAmountInputProps> = ({
                 <Typography variant="body2" color="success.main">
                   Tips:
                 </Typography>
-                <Typography variant="body2" color="success.main" fontWeight={500}>
+                <Typography
+                  variant="body2"
+                  color="success.main"
+                  fontWeight={500}
+                >
                   ${taxCalculation.tip.toFixed(2)}
                 </Typography>
               </Box>

--- a/apps/webApp/src/app/components/appointments/ServiceTypeSelector.tsx
+++ b/apps/webApp/src/app/components/appointments/ServiceTypeSelector.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, TextField, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { Grid, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { NumberInput } from '../common';
 
 export const SERVICE_TYPES = [
   { value: 'TIRE_CHANGE', label: 'Tire Mount Balance', duration: 60 },
@@ -17,7 +18,7 @@ interface ServiceTypeSelectorProps {
   serviceType: string;
   duration: number;
   onServiceTypeChange: (serviceType: string) => void;
-  onDurationChange: (duration: number) => void;
+  onDurationChange: (duration: number | undefined) => void;
 }
 
 export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
@@ -56,13 +57,13 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
 
       {/* Duration */}
       <Grid size={{ xs: 12, sm: 6 }}>
-        <TextField
+        <NumberInput
           fullWidth
           label="Duration (minutes)"
-          type="number"
+          min={15}
+          max={480}
           value={duration}
-          onChange={(e) => onDurationChange(parseInt(e.target.value))}
-          inputProps={{ min: 15, max: 480, step: 15 }}
+          onChange={(v) => onDurationChange(v)}
           required
         />
       </Grid>

--- a/apps/webApp/src/app/components/common/NumberInput.tsx
+++ b/apps/webApp/src/app/components/common/NumberInput.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react';
+import { TextField, TextFieldProps } from '@mui/material';
+
+/**
+ * Reusable numeric input.
+ *
+ * Unlike a raw `<TextField type="number" />`, this component:
+ *  - Lets the field be **empty** (shows nothing, not `0`) when the user clears it
+ *    with backspace/delete. The parent receives `undefined` while empty.
+ *  - Only accepts numeric characters (optionally decimals / a negative sign).
+ *  - Shows the correct numeric keyboard on mobile via `inputMode`.
+ *  - Preserves in-progress typing such as `"12."` or `"-"` without snapping back.
+ *
+ * Value reported to the parent:
+ *  - `undefined` when the field is empty (or only `"-"` / `"."`).
+ *  - a `number` once a valid numeric value has been entered.
+ */
+export interface NumberInputProps
+  extends Omit<TextFieldProps, 'onChange' | 'value' | 'type'> {
+  /** Current value. Pass `''`/`null`/`undefined` for an empty field. */
+  value: number | string | null | undefined;
+  /** Called with the parsed number, or `undefined` when the field is empty. */
+  onChange: (value: number | undefined) => void;
+  /** Allow a decimal point (for amounts/prices). Defaults to false (integers only). */
+  allowDecimals?: boolean;
+  /** Allow a leading minus sign. Defaults to false. */
+  allowNegative?: boolean;
+  /** Maximum number of digits after the decimal point. */
+  decimalPlaces?: number;
+  /** Clamp the value to this minimum on blur. */
+  min?: number;
+  /** Clamp the value to this maximum on blur. */
+  max?: number;
+}
+
+const toDisplay = (value: number | string | null | undefined): string => {
+  if (value === null || value === undefined || value === '') return '';
+  return String(value);
+};
+
+/** Parse a sanitized display string into a number, or undefined if not yet valid. */
+const parseValue = (raw: string): number | undefined => {
+  if (raw === '' || raw === '-' || raw === '.' || raw === '-.')
+    return undefined;
+  const num = Number(raw);
+  return Number.isNaN(num) ? undefined : num;
+};
+
+export const NumberInput: React.FC<NumberInputProps> = ({
+  value,
+  onChange,
+  allowDecimals = false,
+  allowNegative = false,
+  decimalPlaces,
+  min,
+  max,
+  inputProps,
+  onBlur,
+  onFocus,
+  ...textFieldProps
+}) => {
+  const [inputValue, setInputValue] = useState<string>(toDisplay(value));
+  const [isFocused, setIsFocused] = useState(false);
+
+  // Sanitize raw keystrokes into an allowed numeric string.
+  const sanitize = (raw: string): string => {
+    let result = raw;
+
+    // Keep only digits, decimal points and (optionally) a leading minus.
+    result = result.replace(allowDecimals ? /[^0-9.-]/g : /[^0-9-]/g, '');
+
+    // Handle the negative sign: only one, only at the start.
+    if (allowNegative) {
+      const negative = result.startsWith('-');
+      result = result.replace(/-/g, '');
+      if (negative) result = `-${result}`;
+    } else {
+      result = result.replace(/-/g, '');
+    }
+
+    if (allowDecimals) {
+      // Collapse to a single decimal point.
+      const firstDot = result.indexOf('.');
+      if (firstDot !== -1) {
+        result =
+          result.slice(0, firstDot + 1) +
+          result.slice(firstDot + 1).replace(/\./g, '');
+      }
+      // Enforce decimal places limit.
+      if (decimalPlaces !== undefined && firstDot !== -1) {
+        const [intPart, decPart] = result.split('.');
+        result = `${intPart}.${decPart.slice(0, decimalPlaces)}`;
+      }
+    }
+
+    return result;
+  };
+
+  // Sync external value changes (form reset, programmatic set) without
+  // clobbering in-progress typing like "12." or "-". While the field is
+  // focused we never overwrite what the user is typing — this is what keeps a
+  // cleared field empty instead of snapping back to the parent's value.
+  useEffect(() => {
+    if (isFocused) return;
+    const propNum =
+      value === '' || value === null || value === undefined
+        ? undefined
+        : Number(value);
+    const localNum = parseValue(inputValue);
+    const sameNumber = propNum === localNum;
+    const bothEmpty =
+      propNum === undefined && localNum === undefined && inputValue === '';
+    if (!sameNumber && !bothEmpty) {
+      setInputValue(toDisplay(value));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const sanitized = sanitize(e.target.value);
+    setInputValue(sanitized);
+    onChange(parseValue(sanitized));
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    setIsFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    setIsFocused(false);
+    const parsed = parseValue(inputValue);
+    if (parsed !== undefined) {
+      let clamped = parsed;
+      if (min !== undefined && clamped < min) clamped = min;
+      if (max !== undefined && clamped > max) clamped = max;
+      if (clamped !== parsed) {
+        setInputValue(String(clamped));
+        onChange(clamped);
+      } else {
+        // Normalize the display (e.g. "12." -> "12", "01" -> "1").
+        const normalized = String(parsed);
+        if (normalized !== inputValue) setInputValue(normalized);
+      }
+    } else if (inputValue !== '') {
+      // Lingering "-" or "." with no number — clear it.
+      setInputValue('');
+      onChange(undefined);
+    }
+    onBlur?.(e);
+  };
+
+  return (
+    <TextField
+      {...textFieldProps}
+      type="text"
+      value={inputValue}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      inputProps={{
+        inputMode: allowDecimals ? 'decimal' : 'numeric',
+        ...inputProps,
+      }}
+    />
+  );
+};
+
+export default NumberInput;

--- a/apps/webApp/src/app/components/common/index.ts
+++ b/apps/webApp/src/app/components/common/index.ts
@@ -4,3 +4,6 @@ export { default as ErrorDialog } from './ErrorDialog';
 export type { ErrorDialogProps } from './ErrorDialog';
 export { default as AnalyticsCards, AnalyticsIcons } from './AnalyticsCards';
 export type { AnalyticsCardData } from './AnalyticsCards';
+export { default as NumberInput } from './NumberInput';
+export type { NumberInputProps } from './NumberInput';
+export { PhoneInput } from './PhoneInput';

--- a/apps/webApp/src/app/components/expense-invoices/ExpenseInvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/expense-invoices/ExpenseInvoiceDialog.tsx
@@ -13,7 +13,11 @@ import {
   IconButton,
   Alert,
 } from '@mui/material';
-import { CloudUpload as UploadIcon, Delete as DeleteIcon, Close as CloseIcon } from '@mui/icons-material';
+import {
+  CloudUpload as UploadIcon,
+  Delete as DeleteIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
 import { PaymentMethod } from '@gt-automotive/data';
 import {
   ExpenseInvoice,
@@ -22,6 +26,7 @@ import {
 } from '../../requests/expense-invoice.requests';
 import vendorService, { Vendor } from '../../requests/vendor.requests';
 import VendorSelect from '../vendors/VendorSelect';
+import { NumberInput } from '../common';
 
 interface ExpenseInvoiceDialogProps {
   open: boolean;
@@ -45,7 +50,12 @@ const categories: ExpenseCategory[] = [
   'SOFTWARE',
   'OTHER',
 ];
-const statuses: ExpenseInvoiceStatus[] = ['PENDING', 'PAID', 'OVERDUE', 'CANCELLED'];
+const statuses: ExpenseInvoiceStatus[] = [
+  'PENDING',
+  'PAID',
+  'OVERDUE',
+  'CANCELLED',
+];
 const paymentMethods = [
   PaymentMethod.CASH,
   PaymentMethod.CREDIT_CARD,
@@ -93,13 +103,17 @@ const ExpenseInvoiceDialog: React.FC<ExpenseInvoiceDialogProps> = ({
         vendorId: invoice.vendorId || '',
         vendorName: invoice.vendorName || '',
         description: invoice.description || '',
-        invoiceDate: invoice.invoiceDate ? invoice.invoiceDate.split('T')[0] : '',
+        invoiceDate: invoice.invoiceDate
+          ? invoice.invoiceDate.split('T')[0]
+          : '',
         amount: invoice.amount || 0,
         taxAmount: invoice.taxAmount || 0,
         totalAmount: invoice.totalAmount || 0,
         category: invoice.category,
         status: invoice.status,
-        paymentDate: invoice.paymentDate ? invoice.paymentDate.split('T')[0] : '',
+        paymentDate: invoice.paymentDate
+          ? invoice.paymentDate.split('T')[0]
+          : '',
         paymentMethod: (invoice.paymentMethod as PaymentMethod) || '',
         notes: invoice.notes || '',
       });
@@ -132,17 +146,29 @@ const ExpenseInvoiceDialog: React.FC<ExpenseInvoiceDialogProps> = ({
     }
   };
 
-  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setFormData({ ...formData, [field]: value });
+  const handleChange =
+    (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setFormData({ ...formData, [field]: value });
+    };
 
-    // Auto-calculate total if amount or tax changes
-    if (field === 'amount' || field === 'taxAmount') {
-      const amount = field === 'amount' ? parseFloat(value) || 0 : parseFloat(String(formData.amount)) || 0;
-      const tax = field === 'taxAmount' ? parseFloat(value) || 0 : parseFloat(String(formData.taxAmount)) || 0;
-      setFormData((prev) => ({ ...prev, totalAmount: amount + tax, [field]: parseFloat(value) || 0 }));
-    }
-  };
+  // Handle amount / tax numeric changes and auto-calculate total
+  const handleAmountChange =
+    (field: 'amount' | 'taxAmount') => (value: number | undefined) => {
+      const amount =
+        field === 'amount'
+          ? value ?? 0
+          : parseFloat(String(formData.amount)) || 0;
+      const tax =
+        field === 'taxAmount'
+          ? value ?? 0
+          : parseFloat(String(formData.taxAmount)) || 0;
+      setFormData((prev) => ({
+        ...prev,
+        [field]: value ?? '',
+        totalAmount: amount + tax,
+      }));
+    };
 
   const handleVendorChange = (vendorId: string, vendorName: string) => {
     setFormData({
@@ -175,7 +201,9 @@ const ExpenseInvoiceDialog: React.FC<ExpenseInvoiceDialogProps> = ({
     const submitData: any = {
       ...formData,
       amount: parseFloat(formData.amount.toString()),
-      taxAmount: formData.taxAmount ? parseFloat(formData.taxAmount.toString()) : undefined,
+      taxAmount: formData.taxAmount
+        ? parseFloat(formData.taxAmount.toString())
+        : undefined,
       totalAmount: parseFloat(formData.totalAmount.toString()),
     };
 
@@ -200,7 +228,13 @@ const ExpenseInvoiceDialog: React.FC<ExpenseInvoiceDialogProps> = ({
   return (
     <Dialog open={open} maxWidth="md" fullWidth disableEscapeKeyDown>
       <DialogTitle>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
           {invoice ? 'Edit Expense Invoice' : 'Add Expense Invoice'}
           <IconButton onClick={onClose} size="small">
             <CloseIcon />
@@ -273,40 +307,42 @@ const ExpenseInvoiceDialog: React.FC<ExpenseInvoiceDialogProps> = ({
             </Grid>
 
             <Grid size={{ xs: 12, sm: 6 }}>
-              <TextField
+              <NumberInput
                 fullWidth
                 required
-                type="number"
+                allowDecimals
+                min={0}
                 label="Amount"
                 value={formData.amount}
-                onChange={handleChange('amount')}
-                inputProps={{ step: '0.01', min: '0' }}
-                autoComplete="off"
+                onChange={handleAmountChange('amount')}
+                inputProps={{ autoComplete: 'off' }}
               />
             </Grid>
 
             <Grid size={{ xs: 12, sm: 4 }}>
-              <TextField
+              <NumberInput
                 fullWidth
-                type="number"
+                allowDecimals
+                min={0}
                 label="Tax Amount"
                 value={formData.taxAmount}
-                onChange={handleChange('taxAmount')}
-                inputProps={{ step: '0.01', min: '0' }}
-                autoComplete="off"
+                onChange={handleAmountChange('taxAmount')}
+                inputProps={{ autoComplete: 'off' }}
               />
             </Grid>
 
             <Grid size={{ xs: 12, sm: 4 }}>
-              <TextField
+              <NumberInput
                 fullWidth
                 required
-                type="number"
+                allowDecimals
+                min={0}
                 label="Total Amount"
                 value={formData.totalAmount}
-                onChange={handleChange('totalAmount')}
-                inputProps={{ step: '0.01', min: '0' }}
-                autoComplete="off"
+                onChange={(v) =>
+                  setFormData({ ...formData, totalAmount: v ?? '' })
+                }
+                inputProps={{ autoComplete: 'off' }}
               />
             </Grid>
 
@@ -370,7 +406,14 @@ const ExpenseInvoiceDialog: React.FC<ExpenseInvoiceDialogProps> = ({
 
             {invoice && (
               <Grid size={{ xs: 12 }}>
-                <Box sx={{ border: '1px dashed', borderColor: 'divider', p: 2, borderRadius: 1 }}>
+                <Box
+                  sx={{
+                    border: '1px dashed',
+                    borderColor: 'divider',
+                    p: 2,
+                    borderRadius: 1,
+                  }}
+                >
                   <Typography variant="subtitle2" gutterBottom>
                     Invoice Image
                   </Typography>
@@ -379,9 +422,18 @@ const ExpenseInvoiceDialog: React.FC<ExpenseInvoiceDialogProps> = ({
                       Current image: {invoice.imageName}
                     </Alert>
                   )}
-                  <Button variant="outlined" component="label" startIcon={<UploadIcon />}>
+                  <Button
+                    variant="outlined"
+                    component="label"
+                    startIcon={<UploadIcon />}
+                  >
                     {selectedFile ? selectedFile.name : 'Upload New Image'}
-                    <input type="file" hidden accept="image/*,.pdf" onChange={handleFileChange} />
+                    <input
+                      type="file"
+                      hidden
+                      accept="image/*,.pdf"
+                      onChange={handleFileChange}
+                    />
                   </Button>
                   {selectedFile && (
                     <IconButton

--- a/apps/webApp/src/app/components/inspections/InspectionFeeItemDialog.tsx
+++ b/apps/webApp/src/app/components/inspections/InspectionFeeItemDialog.tsx
@@ -15,6 +15,7 @@ import {
   Switch,
   TextField,
 } from '@mui/material';
+import { NumberInput } from '../common';
 import {
   CreateInspectionFeeItemDto,
   InspectionFeeItem,
@@ -140,14 +141,14 @@ export function InspectionFeeItemDialog({
               ))}
             </Select>
           </FormControl>
-          <TextField
+          <NumberInput
             label="Price"
             value={price}
-            onChange={(event) => setPrice(event.target.value)}
+            onChange={(v) => setPrice(v === undefined ? '' : String(v))}
             fullWidth
             required
-            type="number"
-            inputProps={{ min: 0, step: 0.01 }}
+            allowDecimals
+            min={0}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">$</InputAdornment>

--- a/apps/webApp/src/app/components/inventory/StockAdjustmentDialog.tsx
+++ b/apps/webApp/src/app/components/inventory/StockAdjustmentDialog.tsx
@@ -29,12 +29,17 @@ import {
 } from '@mui/icons-material';
 import { TireResponseDto as ITire } from '@gt-automotive/data';
 import { useStockAdjustment } from '../../hooks/useTires';
+import { NumberInput } from '../common';
 
 interface StockAdjustmentDialogProps {
   open: boolean;
   tire: ITire | null;
   onClose: () => void;
-  onConfirm?: (adjustment: { quantity: number; type: 'add' | 'remove' | 'set'; reason: string }) => void;
+  onConfirm?: (adjustment: {
+    quantity: number;
+    type: 'add' | 'remove' | 'set';
+    reason: string;
+  }) => void;
 }
 
 interface AdjustmentForm {
@@ -44,9 +49,24 @@ interface AdjustmentForm {
 }
 
 const ADJUSTMENT_TYPES = [
-  { value: 'add', label: 'Add Stock', icon: <AddIcon />, description: 'Increase inventory quantity' },
-  { value: 'remove', label: 'Remove Stock', icon: <RemoveIcon />, description: 'Decrease inventory quantity' },
-  { value: 'set', label: 'Set Stock', icon: <EditIcon />, description: 'Set exact inventory quantity' },
+  {
+    value: 'add',
+    label: 'Add Stock',
+    icon: <AddIcon />,
+    description: 'Increase inventory quantity',
+  },
+  {
+    value: 'remove',
+    label: 'Remove Stock',
+    icon: <RemoveIcon />,
+    description: 'Decrease inventory quantity',
+  },
+  {
+    value: 'set',
+    label: 'Set Stock',
+    icon: <EditIcon />,
+    description: 'Set exact inventory quantity',
+  },
 ] as const;
 
 const COMMON_REASONS = [
@@ -60,11 +80,11 @@ const COMMON_REASONS = [
   'Internal use',
 ];
 
-export function StockAdjustmentDialog({ 
-  open, 
-  tire, 
-  onClose, 
-  onConfirm 
+export function StockAdjustmentDialog({
+  open,
+  tire,
+  onClose,
+  onConfirm,
 }: StockAdjustmentDialogProps) {
   const [form, setForm] = useState<AdjustmentForm>({
     type: 'add',
@@ -146,7 +166,13 @@ export function StockAdjustmentDialog({
 
   return (
     <Dialog open={open} disableEscapeKeyDown maxWidth="sm" fullWidth>
-      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         <Box>
           <Typography variant="h6">Adjust Stock</Typography>
           <Typography variant="body2" color="text.secondary">
@@ -170,10 +196,10 @@ export function StockAdjustmentDialog({
               {tire.quantity} units
             </Typography>
             {tire.quantity <= (tire.minStock || 5) && (
-              <Chip 
-                label="Low Stock" 
-                color="warning" 
-                size="small" 
+              <Chip
+                label="Low Stock"
+                color="warning"
+                size="small"
                 sx={{ mt: 1 }}
               />
             )}
@@ -184,7 +210,12 @@ export function StockAdjustmentDialog({
             <FormLabel component="legend">Adjustment Type</FormLabel>
             <RadioGroup
               value={form.type}
-              onChange={(e) => setForm({ ...form, type: e.target.value as 'add' | 'remove' | 'set' })}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  type: e.target.value as 'add' | 'remove' | 'set',
+                })
+              }
             >
               {ADJUSTMENT_TYPES.map((type) => (
                 <FormControlLabel
@@ -208,15 +239,18 @@ export function StockAdjustmentDialog({
           </FormControl>
 
           {/* Quantity Input */}
-          <TextField
-            label={form.type === 'set' ? 'New Stock Quantity' : 'Quantity to Adjust'}
-            type="number"
+          <NumberInput
+            label={
+              form.type === 'set' ? 'New Stock Quantity' : 'Quantity to Adjust'
+            }
             value={form.quantity}
-            onChange={(e) => setForm({ ...form, quantity: parseInt(e.target.value) || 0 })}
+            onChange={(v) =>
+              setForm({ ...form, quantity: (v ?? '') as unknown as number })
+            }
             error={!!errors.quantity}
             helperText={errors.quantity}
             fullWidth
-            inputProps={{ min: 1 }}
+            min={1}
           />
 
           {/* Reason Input */}
@@ -231,13 +265,17 @@ export function StockAdjustmentDialog({
               rows={2}
               placeholder="Explain why you're adjusting the stock..."
             />
-            
+
             {/* Common Reasons */}
             <Box sx={{ mt: 1 }}>
               <Typography variant="caption" color="text.secondary">
                 Common reasons:
               </Typography>
-              <Stack direction="row" spacing={0.5} sx={{ mt: 0.5, flexWrap: 'wrap', gap: 0.5 }}>
+              <Stack
+                direction="row"
+                spacing={0.5}
+                sx={{ mt: 0.5, flexWrap: 'wrap', gap: 0.5 }}
+              >
                 {COMMON_REASONS.map((reason) => (
                   <Chip
                     key={reason}
@@ -260,39 +298,44 @@ export function StockAdjustmentDialog({
               Stock Adjustment Preview
             </Typography>
             <Paper sx={{ p: 2, bgcolor: 'primary.50' }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+              >
                 <Box>
                   <Typography variant="body2" color="text.secondary">
                     Current Stock
                   </Typography>
-                  <Typography variant="h6">
-                    {tire.quantity}
-                  </Typography>
+                  <Typography variant="h6">{tire.quantity}</Typography>
                 </Box>
-                
+
                 <Typography variant="h6" color="text.secondary">
                   →
                 </Typography>
-                
+
                 <Box>
                   <Typography variant="body2" color="text.secondary">
                     New Stock
                   </Typography>
-                  <Typography 
-                    variant="h6" 
-                    color={newQuantity <= (tire.minStock || 5) ? 'warning.main' : 'primary.main'}
+                  <Typography
+                    variant="h6"
+                    color={
+                      newQuantity <= (tire.minStock || 5)
+                        ? 'warning.main'
+                        : 'primary.main'
+                    }
                   >
                     {newQuantity}
                   </Typography>
                 </Box>
               </Stack>
-              
+
               {newQuantity <= (tire.minStock || 5) && (
                 <Alert severity="warning" sx={{ mt: 1 }}>
-                  {newQuantity === 0 
+                  {newQuantity === 0
                     ? 'This will result in zero stock!'
-                    : 'This will result in low stock levels.'
-                  }
+                    : 'This will result in low stock levels.'}
                 </Alert>
               )}
             </Paper>

--- a/apps/webApp/src/app/components/inventory/TireDialog.tsx
+++ b/apps/webApp/src/app/components/inventory/TireDialog.tsx
@@ -23,9 +23,9 @@ import {
   Typography,
 } from '@mui/material';
 import { Close as CloseIcon } from '@mui/icons-material';
-import { 
-  TireDto, 
-  CreateTireDto, 
+import {
+  TireDto,
+  CreateTireDto,
   UpdateTireDto,
   TireCondition,
   TireType,
@@ -40,7 +40,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { BrandSelect } from './BrandSelect';
 import { SizeSelect } from './SizeSelect';
 import { LocationSelect } from './LocationSelect';
-
+import { NumberInput } from '../common';
 
 interface TireDialogProps {
   open: boolean;
@@ -49,7 +49,12 @@ interface TireDialogProps {
   onSuccess?: () => void;
 }
 
-export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) {
+export function TireDialog({
+  open,
+  onClose,
+  tire,
+  onSuccess,
+}: TireDialogProps) {
   const queryClient = useQueryClient();
   useAuth();
   const theme = useTheme();
@@ -72,7 +77,9 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
     imageUrl: '',
   });
 
-  const [errors, setErrors] = useState<Partial<Record<keyof CreateTireDto, string>>>({});
+  const [errors, setErrors] = useState<
+    Partial<Record<keyof CreateTireDto, string>>
+  >({});
 
   useEffect(() => {
     if (open) {
@@ -124,7 +131,10 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
     },
     onError: (error: any) => {
       if (process.env.NODE_ENV !== 'production') {
-        console.error('Create tire failed:', error?.response?.data?.message || error.message);
+        console.error(
+          'Create tire failed:',
+          error?.response?.data?.message || error.message
+        );
       }
     },
   });
@@ -141,7 +151,10 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
     },
     onError: (error: any) => {
       if (process.env.NODE_ENV !== 'production') {
-        console.error('Update tire failed:', error?.response?.data?.message || error.message);
+        console.error(
+          'Update tire failed:',
+          error?.response?.data?.message || error.message
+        );
       }
     },
   });
@@ -152,9 +165,12 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
     if (!formData.brand.trim()) newErrors.brand = 'Brand is required';
     if (!formData.size.trim()) newErrors.size = 'Size is required';
     if (formData.price <= 0) newErrors.price = 'Price must be greater than 0';
-    if (formData.quantity < 0) newErrors.quantity = 'Quantity cannot be negative';
-    if (formData.cost && formData.cost < 0) newErrors.cost = 'Cost cannot be negative';
-    if (formData.minStock != null && formData.minStock < 0) newErrors.minStock = 'Minimum stock cannot be negative';
+    if (formData.quantity < 0)
+      newErrors.quantity = 'Quantity cannot be negative';
+    if (formData.cost && formData.cost < 0)
+      newErrors.cost = 'Cost cannot be negative';
+    if (formData.minStock != null && formData.minStock < 0)
+      newErrors.minStock = 'Minimum stock cannot be negative';
 
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
@@ -202,9 +218,9 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
   };
 
   const handleChange = (field: keyof CreateTireDto, value: any) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+    setFormData((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) {
-      setErrors(prev => ({ ...prev, [field]: undefined }));
+      setErrors((prev) => ({ ...prev, [field]: undefined }));
     }
   };
 
@@ -214,7 +230,7 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
     // Find the brand object to get its image URL
     const brands = queryClient.getQueryData(['tire-brands']) as any[];
     if (brands) {
-      const selectedBrand = brands.find(b => b.id === brandId);
+      const selectedBrand = brands.find((b) => b.id === brandId);
       if (selectedBrand?.imageUrl) {
         // Auto-populate image URL from selected brand
         handleChange('imageUrl', selectedBrand.imageUrl);
@@ -272,10 +288,12 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
           </Toolbar>
         </AppBar>
       ) : (
-        <DialogTitle sx={{
-          bgcolor: 'primary.main',
-          color: 'white',
-        }}>
+        <DialogTitle
+          sx={{
+            bgcolor: 'primary.main',
+            color: 'white',
+          }}
+        >
           {isEditMode ? 'Edit Tire' : 'Add New Tire'}
         </DialogTitle>
       )}
@@ -350,7 +368,7 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
                   label="Type"
                   onChange={(e) => handleChange('type', e.target.value)}
                 >
-                  {TIRE_TYPE_OPTIONS.map(type => (
+                  {TIRE_TYPE_OPTIONS.map((type) => (
                     <MenuItem key={type.value} value={type.value}>
                       {type.label}
                     </MenuItem>
@@ -367,7 +385,7 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
                   label="Condition"
                   onChange={(e) => handleChange('condition', e.target.value)}
                 >
-                  {TIRE_CONDITION_OPTIONS.map(condition => (
+                  {TIRE_CONDITION_OPTIONS.map((condition) => (
                     <MenuItem key={condition.value} value={condition.value}>
                       {condition.label}
                     </MenuItem>
@@ -377,85 +395,75 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
             </Grid>
 
             <Grid size={{ xs: 12, md: 6 }}>
-              <TextField
+              <NumberInput
                 label="Quantity"
-                type="number"
                 fullWidth
                 value={formData.quantity}
-                onChange={(e) => handleChange('quantity', e.target.value === '' ? '' : parseInt(e.target.value) || 0)}
-                onKeyDown={(e) => {
-                  if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                    e.preventDefault();
-                  }
-                }}
+                onChange={(v) =>
+                  handleChange('quantity', (v ?? '') as unknown as number)
+                }
                 error={!!errors.quantity}
                 helperText={errors.quantity}
-                inputProps={{ min: 0 }}
+                min={0}
                 autoComplete="off"
                 required
               />
             </Grid>
 
             <Grid size={{ xs: 12, md: 6 }}>
-              <TextField
+              <NumberInput
                 label="Price"
-                type="number"
+                allowDecimals
                 fullWidth
                 value={formData.price}
-                onChange={(e) => handleChange('price', e.target.value === '' ? '' : parseFloat(e.target.value) || 0)}
-                onKeyDown={(e) => {
-                  if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                    e.preventDefault();
-                  }
-                }}
+                onChange={(v) =>
+                  handleChange('price', (v ?? '') as unknown as number)
+                }
                 error={!!errors.price}
                 helperText={errors.price}
                 InputProps={{
-                  startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                  startAdornment: (
+                    <InputAdornment position="start">$</InputAdornment>
+                  ),
                 }}
-                inputProps={{ min: 0, step: 0.01 }}
+                min={0}
                 autoComplete="off"
                 required
               />
             </Grid>
 
             <Grid size={{ xs: 12, md: 6 }}>
-              <TextField
+              <NumberInput
                 label="Cost"
-                type="number"
+                allowDecimals
                 fullWidth
                 value={formData.cost}
-                onChange={(e) => handleChange('cost', e.target.value === '' ? '' : parseFloat(e.target.value) || 0)}
-                onKeyDown={(e) => {
-                  if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                    e.preventDefault();
-                  }
-                }}
+                onChange={(v) =>
+                  handleChange('cost', (v ?? '') as unknown as number)
+                }
                 error={!!errors.cost}
                 helperText={errors.cost}
                 InputProps={{
-                  startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                  startAdornment: (
+                    <InputAdornment position="start">$</InputAdornment>
+                  ),
                 }}
-                inputProps={{ min: 0, step: 0.01 }}
+                min={0}
                 autoComplete="off"
               />
             </Grid>
 
             <Grid size={{ xs: 12, md: 6 }}>
-              <TextField
+              <NumberInput
                 label="Minimum Stock"
-                type="number"
                 fullWidth
                 value={formData.minStock}
-                onChange={(e) => handleChange('minStock', e.target.value === '' ? '' as unknown as number : parseInt(e.target.value) || 0)}
-                onKeyDown={(e) => {
-                  if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                    e.preventDefault();
-                  }
-                }}
+                onChange={(v) =>
+                  handleChange('minStock', (v ?? '') as unknown as number)
+                }
                 error={!!errors.minStock}
                 helperText={errors.minStock}
-                inputProps={{ min: 0 }}
+                min={0}
                 autoComplete="off"
               />
             </Grid>
@@ -484,11 +492,13 @@ export function TireDialog({ open, onClose, tire, onSuccess }: TireDialogProps) 
           </Grid>
         </Box>
       </DialogContent>
-      <DialogActions sx={{
-        p: isMobile ? 2 : 3,
-        gap: isMobile ? 1 : 0,
-        flexDirection: isMobile ? 'column-reverse' : 'row',
-      }}>
+      <DialogActions
+        sx={{
+          p: isMobile ? 2 : 3,
+          gap: isMobile ? 1 : 0,
+          flexDirection: isMobile ? 'column-reverse' : 'row',
+        }}
+      >
         <Button
           onClick={onClose}
           disabled={isLoading}

--- a/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
@@ -52,6 +52,7 @@ import { InvoiceItemType } from '../../../enums';
 import { colors } from '../../theme/colors';
 import ServiceSelect from '../services/ServiceSelect';
 import { PhoneInput } from '../common/PhoneInput';
+import { NumberInput } from '../common';
 
 interface InvoiceFormContentProps {
   customers: any[];
@@ -121,10 +122,16 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
   const [menuItemIndex, setMenuItemIndex] = useState<number | null>(null);
 
   const formatTireType = (type: string) => {
-    return type.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, l => l.toUpperCase());
+    return type
+      .replace(/_/g, ' ')
+      .toLowerCase()
+      .replace(/\b\w/g, (l) => l.toUpperCase());
   };
 
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>, index: number) => {
+  const handleMenuOpen = (
+    event: React.MouseEvent<HTMLElement>,
+    index: number
+  ) => {
     setMenuAnchorEl(event.currentTarget);
     setMenuItemIndex(index);
   };
@@ -141,7 +148,11 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
     }
   };
 
-  const handleServiceChange = (serviceId: string, serviceName: string, unitPrice: number) => {
+  const handleServiceChange = (
+    serviceId: string,
+    serviceName: string,
+    unitPrice: number
+  ) => {
     setNewItem({
       ...newItem,
       itemType: InvoiceItemType.SERVICE,
@@ -163,8 +174,13 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
       // For DISCOUNT_PERCENTAGE items, calculate based on other items (excluding TIPS and discounts)
       if (item.itemType === 'DISCOUNT_PERCENTAGE' && item.unitPrice) {
         const otherItemsSubtotal = items
-          .filter(i => i.itemType !== 'DISCOUNT' && i.itemType !== 'DISCOUNT_PERCENTAGE' && i.itemType !== 'TIPS')
-          .reduce((s, i) => s + (i.quantity * i.unitPrice), 0);
+          .filter(
+            (i) =>
+              i.itemType !== 'DISCOUNT' &&
+              i.itemType !== 'DISCOUNT_PERCENTAGE' &&
+              i.itemType !== 'TIPS'
+          )
+          .reduce((s, i) => s + i.quantity * i.unitPrice, 0);
         itemTotal = -(otherItemsSubtotal * item.unitPrice) / 100;
       }
 
@@ -199,11 +215,13 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
     <Box sx={{ p: { xs: 2, sm: 3 } }}>
       {/* COMPANY SELECTION */}
       <Box sx={{ mb: { xs: 2, sm: 3 } }}>
-        <Card sx={{
-          borderRadius: 2,
-          boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
-          border: `1px solid ${colors.neutral[200]}`,
-        }}>
+        <Card
+          sx={{
+            borderRadius: 2,
+            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+            border: `1px solid ${colors.neutral[200]}`,
+          }}
+        >
           <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               {!isMobile && <BuildIcon sx={{ color: colors.primary.main }} />}
@@ -218,11 +236,17 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
               <InputLabel>Select Company</InputLabel>
               <Select
                 value={formData.companyId}
-                onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, companyId: e.target.value })
+                }
                 label="Select Company"
                 sx={{
-                  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: colors.primary.light },
-                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: colors.primary.main }
+                  '&:hover .MuiOutlinedInput-notchedOutline': {
+                    borderColor: colors.primary.light,
+                  },
+                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                    borderColor: colors.primary.main,
+                  },
                 }}
               >
                 {companies.map((company) => (
@@ -232,7 +256,8 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         {company.name.replace(/[()]/g, '')}
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
-                        {company.registrationNumber} {company.businessType && `• ${company.businessType}`}
+                        {company.registrationNumber}{' '}
+                        {company.businessType && `• ${company.businessType}`}
                       </Typography>
                     </Box>
                   </MenuItem>
@@ -247,16 +272,34 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
       <Box sx={{ mb: { xs: 2, sm: 3 } }}>
         <Grid container spacing={{ xs: 2, sm: 3 }}>
           <Grid size={{ xs: 12, lg: 6 }}>
-            <Card sx={{
-              borderRadius: 2,
-              boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
-              border: `1px solid ${colors.neutral[200]}`,
-              height: '100%',
-              minHeight: isMobile ? 'auto' : 280
-            }}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 }, height: '100%', display: 'flex', flexDirection: 'column' }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: { xs: 2, sm: 3 } }}>
-                  {!isMobile && <PersonIcon sx={{ color: colors.primary.main }} />}
+            <Card
+              sx={{
+                borderRadius: 2,
+                boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+                border: `1px solid ${colors.neutral[200]}`,
+                height: '100%',
+                minHeight: isMobile ? 'auto' : 280,
+              }}
+            >
+              <CardContent
+                sx={{
+                  p: { xs: 2, sm: 3 },
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    mb: { xs: 2, sm: 3 },
+                  }}
+                >
+                  {!isMobile && (
+                    <PersonIcon sx={{ color: colors.primary.main }} />
+                  )}
                   <Typography
                     variant={isMobile ? 'subtitle1' : 'h6'}
                     sx={{ fontWeight: 600, color: colors.text.primary }}
@@ -264,8 +307,15 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                     Customer Information
                   </Typography>
                 </Box>
-                
-                <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+
+                <Box
+                  sx={{
+                    flex: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 2,
+                  }}
+                >
                   {/* Customer Search */}
                   <Autocomplete
                     freeSolo
@@ -282,14 +332,20 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                             {option.firstName} {option.lastName}
                           </Typography>
                           {(option.phone || option.email) && (
-                            <Typography variant="caption" color="text.secondary">
-                              {option.phone} {option.email && `• ${option.email}`}
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
+                              {option.phone}{' '}
+                              {option.email && `• ${option.email}`}
                             </Typography>
                           )}
                         </Box>
                       </li>
                     )}
-                    isOptionEqualToValue={(option, value) => option.id === value.id}
+                    isOptionEqualToValue={(option, value) =>
+                      option.id === value.id
+                    }
                     filterOptions={(options, state) => {
                       const inputValue = state.inputValue.toLowerCase().trim();
 
@@ -298,32 +354,42 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       }
 
                       return options.filter((option) => {
-                        const fullName = `${option.firstName} ${option.lastName}`.toLowerCase();
+                        const fullName =
+                          `${option.firstName} ${option.lastName}`.toLowerCase();
                         const phone = (option.phone || '').toLowerCase();
                         const email = (option.email || '').toLowerCase();
-                        return fullName.includes(inputValue) ||
-                               phone.includes(inputValue) ||
-                               email.includes(inputValue);
+                        return (
+                          fullName.includes(inputValue) ||
+                          phone.includes(inputValue) ||
+                          email.includes(inputValue)
+                        );
                       });
                     }}
-                    value={customers.find(c => c.id === formData.customerId) || null}
+                    value={
+                      customers.find((c) => c.id === formData.customerId) ||
+                      null
+                    }
                     onChange={(_, newValue) => {
                       if (typeof newValue === 'string') {
                         const searchTerm = newValue.trim().toLowerCase();
 
-                        const matchingCustomer = customers.find(c => {
-                          const fullName = `${c.firstName} ${c.lastName}`.toLowerCase();
+                        const matchingCustomer = customers.find((c) => {
+                          const fullName =
+                            `${c.firstName} ${c.lastName}`.toLowerCase();
                           const firstName = c.firstName.toLowerCase();
                           const lastName = c.lastName.toLowerCase();
                           const phone = (c.phone || '').toLowerCase();
                           const email = (c.email || '').toLowerCase();
 
-                          return fullName === searchTerm ||
-                                 firstName === searchTerm ||
-                                 lastName === searchTerm ||
-                                 phone === searchTerm ||
-                                 email === searchTerm ||
-                                 (searchTerm.includes(' ') && fullName.includes(searchTerm));
+                          return (
+                            fullName === searchTerm ||
+                            firstName === searchTerm ||
+                            lastName === searchTerm ||
+                            phone === searchTerm ||
+                            email === searchTerm ||
+                            (searchTerm.includes(' ') &&
+                              fullName.includes(searchTerm))
+                          );
                         });
 
                         if (matchingCustomer) {
@@ -332,7 +398,11 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                           const nameParts = newValue.trim().split(' ');
                           const firstName = nameParts[0] || '';
                           const lastName = nameParts.slice(1).join(' ') || '';
-                          setCustomerForm({ ...customerForm, firstName, lastName });
+                          setCustomerForm({
+                            ...customerForm,
+                            firstName,
+                            lastName,
+                          });
                           setFormData({ ...formData, customerId: '' });
                           onCustomerSelect(null);
                         }
@@ -341,18 +411,22 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       }
                     }}
                     renderInput={(params) => (
-                      <TextField 
-                        {...params} 
-                        label="Search or Add Customer" 
+                      <TextField
+                        {...params}
+                        label="Search or Add Customer"
                         placeholder="Search by name, phone, or email"
                         fullWidth
                         variant="outlined"
                         size="small"
                         sx={{
                           '& .MuiOutlinedInput-root': {
-                            '&:hover fieldset': { borderColor: colors.primary.light },
-                            '&.Mui-focused fieldset': { borderColor: colors.primary.main }
-                          }
+                            '&:hover fieldset': {
+                              borderColor: colors.primary.light,
+                            },
+                            '&.Mui-focused fieldset': {
+                              borderColor: colors.primary.main,
+                            },
+                          },
                         }}
                       />
                     )}
@@ -368,7 +442,10 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         value={customerForm.firstName}
                         disabled={isEditMode}
                         onChange={(e) => {
-                          setCustomerForm({ ...customerForm, firstName: e.target.value });
+                          setCustomerForm({
+                            ...customerForm,
+                            firstName: e.target.value,
+                          });
                           // If user types in the name field and there's no customer selected, mark as new customer
                           if (!formData.customerId) {
                             onCustomerSelect(null);
@@ -376,7 +453,15 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         }}
                         required
                         InputProps={{
-                          startAdornment: <PersonIcon sx={{ color: colors.text.secondary, mr: 1, fontSize: 20 }} />,
+                          startAdornment: (
+                            <PersonIcon
+                              sx={{
+                                color: colors.text.secondary,
+                                mr: 1,
+                                fontSize: 20,
+                              }}
+                            />
+                          ),
                         }}
                       />
                     </Grid>
@@ -388,7 +473,10 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         value={customerForm.lastName}
                         disabled={isEditMode}
                         onChange={(e) => {
-                          setCustomerForm({ ...customerForm, lastName: e.target.value });
+                          setCustomerForm({
+                            ...customerForm,
+                            lastName: e.target.value,
+                          });
                           // If user types in the name field and there's no customer selected, mark as new customer
                           if (!formData.customerId) {
                             onCustomerSelect(null);
@@ -404,7 +492,12 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         label="Business Name"
                         value={customerForm.businessName}
                         disabled={isEditMode}
-                        onChange={(e) => setCustomerForm({ ...customerForm, businessName: e.target.value })}
+                        onChange={(e) =>
+                          setCustomerForm({
+                            ...customerForm,
+                            businessName: e.target.value,
+                          })
+                        }
                         placeholder="Optional"
                       />
                     </Grid>
@@ -415,7 +508,12 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         label="Address"
                         value={customerForm.address}
                         disabled={isEditMode}
-                        onChange={(e) => setCustomerForm({ ...customerForm, address: e.target.value })}
+                        onChange={(e) =>
+                          setCustomerForm({
+                            ...customerForm,
+                            address: e.target.value,
+                          })
+                        }
                         placeholder="Street address, city, province, postal code"
                       />
                     </Grid>
@@ -425,7 +523,9 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         size="small"
                         value={customerForm.phone}
                         disabled={isEditMode}
-                        onChange={(value) => setCustomerForm({ ...customerForm, phone: value })}
+                        onChange={(value) =>
+                          setCustomerForm({ ...customerForm, phone: value })
+                        }
                       />
                     </Grid>
                     <Grid size={{ xs: 12, md: 6 }}>
@@ -436,7 +536,12 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         type="email"
                         value={customerForm.email}
                         disabled={isEditMode}
-                        onChange={(e) => setCustomerForm({ ...customerForm, email: e.target.value })}
+                        onChange={(e) =>
+                          setCustomerForm({
+                            ...customerForm,
+                            email: e.target.value,
+                          })
+                        }
                         placeholder="customer@email.com"
                       />
                     </Grid>
@@ -448,14 +553,24 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       <InputLabel>Vehicle (Optional)</InputLabel>
                       <Select
                         value={formData.vehicleId}
-                        onChange={(e) => setFormData({ ...formData, vehicleId: e.target.value })}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            vehicleId: e.target.value,
+                          })
+                        }
                         label="Vehicle (Optional)"
-                        startAdornment={<CarIcon sx={{ color: colors.text.secondary, ml: 1, mr: 1 }} />}
+                        startAdornment={
+                          <CarIcon
+                            sx={{ color: colors.text.secondary, ml: 1, mr: 1 }}
+                          />
+                        }
                       >
                         <MenuItem value="">No Vehicle</MenuItem>
-                        {vehicles.map(vehicle => (
+                        {vehicles.map((vehicle) => (
                           <MenuItem key={vehicle.id} value={vehicle.id}>
-                            {vehicle.year} {vehicle.make} {vehicle.model} - {vehicle.licensePlate || vehicle.vin}
+                            {vehicle.year} {vehicle.make} {vehicle.model} -{' '}
+                            {vehicle.licensePlate || vehicle.vin}
                           </MenuItem>
                         ))}
                       </Select>
@@ -474,16 +589,34 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
 
           {/* Payment & Notes - Top Row Right */}
           <Grid size={{ xs: 12, lg: 6 }}>
-            <Card sx={{ 
-              borderRadius: 2,
-              boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
-              border: `1px solid ${colors.neutral[200]}`,
-              height: '100%',
-              minHeight: isMobile ? 'auto' : 280
-            }}>
-              <CardContent sx={{ p: { xs: 2, sm: 3 }, height: '100%', display: 'flex', flexDirection: 'column' }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: { xs: 2, sm: 3 } }}>
-                  {!isMobile && <PaymentIcon sx={{ color: colors.primary.main }} />}
+            <Card
+              sx={{
+                borderRadius: 2,
+                boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+                border: `1px solid ${colors.neutral[200]}`,
+                height: '100%',
+                minHeight: isMobile ? 'auto' : 280,
+              }}
+            >
+              <CardContent
+                sx={{
+                  p: { xs: 2, sm: 3 },
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    mb: { xs: 2, sm: 3 },
+                  }}
+                >
+                  {!isMobile && (
+                    <PaymentIcon sx={{ color: colors.primary.main }} />
+                  )}
                   <Typography
                     variant={isMobile ? 'subtitle1' : 'h6'}
                     sx={{ fontWeight: 600, color: colors.text.primary }}
@@ -492,14 +625,23 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                   </Typography>
                 </Box>
 
-                <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                <Box
+                  sx={{
+                    flex: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 3,
+                  }}
+                >
                   <Grid container spacing={2}>
                     <Grid size={{ xs: 12, md: 6 }}>
                       <FormControl fullWidth>
                         <InputLabel>Status</InputLabel>
                         <Select
                           value={formData.status}
-                          onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+                          onChange={(e) =>
+                            setFormData({ ...formData, status: e.target.value })
+                          }
                           label="Status"
                         >
                           <MenuItem value="DRAFT">📝 Draft</MenuItem>
@@ -516,14 +658,21 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         type="date"
                         label="Invoice Date"
                         value={formData.invoiceDate}
-                        onChange={(e) => setFormData({ ...formData, invoiceDate: e.target.value })}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            invoiceDate: e.target.value,
+                          })
+                        }
                         InputLabelProps={{
                           shrink: true,
                         }}
                         sx={{
                           '& .MuiOutlinedInput-root': {
-                            '&:hover fieldset': { borderColor: colors.primary.light }
-                          }
+                            '&:hover fieldset': {
+                              borderColor: colors.primary.light,
+                            },
+                          },
                         }}
                       />
                     </Grid>
@@ -542,7 +691,7 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                             ...formData,
                             paymentMethod,
                             gstRate: 0,
-                            pstRate: 0
+                            pstRate: 0,
                           });
                         } else if (formData.paymentMethod === 'CASH') {
                           // Switching from Cash to another method - restore default rates
@@ -550,7 +699,7 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                             ...formData,
                             paymentMethod,
                             gstRate: 0.05,
-                            pstRate: 0.07
+                            pstRate: 0.07,
                           });
                         } else {
                           setFormData({ ...formData, paymentMethod });
@@ -575,18 +724,25 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                     rows={4}
                     label="Invoice Notes (Optional)"
                     value={formData.notes}
-                    onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                    onChange={(e) =>
+                      setFormData({ ...formData, notes: e.target.value })
+                    }
                     placeholder="Add any special instructions or notes for this invoice..."
                     sx={{
                       '& .MuiOutlinedInput-root': {
-                        '&:hover fieldset': { borderColor: colors.primary.light }
-                      }
+                        '&:hover fieldset': {
+                          borderColor: colors.primary.light,
+                        },
+                      },
                     }}
                   />
 
                   {formData.paymentMethod && (
                     <Alert severity="info" sx={{ mt: 'auto' }}>
-                      Payment Method: <strong>{formData.paymentMethod.replace(/_/g, ' ')}</strong>
+                      Payment Method:{' '}
+                      <strong>
+                        {formData.paymentMethod.replace(/_/g, ' ')}
+                      </strong>
                     </Alert>
                   )}
                 </Box>
@@ -598,14 +754,25 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
 
       {/* SECOND ROW: Add Items Section - Full Width */}
       <Box sx={{ mb: { xs: 2, sm: 3 } }}>
-        <Card sx={{
-          borderRadius: 2,
-          boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
-          border: `1px solid ${colors.neutral[200]}`
-        }}>
+        <Card
+          sx={{
+            borderRadius: 2,
+            boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
+            border: `1px solid ${colors.neutral[200]}`,
+          }}
+        >
           <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: { xs: 2, sm: 3 } }}>
-              {!isMobile && <ShoppingCartIcon sx={{ color: colors.primary.main }} />}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                mb: { xs: 2, sm: 3 },
+              }}
+            >
+              {!isMobile && (
+                <ShoppingCartIcon sx={{ color: colors.primary.main }} />
+              )}
               <Typography
                 variant={isMobile ? 'subtitle1' : 'h6'}
                 sx={{ fontWeight: 600, color: colors.text.primary }}
@@ -614,15 +781,19 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
               </Typography>
             </Box>
 
-            <Box sx={{ 
-              p: 2, 
-              borderRadius: 2, 
-              background: colors.neutral[50],
-              border: `1px solid ${colors.neutral[200]}`,
-              mb: 3
-            }}>
+            <Box
+              sx={{
+                p: 2,
+                borderRadius: 2,
+                background: colors.neutral[50],
+                border: `1px solid ${colors.neutral[200]}`,
+                mb: 3,
+              }}
+            >
               <Grid container spacing={2} alignItems="center">
-                <Grid size={{ xs: 12, md: newItem.itemType === 'TIPS' ? 4 : 2 }}>
+                <Grid
+                  size={{ xs: 12, md: newItem.itemType === 'TIPS' ? 4 : 2 }}
+                >
                   <FormControl fullWidth size="small">
                     <InputLabel>Type</InputLabel>
                     <Select
@@ -665,49 +836,71 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       label="Type"
                     >
                       <MenuItem value="TIRE">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
                           <span style={{ fontSize: '18px' }}>🛞</span>
                           Tire
                         </Box>
                       </MenuItem>
                       <MenuItem value="SERVICE">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
                           <BuildIcon fontSize="small" />
                           Service
                         </Box>
                       </MenuItem>
                       <MenuItem value="PART">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
                           <ExtensionIcon fontSize="small" />
                           Part
                         </Box>
                       </MenuItem>
                       <MenuItem value="OTHER">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
                           <CategoryIcon fontSize="small" />
                           Other
                         </Box>
                       </MenuItem>
                       <MenuItem value="LEVY">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
                           <AccountBalanceIcon fontSize="small" />
                           Levy
                         </Box>
                       </MenuItem>
                       <MenuItem value="DISCOUNT">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <AttachMoneyIcon fontSize="small" sx={{ color: 'red' }} />
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
+                          <AttachMoneyIcon
+                            fontSize="small"
+                            sx={{ color: 'red' }}
+                          />
                           $ Discount
                         </Box>
                       </MenuItem>
                       <MenuItem value="DISCOUNT_PERCENTAGE">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <AttachMoneyIcon fontSize="small" sx={{ color: 'red' }} />
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
+                          <AttachMoneyIcon
+                            fontSize="small"
+                            sx={{ color: 'red' }}
+                          />
                           % Discount
                         </Box>
                       </MenuItem>
                       <MenuItem value="TIPS">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Box
+                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                        >
                           <TipsIcon fontSize="small" sx={{ color: 'green' }} />
                           Tips
                         </Box>
@@ -717,11 +910,12 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                 </Grid>
 
                 {/* Description/Selection field - hidden for TIPS */}
-                {newItem.itemType === 'TIPS' ? null : newItem.itemType === 'TIRE' ? (
+                {newItem.itemType === 'TIPS' ? null : newItem.itemType ===
+                  'TIRE' ? (
                   <Grid size={{ xs: 12, md: 4 }}>
                     <Autocomplete
-                      options={tires.filter(t => t.quantity > 0)}
-                      value={tires.find(t => t.id === newItem.tireId) || null}
+                      options={tires.filter((t) => t.quantity > 0)}
+                      value={tires.find((t) => t.id === newItem.tireId) || null}
                       onChange={(event, newValue) => {
                         if (newValue) {
                           onTireSelect(newValue.id);
@@ -729,28 +923,48 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       }}
                       getOptionLabel={(tire) => {
                         const name = tire.name || '';
-                        const details = `${tire.brand} ${formatTireType(tire.type)} - ${tire.size}`;
+                        const details = `${tire.brand} ${formatTireType(
+                          tire.type
+                        )} - ${tire.size}`;
                         return name ? `${name} - ${details}` : details;
                       }}
                       renderOption={(props, tire) => {
                         const { key, ...otherProps } = props;
                         return (
                           <Box component="li" key={key} {...otherProps}>
-                            <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', alignItems: 'center' }}>
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                width: '100%',
+                                alignItems: 'center',
+                              }}
+                            >
                               <Box>
                                 {tire.name && (
-                                  <Typography variant="body2" fontWeight="medium">
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight="medium"
+                                  >
                                     {tire.name}
                                   </Typography>
                                 )}
-                                <Typography variant="body2" color={tire.name ? "text.secondary" : "inherit"}>
-                                  {tire.brand} {formatTireType(tire.type)} - {tire.size}
+                                <Typography
+                                  variant="body2"
+                                  color={
+                                    tire.name ? 'text.secondary' : 'inherit'
+                                  }
+                                >
+                                  {tire.brand} {formatTireType(tire.type)} -{' '}
+                                  {tire.size}
                                 </Typography>
                               </Box>
                               <Chip
                                 label={`Stock: ${tire.quantity}`}
                                 size="small"
-                                color={tire.quantity < 5 ? 'warning' : 'success'}
+                                color={
+                                  tire.quantity < 5 ? 'warning' : 'success'
+                                }
                                 sx={{ ml: 1 }}
                               />
                             </Box>
@@ -786,9 +1000,12 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       size="small"
                       label="Description"
                       value={newItem.description}
-                      onChange={(e) => setNewItem({ ...newItem, description: e.target.value })}
+                      onChange={(e) =>
+                        setNewItem({ ...newItem, description: e.target.value })
+                      }
                       placeholder={
-                        newItem.itemType === 'DISCOUNT' || newItem.itemType === 'DISCOUNT_PERCENTAGE'
+                        newItem.itemType === 'DISCOUNT' ||
+                        newItem.itemType === 'DISCOUNT_PERCENTAGE'
                           ? 'e.g., Holiday discount, Loyalty discount...'
                           : 'Enter item description'
                       }
@@ -799,67 +1016,96 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                 {/* Quantity field - hidden for TIPS */}
                 {newItem.itemType !== 'TIPS' && (
                   <Grid size={{ xs: 6, md: 2 }}>
-                    <TextField
+                    <NumberInput
                       fullWidth
                       size="small"
-                      type="number"
                       label="Quantity"
                       value={newItem.quantity}
-                      onChange={(e) => setNewItem({ ...newItem, quantity: parseInt(e.target.value) || 1 })}
-                      inputProps={{ min: 1 }}
+                      onChange={(v) =>
+                        setNewItem({
+                          ...newItem,
+                          quantity: (v ?? '') as unknown as number,
+                        })
+                      }
+                      min={1}
                     />
                   </Grid>
                 )}
 
-                <Grid size={{ xs: newItem.itemType === 'TIPS' ? 12 : 6, md: newItem.itemType === 'TIPS' ? 6 : 2 }}>
-                  <TextField
+                <Grid
+                  size={{
+                    xs: newItem.itemType === 'TIPS' ? 12 : 6,
+                    md: newItem.itemType === 'TIPS' ? 6 : 2,
+                  }}
+                >
+                  <NumberInput
                     fullWidth
                     size="small"
-                    type="number"
-                    label={newItem.itemType === 'DISCOUNT' ? 'Discount Amount' : newItem.itemType === 'DISCOUNT_PERCENTAGE' ? 'Discount Percentage' : newItem.itemType === 'TIPS' ? 'Tips Amount' : 'Unit Price'}
-                    value={newItem.itemType === 'DISCOUNT' ? (newItem.unitPrice ? Math.abs(newItem.unitPrice) : '') : newItem.unitPrice}
-                    onChange={(e) => {
-                      // Allow empty string for clearing the field
-                      if (e.target.value === '') {
-                        setNewItem({ ...newItem, unitPrice: '' as unknown as number });
+                    allowDecimals
+                    label={
+                      newItem.itemType === 'DISCOUNT'
+                        ? 'Discount Amount'
+                        : newItem.itemType === 'DISCOUNT_PERCENTAGE'
+                        ? 'Discount Percentage'
+                        : newItem.itemType === 'TIPS'
+                        ? 'Tips Amount'
+                        : 'Unit Price'
+                    }
+                    value={
+                      newItem.itemType === 'DISCOUNT'
+                        ? newItem.unitPrice
+                          ? Math.abs(newItem.unitPrice)
+                          : ''
+                        : newItem.unitPrice
+                    }
+                    onChange={(v) => {
+                      // Allow empty for clearing the field
+                      if (v === undefined) {
+                        setNewItem({
+                          ...newItem,
+                          unitPrice: '' as unknown as number,
+                        });
                         return;
                       }
-                      const value = parseFloat(e.target.value) || 0;
                       // For discount amount items, automatically make the value negative
                       // For percentage items, keep it positive (we'll handle the negative in calculation)
-                      let finalValue = value;
-                      if (newItem.itemType === 'DISCOUNT' && value > 0) {
-                        finalValue = -value;
+                      let finalValue = v;
+                      if (newItem.itemType === 'DISCOUNT' && v > 0) {
+                        finalValue = -v;
                       }
                       setNewItem({ ...newItem, unitPrice: finalValue });
                     }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                        e.preventDefault();
-                      }
-                    }}
                     InputProps={{
-                      startAdornment: <InputAdornment position="start">
-                        {newItem.itemType === 'DISCOUNT' ? '-$' : newItem.itemType === 'DISCOUNT_PERCENTAGE' ? '' : '$'}
-                      </InputAdornment>,
-                      endAdornment: newItem.itemType === 'DISCOUNT_PERCENTAGE' ? <InputAdornment position="end">%</InputAdornment> : undefined,
+                      startAdornment: (
+                        <InputAdornment position="start">
+                          {newItem.itemType === 'DISCOUNT'
+                            ? '-$'
+                            : newItem.itemType === 'DISCOUNT_PERCENTAGE'
+                            ? ''
+                            : '$'}
+                        </InputAdornment>
+                      ),
+                      endAdornment:
+                        newItem.itemType === 'DISCOUNT_PERCENTAGE' ? (
+                          <InputAdornment position="end">%</InputAdornment>
+                        ) : undefined,
                     }}
-                    inputProps={{
-                      min: newItem.itemType === 'DISCOUNT' ? undefined : 0,
-                      max: newItem.itemType === 'DISCOUNT_PERCENTAGE' ? 100 : undefined,
-                      step: newItem.itemType === 'DISCOUNT_PERCENTAGE' ? 0.1 : 0.01
-                    }}
+                    min={newItem.itemType === 'DISCOUNT' ? undefined : 0}
+                    max={
+                      newItem.itemType === 'DISCOUNT_PERCENTAGE'
+                        ? 100
+                        : undefined
+                    }
                     placeholder={
                       newItem.itemType === 'DISCOUNT'
                         ? 'Enter positive amount'
                         : newItem.itemType === 'DISCOUNT_PERCENTAGE'
-                          ? 'Enter percentage (0-100)'
-                          : undefined
+                        ? 'Enter percentage (0-100)'
+                        : undefined
                     }
                     autoComplete="off"
                   />
                 </Grid>
-
 
                 <Grid size={{ xs: 12, md: 2 }}>
                   <Button
@@ -867,21 +1113,24 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                     variant="contained"
                     startIcon={<AddIcon />}
                     onClick={onAddItem}
-                    disabled={!newItem.description || (
-                      newItem.itemType === 'DISCOUNT' ? newItem.unitPrice === 0 :
-                      newItem.itemType === 'DISCOUNT_PERCENTAGE' ? newItem.unitPrice <= 0 || newItem.unitPrice > 100 :
-                      newItem.unitPrice <= 0
-                    )}
+                    disabled={
+                      !newItem.description ||
+                      (newItem.itemType === 'DISCOUNT'
+                        ? newItem.unitPrice === 0
+                        : newItem.itemType === 'DISCOUNT_PERCENTAGE'
+                        ? newItem.unitPrice <= 0 || newItem.unitPrice > 100
+                        : newItem.unitPrice <= 0)
+                    }
                     sx={{
                       background: colors.primary.main,
                       color: 'white',
-                      '&:hover': { 
+                      '&:hover': {
                         background: colors.primary.dark,
                       },
                       '&:disabled': {
                         background: colors.neutral[300],
-                        color: colors.neutral[500]
-                      }
+                        color: colors.neutral[500],
+                      },
                     }}
                   >
                     Add Item
@@ -891,33 +1140,56 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
             </Box>
 
             {/* Items List */}
-            {items.length > 0 && (
-              isMobile ? (
+            {items.length > 0 &&
+              (isMobile ? (
                 // Mobile Card View - Compact Design
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+                <Box
+                  sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
+                >
                   {items.map((item, index) => (
-                    <Card key={index} sx={{ border: `1px solid ${colors.neutral[200]}` }}>
+                    <Card
+                      key={index}
+                      sx={{ border: `1px solid ${colors.neutral[200]}` }}
+                    >
                       <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
                         {/* Header Row: Type + Description + Action */}
-                        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'flex-start',
+                            gap: 1,
+                            mb: 1,
+                          }}
+                        >
                           <Chip
                             label={item.itemType}
                             size="small"
                             sx={{
                               height: 20,
                               fontSize: '0.688rem',
-                              background: item.itemType === 'TIRE'
-                                ? colors.tire?.new || colors.primary.main
-                                : item.itemType === 'DISCOUNT' || item.itemType === 'DISCOUNT_PERCENTAGE'
+                              background:
+                                item.itemType === 'TIRE'
+                                  ? colors.tire?.new || colors.primary.main
+                                  : item.itemType === 'DISCOUNT' ||
+                                    item.itemType === 'DISCOUNT_PERCENTAGE'
                                   ? '#f44336'
-                                  : colors.service?.maintenance || colors.secondary.main,
+                                  : colors.service?.maintenance ||
+                                    colors.secondary.main,
                               color: 'white',
                               flexShrink: 0,
                             }}
                           />
                           <Box sx={{ flex: 1, minWidth: 0 }}>
                             {(item as any).tireName && (
-                              <Typography variant="body2" fontWeight={600} sx={{ fontSize: '0.813rem', lineHeight: 1.3, mb: 0.25 }}>
+                              <Typography
+                                variant="body2"
+                                fontWeight={600}
+                                sx={{
+                                  fontSize: '0.813rem',
+                                  lineHeight: 1.3,
+                                  mb: 0.25,
+                                }}
+                              >
                                 {(item as any).tireName}
                               </Typography>
                             )}
@@ -926,7 +1198,9 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                               sx={{
                                 fontSize: '0.813rem',
                                 lineHeight: 1.3,
-                                color: (item as any).tireName ? 'text.secondary' : 'text.primary',
+                                color: (item as any).tireName
+                                  ? 'text.secondary'
+                                  : 'text.primary',
                                 overflow: 'hidden',
                                 textOverflow: 'ellipsis',
                                 display: '-webkit-box',
@@ -947,21 +1221,51 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                         </Box>
 
                         {/* Compact Info Row */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1 }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            flexWrap: 'wrap',
+                            gap: 1,
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 2,
+                            }}
+                          >
                             <Box>
-                              <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.688rem' }}>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ fontSize: '0.688rem' }}
+                              >
                                 Qty
                               </Typography>
-                              <Typography variant="body2" fontWeight={500} sx={{ fontSize: '0.813rem' }}>
+                              <Typography
+                                variant="body2"
+                                fontWeight={500}
+                                sx={{ fontSize: '0.813rem' }}
+                              >
                                 {item.quantity}
                               </Typography>
                             </Box>
                             <Box>
-                              <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.688rem' }}>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ fontSize: '0.688rem' }}
+                              >
                                 Price
                               </Typography>
-                              <Typography variant="body2" fontWeight={500} sx={{ fontSize: '0.813rem' }}>
+                              <Typography
+                                variant="body2"
+                                fontWeight={500}
+                                sx={{ fontSize: '0.813rem' }}
+                              >
                                 {item.itemType === 'DISCOUNT_PERCENTAGE'
                                   ? `${item.unitPrice}%`
                                   : formatCurrency(item.unitPrice)}
@@ -969,7 +1273,11 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                             </Box>
                           </Box>
                           <Box sx={{ textAlign: 'right' }}>
-                            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.688rem' }}>
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                              sx={{ fontSize: '0.688rem' }}
+                            >
                               Total
                             </Typography>
                             <Typography
@@ -977,10 +1285,16 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                               fontWeight={600}
                               sx={{
                                 fontSize: '0.938rem',
-                                color: item.itemType === 'DISCOUNT' || item.itemType === 'DISCOUNT_PERCENTAGE' ? '#f44336' : colors.primary.main
+                                color:
+                                  item.itemType === 'DISCOUNT' ||
+                                  item.itemType === 'DISCOUNT_PERCENTAGE'
+                                    ? '#f44336'
+                                    : colors.primary.main,
                               }}
                             >
-                              {formatCurrency(item.total || (item.quantity * item.unitPrice))}
+                              {formatCurrency(
+                                item.total || item.quantity * item.unitPrice
+                              )}
                             </Typography>
                           </Box>
                         </Box>
@@ -990,20 +1304,32 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                 </Box>
               ) : (
                 // Desktop Table View
-                <TableContainer sx={{
-                  borderRadius: 2,
-                  border: `1px solid ${colors.neutral[200]}`,
-                  overflow: 'hidden'
-                }}>
+                <TableContainer
+                  sx={{
+                    borderRadius: 2,
+                    border: `1px solid ${colors.neutral[200]}`,
+                    overflow: 'hidden',
+                  }}
+                >
                   <Table>
                     <TableHead>
                       <TableRow sx={{ background: colors.neutral[100] }}>
                         <TableCell sx={{ fontWeight: 600 }}>Type</TableCell>
-                        <TableCell sx={{ fontWeight: 600 }}>Description</TableCell>
-                        <TableCell align="center" sx={{ fontWeight: 600 }}>Qty</TableCell>
-                        <TableCell align="right" sx={{ fontWeight: 600 }}>Unit Price</TableCell>
-                        <TableCell align="right" sx={{ fontWeight: 600 }}>Total</TableCell>
-                        <TableCell align="center" sx={{ fontWeight: 600 }}>Action</TableCell>
+                        <TableCell sx={{ fontWeight: 600 }}>
+                          Description
+                        </TableCell>
+                        <TableCell align="center" sx={{ fontWeight: 600 }}>
+                          Qty
+                        </TableCell>
+                        <TableCell align="right" sx={{ fontWeight: 600 }}>
+                          Unit Price
+                        </TableCell>
+                        <TableCell align="right" sx={{ fontWeight: 600 }}>
+                          Total
+                        </TableCell>
+                        <TableCell align="center" sx={{ fontWeight: 600 }}>
+                          Action
+                        </TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>
@@ -1012,7 +1338,7 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                           key={index}
                           sx={{
                             '&:hover': { background: colors.neutral[50] },
-                            '&:last-child td': { border: 0 }
+                            '&:last-child td': { border: 0 },
                           }}
                         >
                           <TableCell>
@@ -1020,12 +1346,15 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                               label={item.itemType}
                               size="small"
                               sx={{
-                                background: item.itemType === 'TIRE'
-                                  ? colors.tire?.new || colors.primary.main
-                                  : item.itemType === 'DISCOUNT' || item.itemType === 'DISCOUNT_PERCENTAGE'
+                                background:
+                                  item.itemType === 'TIRE'
+                                    ? colors.tire?.new || colors.primary.main
+                                    : item.itemType === 'DISCOUNT' ||
+                                      item.itemType === 'DISCOUNT_PERCENTAGE'
                                     ? '#f44336'
-                                    : colors.service?.maintenance || colors.secondary.main,
-                                color: 'white'
+                                    : colors.service?.maintenance ||
+                                      colors.secondary.main,
+                                color: 'white',
                               }}
                             />
                           </TableCell>
@@ -1035,7 +1364,14 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                                 {(item as any).tireName}
                               </Typography>
                             )}
-                            <Typography variant="body2" color={(item as any).tireName ? "text.secondary" : "inherit"}>
+                            <Typography
+                              variant="body2"
+                              color={
+                                (item as any).tireName
+                                  ? 'text.secondary'
+                                  : 'inherit'
+                              }
+                            >
                               {item.description}
                             </Typography>
                           </TableCell>
@@ -1045,11 +1381,20 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                               ? `${item.unitPrice}%`
                               : formatCurrency(item.unitPrice)}
                           </TableCell>
-                          <TableCell align="right" sx={{
-                            fontWeight: 600,
-                            color: item.itemType === 'DISCOUNT' || item.itemType === 'DISCOUNT_PERCENTAGE' ? '#f44336' : 'inherit'
-                          }}>
-                            {formatCurrency(item.total || (item.quantity * item.unitPrice))}
+                          <TableCell
+                            align="right"
+                            sx={{
+                              fontWeight: 600,
+                              color:
+                                item.itemType === 'DISCOUNT' ||
+                                item.itemType === 'DISCOUNT_PERCENTAGE'
+                                  ? '#f44336'
+                                  : 'inherit',
+                            }}
+                          >
+                            {formatCurrency(
+                              item.total || item.quantity * item.unitPrice
+                            )}
                           </TableCell>
                           <TableCell align="center">
                             <Tooltip title="Remove item">
@@ -1058,7 +1403,9 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                                 onClick={() => onRemoveItem(index)}
                                 sx={{
                                   color: colors.semantic?.error || 'red',
-                                  '&:hover': { background: 'rgba(255,0,0,0.1)' }
+                                  '&:hover': {
+                                    background: 'rgba(255,0,0,0.1)',
+                                  },
                                 }}
                               >
                                 <DeleteIcon />
@@ -1070,8 +1417,7 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                     </TableBody>
                   </Table>
                 </TableContainer>
-              )
-            )}
+              ))}
 
             {items.length === 0 && (
               <Alert severity="info" sx={{ borderRadius: 2 }}>
@@ -1084,86 +1430,144 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
               <>
                 <Divider sx={{ my: 3 }} />
 
-                <Box sx={{ display: 'flex', justifyContent: { xs: 'flex-start', sm: 'flex-end' } }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: isMobile ? '100%' : 400 }}>
-            {/* Subtotal */}
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Typography variant="body1" color="text.secondary">
-                Subtotal:
-              </Typography>
-              <Typography variant="h6" sx={{ fontWeight: 500 }}>
-                {formatCurrency(subtotal)}
-              </Typography>
-            </Box>
-            
-            {/* GST */}
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                <Typography variant="body1" color="text.secondary">
-                  GST:
-                </Typography>
-                <TextField
-                  size="small"
-                  type="number"
-                  value={(formData.gstRate * 100).toFixed(1)}
-                  onChange={(e) => setFormData({ ...formData, gstRate: parseFloat(e.target.value) / 100 || 0 })}
-                  InputProps={{
-                    endAdornment: <InputAdornment position="end">%</InputAdornment>,
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: { xs: 'flex-start', sm: 'flex-end' },
                   }}
-                  inputProps={{ min: 0, max: 100, step: 0.1 }}
-                  sx={{ width: 100 }}
-                />
-              </Box>
-              <Typography variant="h6" sx={{ fontWeight: 500 }}>
-                {formatCurrency(gstAmount)}
-              </Typography>
-            </Box>
-            
-            {/* PST */}
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                <Typography variant="body1" color="text.secondary">
-                  PST:
-                </Typography>
-                <TextField
-                  size="small"
-                  type="number"
-                  value={(formData.pstRate * 100).toFixed(1)}
-                  onChange={(e) => setFormData({ ...formData, pstRate: parseFloat(e.target.value) / 100 || 0 })}
-                  InputProps={{
-                    endAdornment: <InputAdornment position="end">%</InputAdornment>,
-                  }}
-                  inputProps={{ min: 0, max: 100, step: 0.1 }}
-                  sx={{ width: 100 }}
-                />
-              </Box>
-              <Typography variant="h6" sx={{ fontWeight: 500 }}>
-                {formatCurrency(pstAmount)}
-              </Typography>
-            </Box>
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 2,
+                      width: isMobile ? '100%' : 400,
+                    }}
+                  >
+                    {/* Subtotal */}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <Typography variant="body1" color="text.secondary">
+                        Subtotal:
+                      </Typography>
+                      <Typography variant="h6" sx={{ fontWeight: 500 }}>
+                        {formatCurrency(subtotal)}
+                      </Typography>
+                    </Box>
 
-            <Divider sx={{ my: 1 }} />
-            
-            {/* Grand Total */}
-            <Box sx={{ 
-              display: 'flex', 
-              justifyContent: 'space-between', 
-              alignItems: 'center',
-              p: 2,
-              borderRadius: 2,
-              background: colors.primary.main + '10'
-            }}>
-              <Typography variant="h5" sx={{ fontWeight: 600, color: colors.primary.main }}>
-                Invoice Total:
-              </Typography>
-              <Typography variant="h4" sx={{ fontWeight: 700, color: colors.primary.main }}>
-                {formatCurrency(total)}
-              </Typography>
-            </Box>
-            </Box>
-            </Box>
-            </>
-          )}
+                    {/* GST */}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+                      >
+                        <Typography variant="body1" color="text.secondary">
+                          GST:
+                        </Typography>
+                        <NumberInput
+                          size="small"
+                          allowDecimals
+                          value={(formData.gstRate * 100).toFixed(1)}
+                          onChange={(v) =>
+                            setFormData({
+                              ...formData,
+                              gstRate: (v ?? 0) / 100,
+                            })
+                          }
+                          InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">%</InputAdornment>
+                            ),
+                          }}
+                          min={0}
+                          max={100}
+                          sx={{ width: 100 }}
+                        />
+                      </Box>
+                      <Typography variant="h6" sx={{ fontWeight: 500 }}>
+                        {formatCurrency(gstAmount)}
+                      </Typography>
+                    </Box>
+
+                    {/* PST */}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+                      >
+                        <Typography variant="body1" color="text.secondary">
+                          PST:
+                        </Typography>
+                        <NumberInput
+                          size="small"
+                          allowDecimals
+                          value={(formData.pstRate * 100).toFixed(1)}
+                          onChange={(v) =>
+                            setFormData({
+                              ...formData,
+                              pstRate: (v ?? 0) / 100,
+                            })
+                          }
+                          InputProps={{
+                            endAdornment: (
+                              <InputAdornment position="end">%</InputAdornment>
+                            ),
+                          }}
+                          min={0}
+                          max={100}
+                          sx={{ width: 100 }}
+                        />
+                      </Box>
+                      <Typography variant="h6" sx={{ fontWeight: 500 }}>
+                        {formatCurrency(pstAmount)}
+                      </Typography>
+                    </Box>
+
+                    <Divider sx={{ my: 1 }} />
+
+                    {/* Grand Total */}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        p: 2,
+                        borderRadius: 2,
+                        background: colors.primary.main + '10',
+                      }}
+                    >
+                      <Typography
+                        variant="h5"
+                        sx={{ fontWeight: 600, color: colors.primary.main }}
+                      >
+                        Invoice Total:
+                      </Typography>
+                      <Typography
+                        variant="h4"
+                        sx={{ fontWeight: 700, color: colors.primary.main }}
+                      >
+                        {formatCurrency(total)}
+                      </Typography>
+                    </Box>
+                  </Box>
+                </Box>
+              </>
+            )}
 
             {items.length > 0 && (
               <Alert severity="success" sx={{ mt: 3 }}>

--- a/apps/webApp/src/app/components/invoices/PaymentMethodDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/PaymentMethodDialog.tsx
@@ -14,7 +14,6 @@ import {
   IconButton,
   FormControlLabel,
   Checkbox,
-  TextField,
   Alert,
 } from '@mui/material';
 import {
@@ -24,6 +23,7 @@ import {
   Delete as DeleteIcon,
 } from '@mui/icons-material';
 import { PaymentMethod } from '../../../enums';
+import { NumberInput } from '../common';
 
 export interface PaymentEntryInput {
   paymentMethod: PaymentMethod;
@@ -207,14 +207,16 @@ export const PaymentMethodDialog: React.FC<PaymentMethodDialogProps> = ({
               </FormControl>
 
               {(isSplit || !payInFull) && (
-                <TextField
-                  type="number"
+                <NumberInput
+                  allowDecimals
                   label="Amount"
                   value={line.amount}
-                  onChange={(e) =>
-                    updateLine(index, { amount: e.target.value })
+                  onChange={(v) =>
+                    updateLine(index, {
+                      amount: v === undefined ? '' : String(v),
+                    })
                   }
-                  inputProps={{ min: 0, step: '0.01' }}
+                  min={0}
                   sx={{ width: 130 }}
                 />
               )}

--- a/apps/webApp/src/app/components/payroll/CreateJobDialog.tsx
+++ b/apps/webApp/src/app/components/payroll/CreateJobDialog.tsx
@@ -29,6 +29,7 @@ import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { CreateJobDto, JobType } from '@gt-automotive/data';
+import { NumberInput } from '../../components/common';
 import { jobService } from '../../requests/job.requests';
 import { userService } from '../../requests/user.requests';
 import { useAuth } from '../../hooks/useAuth';
@@ -38,7 +39,7 @@ const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
     children: React.ReactElement;
   },
-  ref: React.Ref<unknown>,
+  ref: React.Ref<unknown>
 ) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
@@ -103,7 +104,12 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
     try {
       const users = await userService.getUsers();
       // Include STAFF, ADMIN, and SUPERVISOR users in the dropdown
-      const staffAndAdmins = users.filter(u => u.role?.name === 'STAFF' || u.role?.name === 'ADMIN' || u.role?.name === 'SUPERVISOR');
+      const staffAndAdmins = users.filter(
+        (u) =>
+          u.role?.name === 'STAFF' ||
+          u.role?.name === 'ADMIN' ||
+          u.role?.name === 'SUPERVISOR'
+      );
       setEmployees(staffAndAdmins);
     } catch (err) {
       console.error('Failed to fetch employees:', err);
@@ -112,14 +118,19 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
   };
 
   const handleInputChange = (field: keyof CreateJobDto, value: any) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [field]: value
+      [field]: value,
     }));
   };
 
   const handleSubmit = async () => {
-    if (!formData.employeeId || !formData.title || !formData.payAmount || Number(formData.payAmount) <= 0) {
+    if (
+      !formData.employeeId ||
+      !formData.title ||
+      !formData.payAmount ||
+      Number(formData.payAmount) <= 0
+    ) {
       setError('Please fill in all required fields');
       return;
     }
@@ -133,7 +144,8 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
         title: formData.title,
         payAmount: Number(formData.payAmount),
         jobType: formData.jobType,
-        ...(formData.description && formData.description.trim() && { description: formData.description }),
+        ...(formData.description &&
+          formData.description.trim() && { description: formData.description }),
         ...(formData.dueDate && { dueDate: formData.dueDate }),
       };
 
@@ -148,7 +160,9 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
   };
 
   const getEmployeeName = (employee: Employee) => {
-    const name = [employee.firstName, employee.lastName].filter(Boolean).join(' ');
+    const name = [employee.firstName, employee.lastName]
+      .filter(Boolean)
+      .join(' ');
     return name || employee.email;
   };
 
@@ -169,7 +183,7 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
             display: 'flex',
             flexDirection: 'column',
             height: '100vh',
-          })
+          }),
         },
       }}
     >
@@ -184,7 +198,7 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
           px: { xs: 2, sm: 3 },
           ...(isMobile && {
             flexShrink: 0,
-          })
+          }),
         }}
       >
         <WorkIcon />
@@ -204,11 +218,18 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
             flex: '1 1 auto',
             overflowY: 'auto',
             minHeight: 0,
-          })
+          }),
         }}
       >
         <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: { xs: 2, sm: 3 }, p: { xs: 2, sm: 3 } }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: { xs: 2, sm: 3 },
+              p: { xs: 2, sm: 3 },
+            }}
+          >
             {error && (
               <Alert severity="error" sx={{ mb: 2 }}>
                 {error}
@@ -220,7 +241,9 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
                 <InputLabel>Employee</InputLabel>
                 <Select
                   value={formData.employeeId}
-                  onChange={(e) => handleInputChange('employeeId', e.target.value)}
+                  onChange={(e) =>
+                    handleInputChange('employeeId', e.target.value)
+                  }
                   label="Employee"
                 >
                   {employees.map((employee) => (
@@ -254,18 +277,16 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
             />
 
             <Box sx={{ display: 'flex', gap: 2 }}>
-              <TextField
+              <NumberInput
                 fullWidth
                 required
-                type="number"
+                allowDecimals
+                min={0}
                 label="Payment Amount"
                 value={formData.payAmount}
-                onChange={(e) => handleInputChange('payAmount', e.target.value === '' ? '' : parseFloat(e.target.value) || 0)}
-                onKeyDown={(e) => {
-                  if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                    e.preventDefault();
-                  }
-                }}
+                onChange={(v) =>
+                  handleInputChange('payAmount', (v ?? '') as unknown as number)
+                }
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
@@ -273,7 +294,6 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
                     </InputAdornment>
                   ),
                 }}
-                inputProps={{ min: 0, step: 0.01 }}
                 autoComplete="off"
               />
 
@@ -296,7 +316,9 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
             <DateTimePicker
               label="Due Date (Optional)"
               value={formData.dueDate ? new Date(formData.dueDate) : null}
-              onChange={(date) => handleInputChange('dueDate', date?.toISOString() || '')}
+              onChange={(date) =>
+                handleInputChange('dueDate', date?.toISOString() || '')
+              }
               slotProps={{
                 textField: {
                   fullWidth: true,
@@ -316,7 +338,7 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
             flexShrink: 0,
             backgroundColor: 'white',
             borderTop: `1px solid ${colors.neutral[200]}`,
-          })
+          }),
         }}
       >
         <Button
@@ -330,13 +352,29 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
         </Button>
         <Button
           onClick={handleSubmit}
-          variant={!formData.employeeId || !formData.title || !formData.payAmount || Number(formData.payAmount) <= 0 ? 'outlined' : 'contained'}
+          variant={
+            !formData.employeeId ||
+            !formData.title ||
+            !formData.payAmount ||
+            Number(formData.payAmount) <= 0
+              ? 'outlined'
+              : 'contained'
+          }
           size="large"
-          disabled={loading || !formData.employeeId || !formData.title || !formData.payAmount || Number(formData.payAmount) <= 0}
+          disabled={
+            loading ||
+            !formData.employeeId ||
+            !formData.title ||
+            !formData.payAmount ||
+            Number(formData.payAmount) <= 0
+          }
           fullWidth={isMobile}
           sx={{
             minWidth: isMobile ? 'auto' : 120,
-            ...(!formData.employeeId || !formData.title || !formData.payAmount || Number(formData.payAmount) <= 0
+            ...(!formData.employeeId ||
+            !formData.title ||
+            !formData.payAmount ||
+            Number(formData.payAmount) <= 0
               ? {
                   borderColor: colors.neutral[300],
                   color: colors.neutral[400],

--- a/apps/webApp/src/app/components/payroll/EditJobDialog.tsx
+++ b/apps/webApp/src/app/components/payroll/EditJobDialog.tsx
@@ -26,7 +26,13 @@ import { TransitionProps } from '@mui/material/transitions';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { UpdateJobDto, JobType, JobStatus, JobResponseDto } from '@gt-automotive/data';
+import {
+  UpdateJobDto,
+  JobType,
+  JobStatus,
+  JobResponseDto,
+} from '@gt-automotive/data';
+import { NumberInput } from '../../components/common';
 import { jobService } from '../../requests/job.requests';
 // import { userService } from '../../requests/user.requests'; // TODO: Use for employee reassignment
 import { colors } from '../../theme/colors';
@@ -35,7 +41,7 @@ const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
     children: React.ReactElement;
   },
-  ref: React.Ref<unknown>,
+  ref: React.Ref<unknown>
 ) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
@@ -69,7 +75,7 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
   const [formData, setFormData] = useState<UpdateJobDto>({
     title: '',
     description: '',
-    payAmount: 0,
+    payAmount: '' as unknown as number,
     status: JobStatus.PENDING,
     jobType: JobType.REGULAR,
     dueDate: '',
@@ -82,11 +88,13 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
       const formDataToSet = {
         title: job.title || '',
         description: job.description || '',
-        payAmount: job.payAmount || 0,
+        payAmount: (job.payAmount ?? '') as unknown as number,
         status: job.status || JobStatus.PENDING,
         jobType: job.jobType || JobType.REGULAR,
         dueDate: job.dueDate ? new Date(job.dueDate).toISOString() : '',
-        completedAt: job.completedAt ? new Date(job.completedAt).toISOString() : '',
+        completedAt: job.completedAt
+          ? new Date(job.completedAt).toISOString()
+          : '',
       };
       setFormData(formDataToSet);
       setError(null);
@@ -95,7 +103,7 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
       setFormData({
         title: '',
         description: '',
-        payAmount: 0,
+        payAmount: '' as unknown as number,
         status: JobStatus.PENDING,
         jobType: JobType.REGULAR,
         dueDate: '',
@@ -118,14 +126,19 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
   };
 
   const handleInputChange = (field: keyof UpdateJobDto, value: any) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [field]: value
+      [field]: value,
     }));
   };
 
   const handleSubmit = async () => {
-    if (!job || !formData.title || !formData.payAmount || formData.payAmount <= 0) {
+    if (
+      !job ||
+      !formData.title ||
+      !formData.payAmount ||
+      formData.payAmount <= 0
+    ) {
       setError('Please fill in all required fields');
       return;
     }
@@ -139,7 +152,8 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
         payAmount: formData.payAmount,
         status: formData.status,
         jobType: formData.jobType,
-        ...(formData.description && formData.description.trim() && { description: formData.description }),
+        ...(formData.description &&
+          formData.description.trim() && { description: formData.description }),
         ...(formData.dueDate && { dueDate: formData.dueDate }),
         ...(formData.completedAt && { completedAt: formData.completedAt }),
       };
@@ -155,7 +169,9 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
   };
 
   const getEmployeeName = (employee: Employee) => {
-    const name = [employee.firstName, employee.lastName].filter(Boolean).join(' ');
+    const name = [employee.firstName, employee.lastName]
+      .filter(Boolean)
+      .join(' ');
     return name || employee.email;
   };
 
@@ -203,7 +219,8 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
 
             {job && (
               <Alert severity="info" sx={{ mb: 2 }}>
-                Employee: {job.employee ? getEmployeeName(job.employee) : 'Unknown'}
+                Employee:{' '}
+                {job.employee ? getEmployeeName(job.employee) : 'Unknown'}
               </Alert>
             )}
 
@@ -227,13 +244,16 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
             />
 
             <Box sx={{ display: 'flex', gap: 2 }}>
-              <TextField
+              <NumberInput
                 fullWidth
                 required
-                type="number"
+                allowDecimals
+                min={0}
                 label="Payment Amount"
                 value={formData.payAmount}
-                onChange={(e) => handleInputChange('payAmount', parseFloat(e.target.value) || 0)}
+                onChange={(v) =>
+                  handleInputChange('payAmount', (v ?? '') as unknown as number)
+                }
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
@@ -241,7 +261,6 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
                     </InputAdornment>
                   ),
                 }}
-                inputProps={{ min: 0, step: 0.01 }}
               />
 
               <FormControl fullWidth required>
@@ -266,16 +285,22 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
                   <InputLabel>Status</InputLabel>
                   <Select
                     value={formData.status}
-                    onChange={(e) => handleInputChange('status', e.target.value)}
+                    onChange={(e) =>
+                      handleInputChange('status', e.target.value)
+                    }
                     label="Status"
                   >
                     {Object.values(JobStatus)
-                      .filter(status => status !== JobStatus.PAID && status !== JobStatus.PARTIALLY_PAID)
+                      .filter(
+                        (status) =>
+                          status !== JobStatus.PAID &&
+                          status !== JobStatus.PARTIALLY_PAID
+                      )
                       .map((status) => (
-                      <MenuItem key={status} value={status}>
-                        {status.replace('_', ' ')}
-                      </MenuItem>
-                    ))}
+                        <MenuItem key={status} value={status}>
+                          {status.replace('_', ' ')}
+                        </MenuItem>
+                      ))}
                   </Select>
                 </FormControl>
               )}
@@ -292,7 +317,9 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
               <DateTimePicker
                 label="Due Date (Optional)"
                 value={formData.dueDate ? new Date(formData.dueDate) : null}
-                onChange={(date) => handleInputChange('dueDate', date?.toISOString() || '')}
+                onChange={(date) =>
+                  handleInputChange('dueDate', date?.toISOString() || '')
+                }
                 slotProps={{
                   textField: {
                     fullWidth: true,
@@ -305,8 +332,12 @@ export const EditJobDialog: React.FC<EditJobDialogProps> = ({
             {formData.status === JobStatus.READY && (
               <DateTimePicker
                 label="Completed At"
-                value={formData.completedAt ? new Date(formData.completedAt) : null}
-                onChange={(date) => handleInputChange('completedAt', date?.toISOString() || '')}
+                value={
+                  formData.completedAt ? new Date(formData.completedAt) : null
+                }
+                onChange={(date) =>
+                  handleInputChange('completedAt', date?.toISOString() || '')
+                }
                 slotProps={{
                   textField: {
                     fullWidth: true,

--- a/apps/webApp/src/app/components/payroll/ProcessPaymentDialog.tsx
+++ b/apps/webApp/src/app/components/payroll/ProcessPaymentDialog.tsx
@@ -39,6 +39,7 @@ import {
 import { TransitionProps } from '@mui/material/transitions';
 import { ProcessPaymentDto, JobResponseDto } from '@gt-automotive/data';
 import { PaymentMethod } from '@gt-automotive/data';
+import { NumberInput } from '../../components/common';
 import { paymentService } from '../../requests/payment.requests';
 import { useAuth } from '../../hooks/useAuth';
 import { colors } from '../../theme/colors';
@@ -47,7 +48,7 @@ const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
     children: React.ReactElement;
   },
-  ref: React.Ref<unknown>,
+  ref: React.Ref<unknown>
 ) {
   return <Slide direction="up" ref={ref} {...props} />;
 });
@@ -104,11 +105,14 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
   }, [open, job, user]);
 
   // Calculate total amount for selected jobs
-  const selectedJobs = allJobs.filter(j => selectedJobIds.has(j.id));
-  const totalSelectedAmount = selectedJobs.reduce((sum, j) => sum + j.payAmount, 0);
+  const selectedJobs = allJobs.filter((j) => selectedJobIds.has(j.id));
+  const totalSelectedAmount = selectedJobs.reduce(
+    (sum, j) => sum + j.payAmount,
+    0
+  );
 
   const handleJobToggle = (jobId: string) => {
-    setSelectedJobIds(prev => {
+    setSelectedJobIds((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(jobId)) {
         newSet.delete(jobId);
@@ -125,7 +129,7 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
       setSelectedJobIds(new Set());
     } else {
       // Select all
-      setSelectedJobIds(new Set(allJobs.map(j => j.id)));
+      setSelectedJobIds(new Set(allJobs.map((j) => j.id)));
     }
   };
 
@@ -134,9 +138,9 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
   useEffect(() => {
     if (selectedJobIds.size > 0) {
       const total = allJobs
-        .filter(j => selectedJobIds.has(j.id))
+        .filter((j) => selectedJobIds.has(j.id))
         .reduce((sum, j) => sum + j.payAmount, 0);
-      setFormData(prev => {
+      setFormData((prev) => {
         // Only update if the amount actually changed to prevent unnecessary re-renders
         if (prev.amount !== total) {
           return { ...prev, amount: total };
@@ -147,9 +151,9 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
   }, [selectedJobIds, allJobs.length]);
 
   const handleInputChange = (field: keyof ProcessPaymentDto, value: any) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      [field]: value
+      [field]: value,
     }));
   };
 
@@ -174,8 +178,8 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
 
     try {
       // Process payments for all selected jobs
-      const paymentPromises = Array.from(selectedJobIds).map(jobId => {
-        const selectedJob = allJobs.find(j => j.id === jobId);
+      const paymentPromises = Array.from(selectedJobIds).map((jobId) => {
+        const selectedJob = allJobs.find((j) => j.id === jobId);
         if (!selectedJob) return Promise.resolve(null);
 
         return paymentService.processPayment({
@@ -207,7 +211,9 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
 
   const getEmployeeName = (employee: any) => {
     if (!employee) return 'Unknown';
-    const name = [employee.firstName, employee.lastName].filter(Boolean).join(' ');
+    const name = [employee.firstName, employee.lastName]
+      .filter(Boolean)
+      .join(' ');
     return name || employee.email;
   };
 
@@ -239,22 +245,37 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
       >
         <PaymentIcon sx={{ fontSize: isMobile ? 20 : 24 }} />
         <Box sx={{ flex: 1 }}>
-          <Typography variant={isMobile ? 'h6' : 'h5'} component="div" sx={{ fontWeight: 600 }}>
+          <Typography
+            variant={isMobile ? 'h6' : 'h5'}
+            component="div"
+            sx={{ fontWeight: 600 }}
+          >
             Process Payment{selectedJobIds.size > 1 ? 's' : ''}
           </Typography>
           {selectedJobIds.size > 0 && (
             <Typography variant="caption" sx={{ opacity: 0.9 }}>
-              {selectedJobIds.size} job{selectedJobIds.size > 1 ? 's' : ''} selected
+              {selectedJobIds.size} job{selectedJobIds.size > 1 ? 's' : ''}{' '}
+              selected
             </Typography>
           )}
         </Box>
-        <IconButton onClick={onClose} sx={{ color: 'white' }} size={isMobile ? 'small' : 'medium'}>
+        <IconButton
+          onClick={onClose}
+          sx={{ color: 'white' }}
+          size={isMobile ? 'small' : 'medium'}
+        >
           <CloseIcon />
         </IconButton>
       </DialogTitle>
 
       <DialogContent sx={{ p: isMobile ? 2 : 3 }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 2 : 3 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: isMobile ? 2 : 3,
+          }}
+        >
           {error && (
             <Alert severity="error" sx={{ mb: isMobile ? 1 : 2 }}>
               {error}
@@ -263,24 +284,54 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
 
           {/* All Jobs List - Show when processing multiple jobs */}
           {allJobs.length > 0 && (
-            <Card sx={{ backgroundColor: colors.primary.light + '10', border: `1px solid ${colors.primary.light}` }}>
+            <Card
+              sx={{
+                backgroundColor: colors.primary.light + '10',
+                border: `1px solid ${colors.primary.light}`,
+              }}
+            >
               <CardContent sx={{ p: isMobile ? 1.5 : 2 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.5 }}>
-                  <Typography variant={isMobile ? 'subtitle1' : 'h6'} sx={{ display: 'flex', alignItems: 'center', gap: 1, fontWeight: 600, color: colors.primary.main }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    mb: 1.5,
+                  }}
+                >
+                  <Typography
+                    variant={isMobile ? 'subtitle1' : 'h6'}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      fontWeight: 600,
+                      color: colors.primary.main,
+                    }}
+                  >
                     <WorkIcon sx={{ fontSize: isMobile ? 18 : 24 }} />
                     Jobs Ready for Payment ({allJobs.length})
                   </Typography>
                   <FormControlLabel
                     control={
                       <Checkbox
-                        checked={selectedJobIds.size === allJobs.length && allJobs.length > 0}
-                        indeterminate={selectedJobIds.size > 0 && selectedJobIds.size < allJobs.length}
+                        checked={
+                          selectedJobIds.size === allJobs.length &&
+                          allJobs.length > 0
+                        }
+                        indeterminate={
+                          selectedJobIds.size > 0 &&
+                          selectedJobIds.size < allJobs.length
+                        }
                         onChange={handleSelectAll}
                         size={isMobile ? 'small' : 'medium'}
                       />
                     }
                     label={
-                      <Typography variant={isMobile ? 'caption' : 'body2'} fontWeight={600}>
+                      <Typography
+                        variant={isMobile ? 'caption' : 'body2'}
+                        fontWeight={600}
+                      >
                         Select All
                       </Typography>
                     }
@@ -289,9 +340,17 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
                 </Box>
 
                 {selectedJobIds.size > 0 && (
-                  <Alert severity="info" sx={{ mb: 1.5, py: isMobile ? 0.5 : 1 }}>
-                    <Typography variant={isMobile ? 'caption' : 'body2'} fontWeight={600}>
-                      {selectedJobIds.size} job{selectedJobIds.size > 1 ? 's' : ''} selected • Total: ${totalSelectedAmount.toFixed(2)}
+                  <Alert
+                    severity="info"
+                    sx={{ mb: 1.5, py: isMobile ? 0.5 : 1 }}
+                  >
+                    <Typography
+                      variant={isMobile ? 'caption' : 'body2'}
+                      fontWeight={600}
+                    >
+                      {selectedJobIds.size} job
+                      {selectedJobIds.size > 1 ? 's' : ''} selected • Total: $
+                      {totalSelectedAmount.toFixed(2)}
                     </Typography>
                   </Alert>
                 )}
@@ -299,7 +358,9 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
                 <List dense sx={{ py: 0 }}>
                   {allJobs.map((listJob, index) => {
                     const isSelected = selectedJobIds.has(listJob.id);
-                    const isPastJob = index < (progressInfo?.current ? progressInfo.current - 1 : 0);
+                    const isPastJob =
+                      index <
+                      (progressInfo?.current ? progressInfo.current - 1 : 0);
                     return (
                       <ListItem
                         key={listJob.id}
@@ -308,11 +369,17 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
                           py: isMobile ? 0.5 : 1,
                           borderRadius: 1,
                           mb: 0.5,
-                          backgroundColor: isSelected ? colors.semantic.successLight + '20' : 'transparent',
-                          border: isSelected ? `2px solid ${colors.semantic.success}` : '1px solid ' + colors.neutral[200],
+                          backgroundColor: isSelected
+                            ? colors.semantic.successLight + '20'
+                            : 'transparent',
+                          border: isSelected
+                            ? `2px solid ${colors.semantic.success}`
+                            : '1px solid ' + colors.neutral[200],
                           cursor: 'pointer',
                           '&:hover': {
-                            backgroundColor: isSelected ? colors.semantic.successLight + '30' : colors.neutral[50],
+                            backgroundColor: isSelected
+                              ? colors.semantic.successLight + '30'
+                              : colors.neutral[50],
                           },
                         }}
                         onClick={() => handleJobToggle(listJob.id)}
@@ -331,15 +398,37 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
                         </ListItemIcon>
                         <ListItemIcon sx={{ minWidth: isMobile ? 32 : 40 }}>
                           {isPastJob ? (
-                            <CheckCircleIcon sx={{ color: colors.semantic.success, fontSize: isMobile ? 18 : 24 }} />
+                            <CheckCircleIcon
+                              sx={{
+                                color: colors.semantic.success,
+                                fontSize: isMobile ? 18 : 24,
+                              }}
+                            />
                           ) : (
-                            <PaymentIcon sx={{ color: isSelected ? colors.semantic.success : colors.neutral[400], fontSize: isMobile ? 18 : 24 }} />
+                            <PaymentIcon
+                              sx={{
+                                color: isSelected
+                                  ? colors.semantic.success
+                                  : colors.neutral[400],
+                                fontSize: isMobile ? 18 : 24,
+                              }}
+                            />
                           )}
                         </ListItemIcon>
                         <ListItemText
                           primary={
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                              <Typography variant={isMobile ? 'body2' : 'body1'} fontWeight={isSelected ? 600 : 500}>
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 1,
+                                flexWrap: 'wrap',
+                              }}
+                            >
+                              <Typography
+                                variant={isMobile ? 'body2' : 'body1'}
+                                fontWeight={isSelected ? 600 : 500}
+                              >
                                 {listJob.title}
                               </Typography>
                               {isPastJob && (
@@ -359,16 +448,40 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
                           }
                           secondary={
                             <Box component="span" sx={{ display: 'block' }}>
-                              <Typography component="span" variant={isMobile ? 'caption' : 'body2'} color="text.secondary" sx={{ display: 'block' }}>
-                                ${listJob.payAmount.toFixed(2)} • {getEmployeeName(listJob.employee)}
+                              <Typography
+                                component="span"
+                                variant={isMobile ? 'caption' : 'body2'}
+                                color="text.secondary"
+                                sx={{ display: 'block' }}
+                              >
+                                ${listJob.payAmount.toFixed(2)} •{' '}
+                                {getEmployeeName(listJob.employee)}
                               </Typography>
                               {listJob.appointment && (
-                                <Typography component="span" variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.7rem' }}>
-                                  Appt: {(() => {
+                                <Typography
+                                  component="span"
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ display: 'block', fontSize: '0.7rem' }}
+                                >
+                                  Appt:{' '}
+                                  {(() => {
                                     const d = listJob.appointment.scheduledDate;
-                                    const dateStr = typeof d === 'string' ? d.split('T')[0] : new Date(d).toISOString().split('T')[0];
+                                    const dateStr =
+                                      typeof d === 'string'
+                                        ? d.split('T')[0]
+                                        : new Date(d)
+                                            .toISOString()
+                                            .split('T')[0];
                                     return `${dateStr} ${listJob.appointment.scheduledTime}`;
-                                  })()} · <Box component="span" sx={{ fontFamily: 'monospace' }}>ID: {listJob.appointment.id}</Box>
+                                  })()}{' '}
+                                  ·{' '}
+                                  <Box
+                                    component="span"
+                                    sx={{ fontFamily: 'monospace' }}
+                                  >
+                                    ID: {listJob.appointment.id}
+                                  </Box>
                                 </Typography>
                               )}
                             </Box>
@@ -385,38 +498,78 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
           {allJobs.length === 0 && <Divider />}
 
           {/* Payment Form */}
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: isMobile ? 2 : 3 }}>
-            <Typography variant={isMobile ? 'subtitle1' : 'h6'} sx={{ display: 'flex', alignItems: 'center', gap: 1, fontWeight: 600 }}>
-              <PaymentIcon sx={{ color: colors.semantic.success, fontSize: isMobile ? 18 : 24 }} />
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: isMobile ? 2 : 3,
+            }}
+          >
+            <Typography
+              variant={isMobile ? 'subtitle1' : 'h6'}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                fontWeight: 600,
+              }}
+            >
+              <PaymentIcon
+                sx={{
+                  color: colors.semantic.success,
+                  fontSize: isMobile ? 18 : 24,
+                }}
+              />
               Payment Information
             </Typography>
 
-            <Box sx={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: 2 }}>
-              <TextField
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: isMobile ? 'column' : 'row',
+                gap: 2,
+              }}
+            >
+              <NumberInput
                 fullWidth
                 required
-                type="number"
+                allowDecimals
+                min={0}
                 label="Payment Amount"
                 value={formData.amount}
-                onChange={(e) => handleInputChange('amount', parseFloat(e.target.value) || 0)}
+                onChange={(v) =>
+                  handleInputChange('amount', (v ?? '') as unknown as number)
+                }
                 size={isMobile ? 'small' : 'medium'}
                 disabled
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
-                      <MoneyIcon sx={{ color: colors.semantic.success, fontSize: isMobile ? 18 : 24 }} />
+                      <MoneyIcon
+                        sx={{
+                          color: colors.semantic.success,
+                          fontSize: isMobile ? 18 : 24,
+                        }}
+                      />
                     </InputAdornment>
                   ),
                 }}
-                inputProps={{ min: 0, step: 0.01 }}
-                helperText={`Total amount for ${selectedJobIds.size} selected job${selectedJobIds.size > 1 ? 's' : ''}`}
+                helperText={`Total amount for ${
+                  selectedJobIds.size
+                } selected job${selectedJobIds.size > 1 ? 's' : ''}`}
               />
 
-              <FormControl fullWidth required size={isMobile ? 'small' : 'medium'}>
+              <FormControl
+                fullWidth
+                required
+                size={isMobile ? 'small' : 'medium'}
+              >
                 <InputLabel>Payment Method</InputLabel>
                 <Select
                   value={formData.paymentMethod}
-                  onChange={(e) => handleInputChange('paymentMethod', e.target.value)}
+                  onChange={(e) =>
+                    handleInputChange('paymentMethod', e.target.value)
+                  }
                   label="Payment Method"
                 >
                   {Object.values(PaymentMethod).map((method) => (
@@ -443,31 +596,80 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
           {/* Payment Summary */}
           <Card sx={{ backgroundColor: colors.semantic.successLight + '20' }}>
             <CardContent sx={{ p: isMobile ? 1.5 : 2 }}>
-              <Typography variant={isMobile ? 'subtitle1' : 'h6'} gutterBottom sx={{ color: colors.semantic.successDark, fontWeight: 600 }}>
+              <Typography
+                variant={isMobile ? 'subtitle1' : 'h6'}
+                gutterBottom
+                sx={{ color: colors.semantic.successDark, fontWeight: 600 }}
+              >
                 Payment Summary
               </Typography>
               {selectedJobIds.size > 0 && (
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: isMobile ? 0.5 : 1 }}>
-                  <Typography variant={isMobile ? 'body2' : 'body1'}>Jobs Selected:</Typography>
-                  <Typography variant={isMobile ? 'body2' : 'body1'} fontWeight="bold">{selectedJobIds.size}</Typography>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    mb: isMobile ? 0.5 : 1,
+                  }}
+                >
+                  <Typography variant={isMobile ? 'body2' : 'body1'}>
+                    Jobs Selected:
+                  </Typography>
+                  <Typography
+                    variant={isMobile ? 'body2' : 'body1'}
+                    fontWeight="bold"
+                  >
+                    {selectedJobIds.size}
+                  </Typography>
                 </Box>
               )}
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: isMobile ? 0.5 : 1 }}>
-                <Typography variant={isMobile ? 'body2' : 'body1'}>Total Payment Amount:</Typography>
-                <Typography variant={isMobile ? 'body2' : 'body1'} fontWeight="bold" color={colors.semantic.success}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  mb: isMobile ? 0.5 : 1,
+                }}
+              >
+                <Typography variant={isMobile ? 'body2' : 'body1'}>
+                  Total Payment Amount:
+                </Typography>
+                <Typography
+                  variant={isMobile ? 'body2' : 'body1'}
+                  fontWeight="bold"
+                  color={colors.semantic.success}
+                >
                   ${totalSelectedAmount.toFixed(2)}
                 </Typography>
               </Box>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: isMobile ? 0.5 : 1 }}>
-                <Typography variant={isMobile ? 'body2' : 'body1'}>Payment Method:</Typography>
-                <Typography variant={isMobile ? 'body2' : 'body1'} fontWeight="medium">{formData.paymentMethod.replace('_', ' ')}</Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  mb: isMobile ? 0.5 : 1,
+                }}
+              >
+                <Typography variant={isMobile ? 'body2' : 'body1'}>
+                  Payment Method:
+                </Typography>
+                <Typography
+                  variant={isMobile ? 'body2' : 'body1'}
+                  fontWeight="medium"
+                >
+                  {formData.paymentMethod.replace('_', ' ')}
+                </Typography>
               </Box>
             </CardContent>
           </Card>
         </Box>
       </DialogContent>
 
-      <DialogActions sx={{ p: isMobile ? 2 : 3, pt: 0, gap: 1, flexDirection: isMobile ? 'column-reverse' : 'row' }}>
+      <DialogActions
+        sx={{
+          p: isMobile ? 2 : 3,
+          pt: 0,
+          gap: 1,
+          flexDirection: isMobile ? 'column-reverse' : 'row',
+        }}
+      >
         <Button
           onClick={onClose}
           variant="outlined"
@@ -481,7 +683,12 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
           onClick={handleSubmit}
           variant="contained"
           size={isMobile ? 'large' : 'large'}
-          disabled={loading || selectedJobIds.size === 0 || !formData.amount || formData.amount <= 0}
+          disabled={
+            loading ||
+            selectedJobIds.size === 0 ||
+            !formData.amount ||
+            formData.amount <= 0
+          }
           fullWidth={isMobile}
           sx={{
             minWidth: isMobile ? '100%' : 120,
@@ -490,8 +697,9 @@ export const ProcessPaymentDialog: React.FC<ProcessPaymentDialogProps> = ({
         >
           {loading
             ? 'Processing...'
-            : `Process ${selectedJobIds.size} Payment${selectedJobIds.size > 1 ? 's' : ''}`
-          }
+            : `Process ${selectedJobIds.size} Payment${
+                selectedJobIds.size > 1 ? 's' : ''
+              }`}
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/webApp/src/app/components/purchase-expense-invoices/PurchaseExpenseInvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/purchase-expense-invoices/PurchaseExpenseInvoiceDialog.tsx
@@ -35,6 +35,7 @@ import purchaseExpenseInvoiceService, {
 } from '../../requests/purchase-expense-invoice.requests';
 import vendorService, { Vendor } from '../../requests/vendor.requests';
 import VendorSelect from '../vendors/VendorSelect';
+import { NumberInput } from '../common';
 
 interface PurchaseExpenseInvoiceDialogProps {
   open: boolean;
@@ -160,9 +161,8 @@ const PurchaseExpenseInvoiceDialog: React.FC<
   };
 
   // Handle amount (subtotal) change - forward calculation
-  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    const subtotal = parseFloat(value) || 0;
+  const handleAmountChange = (value: number | undefined) => {
+    const subtotal = value ?? 0;
     const { gstAmount, pstAmount, hstAmount, total } = calculateFromSubtotal(
       subtotal,
       Number(formData.gstRate),
@@ -172,7 +172,7 @@ const PurchaseExpenseInvoiceDialog: React.FC<
 
     setFormData((prev) => ({
       ...prev,
-      amount: value,
+      amount: value ?? '',
       gstAmount: gstAmount > 0 ? Math.round(gstAmount * 100) / 100 : '',
       pstAmount: pstAmount > 0 ? Math.round(pstAmount * 100) / 100 : '',
       hstAmount: hstAmount > 0 ? Math.round(hstAmount * 100) / 100 : '',
@@ -182,9 +182,8 @@ const PurchaseExpenseInvoiceDialog: React.FC<
   };
 
   // Handle total change - reverse calculation
-  const handleTotalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    const total = parseFloat(value) || 0;
+  const handleTotalChange = (value: number | undefined) => {
+    const total = value ?? 0;
     const { subtotal, gstAmount, pstAmount, hstAmount } = calculateFromTotal(
       total,
       Number(formData.gstRate),
@@ -198,7 +197,7 @@ const PurchaseExpenseInvoiceDialog: React.FC<
       gstAmount: gstAmount > 0 ? Math.round(gstAmount * 100) / 100 : '',
       pstAmount: pstAmount > 0 ? Math.round(pstAmount * 100) / 100 : '',
       hstAmount: hstAmount > 0 ? Math.round(hstAmount * 100) / 100 : '',
-      totalAmount: value,
+      totalAmount: value ?? '',
     }));
     setLastEditedField('total');
   };
@@ -206,8 +205,8 @@ const PurchaseExpenseInvoiceDialog: React.FC<
   // Handle tax rate changes - recalculate based on last edited field
   const handleTaxRateChange =
     (field: 'gstRate' | 'pstRate' | 'hstRate') =>
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = parseFloat(e.target.value) || 0;
+    (rate: number | undefined) => {
+      const value = rate ?? 0;
       const newRates = {
         gstRate: field === 'gstRate' ? value : Number(formData.gstRate),
         pstRate: field === 'pstRate' ? value : Number(formData.pstRate),
@@ -626,12 +625,12 @@ const PurchaseExpenseInvoiceDialog: React.FC<
                 }}
               >
                 <Typography variant="body1">Subtotal</Typography>
-                <TextField
-                  type="number"
+                <NumberInput
+                  allowDecimals
+                  min={0}
                   value={formData.amount}
                   onChange={handleAmountChange}
-                  inputProps={{ step: '0.01', min: '0' }}
-                  autoComplete="off"
+                  inputProps={{ autoComplete: 'off' }}
                   size="small"
                   sx={{ width: 150 }}
                   InputProps={{
@@ -661,12 +660,13 @@ const PurchaseExpenseInvoiceDialog: React.FC<
                   >
                     GST
                   </Typography>
-                  <TextField
-                    type="number"
+                  <NumberInput
+                    allowDecimals
+                    min={0}
+                    max={15}
                     value={formData.gstRate}
                     onChange={handleTaxRateChange('gstRate')}
-                    inputProps={{ step: '0.5', min: '0', max: '15' }}
-                    autoComplete="off"
+                    inputProps={{ autoComplete: 'off' }}
                     size="small"
                     sx={{ width: 60, '& .MuiInputBase-input': { py: 0.5 } }}
                   />
@@ -706,12 +706,13 @@ const PurchaseExpenseInvoiceDialog: React.FC<
                   >
                     PST
                   </Typography>
-                  <TextField
-                    type="number"
+                  <NumberInput
+                    allowDecimals
+                    min={0}
+                    max={15}
                     value={formData.pstRate}
                     onChange={handleTaxRateChange('pstRate')}
-                    inputProps={{ step: '0.5', min: '0', max: '15' }}
-                    autoComplete="off"
+                    inputProps={{ autoComplete: 'off' }}
                     size="small"
                     sx={{ width: 60, '& .MuiInputBase-input': { py: 0.5 } }}
                   />
@@ -751,12 +752,13 @@ const PurchaseExpenseInvoiceDialog: React.FC<
                   >
                     HST
                   </Typography>
-                  <TextField
-                    type="number"
+                  <NumberInput
+                    allowDecimals
+                    min={0}
+                    max={15}
                     value={formData.hstRate}
                     onChange={handleTaxRateChange('hstRate')}
-                    inputProps={{ step: '0.5', min: '0', max: '15' }}
-                    autoComplete="off"
+                    inputProps={{ autoComplete: 'off' }}
                     size="small"
                     sx={{ width: 60, '& .MuiInputBase-input': { py: 0.5 } }}
                   />
@@ -793,12 +795,12 @@ const PurchaseExpenseInvoiceDialog: React.FC<
                 <Typography variant="body1" fontWeight={600}>
                   Total
                 </Typography>
-                <TextField
-                  type="number"
+                <NumberInput
+                  allowDecimals
+                  min={0}
                   value={formData.totalAmount}
                   onChange={handleTotalChange}
-                  inputProps={{ step: '0.01', min: '0' }}
-                  autoComplete="off"
+                  inputProps={{ autoComplete: 'off' }}
                   size="small"
                   sx={{ width: 150 }}
                   InputProps={{

--- a/apps/webApp/src/app/components/purchase-invoices/PurchaseInvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/purchase-invoices/PurchaseInvoiceDialog.tsx
@@ -13,7 +13,11 @@ import {
   Alert,
   IconButton,
 } from '@mui/material';
-import { CloudUpload as UploadIcon, Image as ImageIcon, Close as CloseIcon } from '@mui/icons-material';
+import {
+  CloudUpload as UploadIcon,
+  Image as ImageIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
 import {
   PurchaseInvoice,
   PurchaseCategory,
@@ -24,15 +28,26 @@ import {
 } from '../../requests/expense-invoice.requests';
 import vendorService, { Vendor } from '../../requests/vendor.requests';
 import VendorSelect from '../vendors/VendorSelect';
+import { NumberInput } from '../common';
 
 interface PurchaseInvoiceDialogProps {
   open: boolean;
   invoice: PurchaseInvoice | ExpenseInvoice | null;
   onClose: () => void;
-  onSave: (data: any, file: File | null, invoiceType: 'purchase' | 'expense') => void;
+  onSave: (
+    data: any,
+    file: File | null,
+    invoiceType: 'purchase' | 'expense'
+  ) => void;
 }
 
-const purchaseCategories: PurchaseCategory[] = ['TIRES', 'PARTS', 'TOOLS', 'SUPPLIES', 'OTHER'];
+const purchaseCategories: PurchaseCategory[] = [
+  'TIRES',
+  'PARTS',
+  'TOOLS',
+  'SUPPLIES',
+  'OTHER',
+];
 const expenseCategories: ExpenseCategory[] = [
   'RENT',
   'UTILITIES',
@@ -56,7 +71,9 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
 }) => {
   const [vendors, setVendors] = useState<Vendor[]>([]);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [invoiceType, setInvoiceType] = useState<'purchase' | 'expense'>('purchase');
+  const [invoiceType, setInvoiceType] = useState<'purchase' | 'expense'>(
+    'purchase'
+  );
   const [formData, setFormData] = useState({
     vendorId: '',
     vendorName: '',
@@ -76,14 +93,18 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
   useEffect(() => {
     if (invoice) {
       // Detect invoice type based on category
-      const isPurchase = purchaseCategories.includes(invoice.category as PurchaseCategory);
+      const isPurchase = purchaseCategories.includes(
+        invoice.category as PurchaseCategory
+      );
       setInvoiceType(isPurchase ? 'purchase' : 'expense');
 
       setFormData({
         vendorId: invoice.vendorId || '',
         vendorName: invoice.vendorName || '',
         description: invoice.description || '',
-        invoiceDate: invoice.invoiceDate ? invoice.invoiceDate.split('T')[0] : '',
+        invoiceDate: invoice.invoiceDate
+          ? invoice.invoiceDate.split('T')[0]
+          : '',
         totalAmount: invoice.totalAmount || 0,
         category: invoice.category,
         notes: invoice.notes || '',
@@ -112,10 +133,11 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
     }
   };
 
-  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setFormData({ ...formData, [field]: value });
-  };
+  const handleChange =
+    (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setFormData({ ...formData, [field]: value });
+    };
 
   const handleVendorChange = (vendorId: string, vendorName: string) => {
     setFormData({
@@ -140,7 +162,13 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
       alert('File size must be less than 10MB');
       return false;
     }
-    const validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'application/pdf'];
+    const validTypes = [
+      'image/jpeg',
+      'image/jpg',
+      'image/png',
+      'image/webp',
+      'application/pdf',
+    ];
     if (!validTypes.includes(file.type)) {
       alert('Only PDF, JPG, PNG, and WEBP files are allowed');
       return false;
@@ -201,7 +229,8 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
     onSave(submitData, selectedFile, invoiceType);
   };
 
-  const currentCategories = invoiceType === 'purchase' ? purchaseCategories : expenseCategories;
+  const currentCategories =
+    invoiceType === 'purchase' ? purchaseCategories : expenseCategories;
 
   const isValid =
     formData.vendorName.trim().length > 0 &&
@@ -211,7 +240,13 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
   return (
     <Dialog open={open} maxWidth="sm" fullWidth disableEscapeKeyDown>
       <DialogTitle>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
           {invoice ? 'Edit Invoice' : 'Add Invoice'}
           <IconButton onClick={onClose} size="small">
             <CloseIcon />
@@ -294,14 +329,19 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
 
             {/* Total Amount */}
             <Grid size={{ xs: 12 }}>
-              <TextField
+              <NumberInput
                 fullWidth
                 required
-                type="number"
+                allowDecimals
+                min={0}
                 label="Total Amount"
                 value={formData.totalAmount}
-                onChange={handleChange('totalAmount')}
-                inputProps={{ step: '0.01', min: '0' }}
+                onChange={(v) =>
+                  setFormData({
+                    ...formData,
+                    totalAmount: (v ?? '') as unknown as number,
+                  })
+                }
                 helperText="Total amount including taxes"
               />
             </Grid>
@@ -310,7 +350,9 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
             <Grid size={{ xs: 12 }}>
               {invoice?.imageUrl && (
                 <Alert severity="info" sx={{ mb: 1, py: 0.5 }}>
-                  <Typography variant="caption">Current: {invoice.imageName}</Typography>
+                  <Typography variant="caption">
+                    Current: {invoice.imageName}
+                  </Typography>
                 </Alert>
               )}
 
@@ -335,7 +377,13 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
                 }}
               >
                 {selectedFile ? (
-                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                    }}
+                  >
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                       <ImageIcon sx={{ fontSize: 32, color: 'primary.main' }} />
                       <Box sx={{ textAlign: 'left' }}>
@@ -358,15 +406,31 @@ const PurchaseInvoiceDialog: React.FC<PurchaseInvoiceDialogProps> = ({
                   </Box>
                 ) : (
                   <Box>
-                    <UploadIcon sx={{ fontSize: 32, color: 'text.secondary', mb: 1 }} />
+                    <UploadIcon
+                      sx={{ fontSize: 32, color: 'text.secondary', mb: 1 }}
+                    />
                     <Typography variant="body2" gutterBottom>
                       Drag & drop invoice here
                     </Typography>
-                    <Button variant="outlined" component="label" size="small" startIcon={<UploadIcon />}>
+                    <Button
+                      variant="outlined"
+                      component="label"
+                      size="small"
+                      startIcon={<UploadIcon />}
+                    >
                       Choose File
-                      <input type="file" hidden accept="image/*,.pdf" onChange={handleFileChange} />
+                      <input
+                        type="file"
+                        hidden
+                        accept="image/*,.pdf"
+                        onChange={handleFileChange}
+                      />
                     </Button>
-                    <Typography variant="caption" display="block" sx={{ mt: 1, color: 'text.secondary' }}>
+                    <Typography
+                      variant="caption"
+                      display="block"
+                      sx={{ mt: 1, color: 'text.secondary' }}
+                    >
                       PDF, JPG, PNG, WEBP (Max 10MB)
                     </Typography>
                   </Box>

--- a/apps/webApp/src/app/components/quotations/QuotationFormContent.tsx
+++ b/apps/webApp/src/app/components/quotations/QuotationFormContent.tsx
@@ -43,6 +43,7 @@ import { ServiceDto } from '@gt-automotive/data';
 import type { QuoteItem as QuotationItem } from '../../requests/quotation.requests';
 import ServiceSelect from '../services/ServiceSelect';
 import { PhoneInput } from '../common/PhoneInput';
+import { NumberInput } from '../common';
 
 interface QuotationFormContentProps {
   tires: any[];
@@ -92,7 +93,11 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const handleServiceChange = (serviceId: string, serviceName: string, unitPrice: number) => {
+  const handleServiceChange = (
+    serviceId: string,
+    serviceName: string,
+    unitPrice: number
+  ) => {
     setNewItem({
       ...newItem,
       itemType: 'SERVICE',
@@ -102,9 +107,11 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
     });
   };
 
-
   const calculateTotals = () => {
-    const subtotal = items.reduce((sum, item) => sum + (item.quantity * Number(item.unitPrice)), 0);
+    const subtotal = items.reduce(
+      (sum, item) => sum + item.quantity * Number(item.unitPrice),
+      0
+    );
     const gstAmount = subtotal * (formData.gstRate || 0.05);
     const pstAmount = subtotal * (formData.pstRate || 0.07);
     const total = subtotal + gstAmount + pstAmount;
@@ -158,14 +165,19 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
               Customer Information
             </Typography>
           </Box>
-          
+
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, md: 6 }}>
               <TextField
                 fullWidth
                 label="Customer Name"
                 value={quotationForm.customerName}
-                onChange={(e) => setQuotationForm({ ...quotationForm, customerName: e.target.value })}
+                onChange={(e) =>
+                  setQuotationForm({
+                    ...quotationForm,
+                    customerName: e.target.value,
+                  })
+                }
                 required
               />
             </Grid>
@@ -174,14 +186,21 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                 fullWidth
                 label="Business Name (Optional)"
                 value={quotationForm.businessName}
-                onChange={(e) => setQuotationForm({ ...quotationForm, businessName: e.target.value })}
+                onChange={(e) =>
+                  setQuotationForm({
+                    ...quotationForm,
+                    businessName: e.target.value,
+                  })
+                }
               />
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
               <PhoneInput
                 fullWidth
                 value={quotationForm.phone}
-                onChange={(value) => setQuotationForm({ ...quotationForm, phone: value })}
+                onChange={(value) =>
+                  setQuotationForm({ ...quotationForm, phone: value })
+                }
               />
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
@@ -190,7 +209,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                 label="Email"
                 type="email"
                 value={quotationForm.email}
-                onChange={(e) => setQuotationForm({ ...quotationForm, email: e.target.value })}
+                onChange={(e) =>
+                  setQuotationForm({ ...quotationForm, email: e.target.value })
+                }
               />
             </Grid>
             <Grid size={{ xs: 12 }}>
@@ -198,19 +219,25 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                 fullWidth
                 label="Address"
                 value={quotationForm.address}
-                onChange={(e) => setQuotationForm({ ...quotationForm, address: e.target.value })}
+                onChange={(e) =>
+                  setQuotationForm({
+                    ...quotationForm,
+                    address: e.target.value,
+                  })
+                }
               />
             </Grid>
           </Grid>
         </CardContent>
       </Card>
 
-
       {/* Add Items */}
       <Card sx={{ mb: { xs: 2, sm: 3 } }}>
         <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-            {!isMobile && <ShoppingCartIcon sx={{ mr: 1, color: colors.primary }} />}
+            {!isMobile && (
+              <ShoppingCartIcon sx={{ mr: 1, color: colors.primary }} />
+            )}
             <Typography
               variant={isMobile ? 'subtitle1' : 'h6'}
               sx={{ fontWeight: 600 }}
@@ -218,7 +245,7 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
               Items
             </Typography>
           </Box>
-          
+
           <Grid container spacing={2} alignItems="flex-end">
             <Grid size={{ xs: 12, md: 3 }}>
               <FormControl fullWidth>
@@ -289,7 +316,7 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
               <Grid size={{ xs: 12, md: 3 }}>
                 <Autocomplete
                   options={tires}
-                  value={tires.find(t => t.id === newItem.tireId) || null}
+                  value={tires.find((t) => t.id === newItem.tireId) || null}
                   onChange={(event, newValue) => {
                     if (newValue) {
                       onTireSelect(newValue.id);
@@ -302,7 +329,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   }}
                   renderOption={(props, tire) => (
                     <Box component="li" {...props}>
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                      >
                         <span>{getTireEmoji(tire.type)}</span>
                         <Box>
                           {tire.name && (
@@ -310,7 +339,10 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                               {tire.name}
                             </Typography>
                           )}
-                          <Typography variant="body2" color={tire.name ? "text.secondary" : "inherit"}>
+                          <Typography
+                            variant="body2"
+                            color={tire.name ? 'text.secondary' : 'inherit'}
+                          >
                             {tire.brand} - {tire.size}
                           </Typography>
                         </Box>
@@ -342,37 +374,45 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   fullWidth
                   label="Description"
                   value={newItem.description}
-                  onChange={(e) => setNewItem({ ...newItem, description: e.target.value })}
+                  onChange={(e) =>
+                    setNewItem({ ...newItem, description: e.target.value })
+                  }
                 />
               </Grid>
             )}
 
             <Grid size={{ xs: 12, md: 2 }}>
-              <TextField
+              <NumberInput
                 fullWidth
-                type="number"
                 label="Quantity"
                 value={newItem.quantity}
-                onChange={(e) => setNewItem({ ...newItem, quantity: parseInt(e.target.value) || 0 })}
-                inputProps={{ min: 1 }}
+                onChange={(v) =>
+                  setNewItem({
+                    ...newItem,
+                    quantity: (v ?? '') as unknown as number,
+                  })
+                }
+                min={1}
               />
             </Grid>
 
             <Grid size={{ xs: 12, md: 2 }}>
-              <TextField
+              <NumberInput
                 fullWidth
-                type="number"
+                allowDecimals
                 label="Unit Price"
                 value={newItem.unitPrice}
-                onChange={(e) => setNewItem({ ...newItem, unitPrice: e.target.value === '' ? '' as unknown as number : parseFloat(e.target.value) || 0 })}
-                onKeyDown={(e) => {
-                  if (e.key === 'e' || e.key === 'E' || e.key === '+' || e.key === '-') {
-                    e.preventDefault();
-                  }
-                }}
-                inputProps={{ min: 0, step: 0.01 }}
+                onChange={(v) =>
+                  setNewItem({
+                    ...newItem,
+                    unitPrice: (v ?? '') as unknown as number,
+                  })
+                }
+                min={0}
                 InputProps={{
-                  startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                  startAdornment: (
+                    <InputAdornment position="start">$</InputAdornment>
+                  ),
                 }}
                 autoComplete="off"
               />
@@ -384,8 +424,12 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                 fullWidth
                 onClick={onAddItem}
                 startIcon={<AddIcon />}
-                disabled={!newItem.description || !newItem.quantity || !newItem.unitPrice}
-                sx={{ 
+                disabled={
+                  !newItem.description ||
+                  !newItem.quantity ||
+                  !newItem.unitPrice
+                }
+                sx={{
                   height: '56px', // Match TextField height
                   color: 'white',
                   '&:hover': {
@@ -393,7 +437,7 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   },
                   '&.Mui-disabled': {
                     color: 'rgba(255, 255, 255, 0.5)',
-                  }
+                  },
                 }}
               >
                 Add Item
@@ -418,8 +462,12 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   {items.map((item, index) => (
                     <TableRow key={index}>
                       <TableCell>
-                        {item.itemType === 'TIRE' && <InventoryIcon fontSize="small" sx={{ mr: 0.5 }} />}
-                        {item.itemType === 'SERVICE' && <BuildIcon fontSize="small" sx={{ mr: 0.5 }} />}
+                        {item.itemType === 'TIRE' && (
+                          <InventoryIcon fontSize="small" sx={{ mr: 0.5 }} />
+                        )}
+                        {item.itemType === 'SERVICE' && (
+                          <BuildIcon fontSize="small" sx={{ mr: 0.5 }} />
+                        )}
                         {item.itemType.replace('_', ' ')}
                       </TableCell>
                       <TableCell>
@@ -428,13 +476,24 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                             {(item as any).tireName}
                           </Typography>
                         )}
-                        <Typography variant="body2" color={(item as any).tireName ? "text.secondary" : "inherit"}>
+                        <Typography
+                          variant="body2"
+                          color={
+                            (item as any).tireName
+                              ? 'text.secondary'
+                              : 'inherit'
+                          }
+                        >
                           {item.description}
                         </Typography>
                       </TableCell>
                       <TableCell align="center">{item.quantity}</TableCell>
-                      <TableCell align="right">${Number(item.unitPrice).toFixed(2)}</TableCell>
-                      <TableCell align="right">${(item.quantity * Number(item.unitPrice)).toFixed(2)}</TableCell>
+                      <TableCell align="right">
+                        ${Number(item.unitPrice).toFixed(2)}
+                      </TableCell>
+                      <TableCell align="right">
+                        ${(item.quantity * Number(item.unitPrice)).toFixed(2)}
+                      </TableCell>
                       <TableCell align="center">
                         <Tooltip title="Remove Item">
                           <IconButton
@@ -459,7 +518,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
       <Card sx={{ mb: { xs: 2, sm: 3 } }}>
         <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-            {!isMobile && <DescriptionIcon sx={{ mr: 1, color: colors.primary }} />}
+            {!isMobile && (
+              <DescriptionIcon sx={{ mr: 1, color: colors.primary }} />
+            )}
             <Typography
               variant={isMobile ? 'subtitle1' : 'h6'}
               sx={{ fontWeight: 600 }}
@@ -467,26 +528,36 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
               Additional Information
             </Typography>
           </Box>
-          
+
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, md: 3 }}>
-              <TextField
+              <NumberInput
                 fullWidth
-                type="number"
+                allowDecimals
                 label="GST Rate (%)"
                 value={Math.round((formData.gstRate || 0.05) * 100 * 100) / 100}
-                onChange={(e) => setFormData({ ...formData, gstRate: parseFloat(e.target.value) / 100 || 0.05 })}
-                inputProps={{ min: 0, step: 0.1 }}
+                onChange={(v) =>
+                  setFormData({
+                    ...formData,
+                    gstRate: v === undefined ? 0.05 : v / 100,
+                  })
+                }
+                min={0}
               />
             </Grid>
             <Grid size={{ xs: 12, md: 3 }}>
-              <TextField
+              <NumberInput
                 fullWidth
-                type="number"
+                allowDecimals
                 label="PST Rate (%)"
                 value={Math.round((formData.pstRate || 0.07) * 100 * 100) / 100}
-                onChange={(e) => setFormData({ ...formData, pstRate: parseFloat(e.target.value) / 100 || 0.07 })}
-                inputProps={{ min: 0, step: 0.1 }}
+                onChange={(v) =>
+                  setFormData({
+                    ...formData,
+                    pstRate: v === undefined ? 0.07 : v / 100,
+                  })
+                }
+                min={0}
               />
             </Grid>
             <Grid size={{ xs: 12, md: 3 }}>
@@ -494,7 +565,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                 <InputLabel>Status</InputLabel>
                 <Select
                   value={formData.status || 'DRAFT'}
-                  onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, status: e.target.value })
+                  }
                   label="Status"
                 >
                   <MenuItem value="DRAFT">Draft</MenuItem>
@@ -511,7 +584,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                 type="date"
                 label="Valid Until"
                 value={formData.validUntil}
-                onChange={(e) => setFormData({ ...formData, validUntil: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, validUntil: e.target.value })
+                }
                 InputLabelProps={{ shrink: true }}
               />
             </Grid>
@@ -522,7 +597,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                 rows={3}
                 label="Notes"
                 value={formData.notes}
-                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, notes: e.target.value })
+                }
               />
             </Grid>
           </Grid>
@@ -533,7 +610,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
       <Card>
         <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-            {!isMobile && <AttachMoneyIcon sx={{ mr: 1, color: colors.primary }} />}
+            {!isMobile && (
+              <AttachMoneyIcon sx={{ mr: 1, color: colors.primary }} />
+            )}
             <Typography
               variant={isMobile ? 'subtitle1' : 'h6'}
               sx={{ fontWeight: 600 }}
@@ -541,16 +620,24 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
               Totals
             </Typography>
           </Box>
-          
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
+
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+            }}
+          >
             <Typography variant="body1" sx={{ mb: 1 }}>
               Subtotal: <strong>${totals.subtotal.toFixed(2)}</strong>
             </Typography>
             <Typography variant="body2" sx={{ mb: 1 }}>
-              GST ({((formData.gstRate || 0.05) * 100).toFixed(0)}%): ${totals.gstAmount.toFixed(2)}
+              GST ({((formData.gstRate || 0.05) * 100).toFixed(0)}%): $
+              {totals.gstAmount.toFixed(2)}
             </Typography>
             <Typography variant="body2" sx={{ mb: 1 }}>
-              PST ({((formData.pstRate || 0.07) * 100).toFixed(0)}%): ${totals.pstAmount.toFixed(2)}
+              PST ({((formData.pstRate || 0.07) * 100).toFixed(0)}%): $
+              {totals.pstAmount.toFixed(2)}
             </Typography>
             <Divider sx={{ width: 150, my: 1 }} />
             <Typography variant="h6" color="primary">

--- a/apps/webApp/src/app/components/repair-orders/AddVehicleDialog.tsx
+++ b/apps/webApp/src/app/components/repair-orders/AddVehicleDialog.tsx
@@ -21,6 +21,7 @@ import {
   VehicleMakeWithModels,
 } from '../../requests/vehicle.requests';
 import { useErrorHelpers } from '../../contexts/ErrorContext';
+import { NumberInput } from '../common';
 
 const CURRENT_YEAR = new Date().getFullYear() + 1;
 const YEARS = Array.from({ length: 60 }, (_, i) => CURRENT_YEAR - i);
@@ -332,14 +333,14 @@ export function AddVehicleDialog({
               value={licensePlate}
               onChange={(e) => setLicensePlate(e.target.value)}
             />
-            <TextField
+            <NumberInput
               label={requireVin ? 'Mileage' : 'Mileage (optional)'}
               required={requireVin}
-              type="number"
               size="small"
               sx={{ flex: 1 }}
               value={mileage}
-              onChange={(e) => setMileage(e.target.value)}
+              onChange={(v) => setMileage(v === undefined ? '' : String(v))}
+              min={0}
               InputProps={{
                 endAdornment: (
                   <InputAdornment position="end">km</InputAdornment>

--- a/apps/webApp/src/app/components/repair-orders/InspectVehicleDialog.tsx
+++ b/apps/webApp/src/app/components/repair-orders/InspectVehicleDialog.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   Typography,
   CircularProgress,
-  TextField,
   InputAdornment,
   List,
   ListItemButton,
@@ -24,6 +23,7 @@ import {
 } from '../../requests/inspection.requests';
 import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { InspectionForm } from '../inspections/InspectionForm';
+import { NumberInput } from '../common';
 
 interface InspectVehicleDialogProps {
   open: boolean;
@@ -86,7 +86,9 @@ export function InspectVehicleDialog({
         setTemplates(list);
         if (list.length > 0) setTemplateId((prev) => prev || list[0].id);
       })
-      .catch((error) => showApiError(error, 'Failed to load inspection templates.'))
+      .catch((error) =>
+        showApiError(error, 'Failed to load inspection templates.')
+      )
       .finally(() => setLoading(false));
   }, [open, existingInspectionId, defaultMileage]);
 
@@ -129,7 +131,8 @@ export function InspectVehicleDialog({
       PaperProps={fullView ? { sx: { height: '90vh' } } : undefined}
     >
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Assignment color="action" /> {fullView ? 'Vehicle Inspection' : 'Inspect Vehicle'}
+        <Assignment color="action" />{' '}
+        {fullView ? 'Vehicle Inspection' : 'Inspect Vehicle'}
       </DialogTitle>
 
       <DialogContent dividers={fullView}>
@@ -141,7 +144,9 @@ export function InspectVehicleDialog({
             onDone={handleClose}
           />
         ) : existingInspectionId ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}><CircularProgress /></Box>
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
         ) : (
           <>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
@@ -151,38 +156,69 @@ export function InspectVehicleDialog({
 
             {!vehicleId && (
               <Alert severity="info" sx={{ mb: 2 }}>
-                No vehicle is linked to this repair order. You can still inspect, but adding a vehicle first is recommended.
+                No vehicle is linked to this repair order. You can still
+                inspect, but adding a vehicle first is recommended.
               </Alert>
             )}
 
-            <Typography variant="subtitle2" sx={{ mb: 1 }}>Inspection Type</Typography>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Inspection Type
+            </Typography>
             {loading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}><CircularProgress size={24} /></Box>
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+                <CircularProgress size={24} />
+              </Box>
             ) : templates.length === 0 ? (
-              <Alert severity="warning">No inspection templates are configured.</Alert>
+              <Alert severity="warning">
+                No inspection templates are configured.
+              </Alert>
             ) : (
-              <List dense sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, mb: 2 }}>
+              <List
+                dense
+                sx={{
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  mb: 2,
+                }}
+              >
                 {templates.map((t) => (
-                  <ListItemButton key={t.id} selected={templateId === t.id} onClick={() => setTemplateId(t.id)}>
-                    <Radio edge="start" checked={templateId === t.id} tabIndex={-1} size="small" />
+                  <ListItemButton
+                    key={t.id}
+                    selected={templateId === t.id}
+                    onClick={() => setTemplateId(t.id)}
+                  >
+                    <Radio
+                      edge="start"
+                      checked={templateId === t.id}
+                      tabIndex={-1}
+                      size="small"
+                    />
                     <ListItemText
                       primary={t.name}
                       secondary={t.description}
-                      primaryTypographyProps={{ variant: 'body2', fontWeight: 500 }}
+                      primaryTypographyProps={{
+                        variant: 'body2',
+                        fontWeight: 500,
+                      }}
                     />
                   </ListItemButton>
                 ))}
               </List>
             )}
 
-            <TextField
+            <NumberInput
               label="Mileage (optional)"
-              type="number"
               size="small"
               fullWidth
               value={mileage}
-              onChange={(e) => setMileage(e.target.value)}
-              InputProps={{ endAdornment: <InputAdornment position="end">km</InputAdornment> }}
+              onChange={(v) => setMileage(v === undefined ? '' : String(v))}
+              min={0}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">km</InputAdornment>
+                ),
+              }}
             />
           </>
         )}
@@ -193,12 +229,20 @@ export function InspectVehicleDialog({
           <Button onClick={handleClose}>Close</Button>
         ) : (
           <>
-            <Button onClick={onClose} disabled={creating}>Cancel</Button>
+            <Button onClick={onClose} disabled={creating}>
+              Cancel
+            </Button>
             <Button
               variant="contained"
               onClick={handleStart}
               disabled={creating || !templateId}
-              startIcon={creating ? <CircularProgress size={16} color="inherit" /> : <Assignment />}
+              startIcon={
+                creating ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : (
+                  <Assignment />
+                )
+              }
             >
               Start Inspection
             </Button>

--- a/apps/webApp/src/app/components/repair-orders/ServiceCatalogPicker.tsx
+++ b/apps/webApp/src/app/components/repair-orders/ServiceCatalogPicker.tsx
@@ -32,6 +32,7 @@ import {
   serviceCatalogRequests,
   ServiceCatalogItem,
 } from '../../requests/service-catalog.requests';
+import { NumberInput } from '../common';
 
 interface ServiceCatalogPickerProps {
   open: boolean;
@@ -72,7 +73,10 @@ export function ServiceCatalogPicker({
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [menuItem, setMenuItem] = useState<ServiceCatalogItem | null>(null);
 
-  const openMenu = (e: React.MouseEvent<HTMLElement>, item: ServiceCatalogItem) => {
+  const openMenu = (
+    e: React.MouseEvent<HTMLElement>,
+    item: ServiceCatalogItem
+  ) => {
     e.stopPropagation();
     setMenuAnchor(e.currentTarget);
     setMenuItem(item);
@@ -107,7 +111,9 @@ export function ServiceCatalogPicker({
   // Flat list, sorted by name; filtered by the search query.
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase();
-    const list = q ? items.filter((s) => s.name.toLowerCase().includes(q)) : items;
+    const list = q
+      ? items.filter((s) => s.name.toLowerCase().includes(q))
+      : items;
     return [...list].sort((a, b) => a.name.localeCompare(b.name));
   }, [query, items]);
 
@@ -154,7 +160,9 @@ export function ServiceCatalogPicker({
       }
       resetAddForm();
     } catch {
-      setError(editingId ? 'Failed to update service.' : 'Failed to add service.');
+      setError(
+        editingId ? 'Failed to update service.' : 'Failed to add service.'
+      );
     } finally {
       setSaving(false);
     }
@@ -179,7 +187,12 @@ export function ServiceCatalogPicker({
         primary={s.name}
         primaryTypographyProps={{ variant: 'body2', fontWeight: 500 }}
       />
-      <Chip label={hoursLabel(s.labourHours)} size="small" variant="outlined" sx={{ mr: 1 }} />
+      <Chip
+        label={hoursLabel(s.labourHours)}
+        size="small"
+        variant="outlined"
+        sx={{ mr: 1 }}
+      />
       {canManage || canDelete ? (
         deletingId === s.id ? (
           <Box sx={{ px: 0.75, display: 'flex', alignItems: 'center' }}>
@@ -197,10 +210,20 @@ export function ServiceCatalogPicker({
   );
 
   return (
-    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm" PaperProps={{ sx: { height: '80vh' } }}>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{ sx: { height: '80vh' } }}
+    >
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', pb: 1 }}>
-        <Typography variant="h6" sx={{ flexGrow: 1 }}>Choose a Service</Typography>
-        <IconButton onClick={handleClose} size="small"><Close /></IconButton>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          Choose a Service
+        </Typography>
+        <IconButton onClick={handleClose} size="small">
+          <Close />
+        </IconButton>
       </DialogTitle>
 
       <Box sx={{ px: 3, pb: 1 }}>
@@ -223,8 +246,18 @@ export function ServiceCatalogPicker({
         {canManage && (
           <Box sx={{ mt: 1 }}>
             {showAddForm ? (
-              <Box sx={{ p: 1.5, border: '1px solid', borderColor: 'divider', borderRadius: 1, bgcolor: 'action.hover' }}>
-                <Typography variant="subtitle2" sx={{ mb: 1 }}>{editingId ? 'Edit Service' : 'New Service'}</Typography>
+              <Box
+                sx={{
+                  p: 1.5,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  bgcolor: 'action.hover',
+                }}
+              >
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  {editingId ? 'Edit Service' : 'New Service'}
+                </Typography>
                 <Stack spacing={1}>
                   <Box sx={{ display: 'flex', gap: 1 }}>
                     <TextField
@@ -236,26 +269,45 @@ export function ServiceCatalogPicker({
                       onChange={(e) => setNewName(e.target.value)}
                       required
                     />
-                    <TextField
+                    <NumberInput
                       label="Default hours"
-                      type="number"
+                      allowDecimals
                       size="small"
                       sx={{ width: 120 }}
                       value={newHours}
-                      onChange={(e) => setNewHours(Number(e.target.value))}
-                      inputProps={{ min: 0, step: 0.25 }}
+                      onChange={(v) =>
+                        setNewHours((v ?? '') as unknown as number)
+                      }
+                      min={0}
                     />
                   </Box>
                   <Box sx={{ display: 'flex', gap: 1 }}>
-                    <Button variant="contained" size="small" onClick={handleSave} disabled={saving || !newName.trim()}>
-                      {saving ? <CircularProgress size={16} /> : editingId ? 'Save' : 'Add'}
+                    <Button
+                      variant="contained"
+                      size="small"
+                      onClick={handleSave}
+                      disabled={saving || !newName.trim()}
+                    >
+                      {saving ? (
+                        <CircularProgress size={16} />
+                      ) : editingId ? (
+                        'Save'
+                      ) : (
+                        'Add'
+                      )}
                     </Button>
-                    <Button size="small" onClick={resetAddForm}>Cancel</Button>
+                    <Button size="small" onClick={resetAddForm}>
+                      Cancel
+                    </Button>
                   </Box>
                 </Stack>
               </Box>
             ) : (
-              <Button size="small" startIcon={<Add />} onClick={() => setShowAddForm(true)}>
+              <Button
+                size="small"
+                startIcon={<Add />}
+                onClick={() => setShowAddForm(true)}
+              >
                 Add Service
               </Button>
             )}
@@ -263,7 +315,11 @@ export function ServiceCatalogPicker({
         )}
 
         {error && (
-          <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>
+          <Typography
+            variant="caption"
+            color="error"
+            sx={{ display: 'block', mt: 0.5 }}
+          >
             {error}
           </Typography>
         )}
@@ -278,13 +334,21 @@ export function ServiceCatalogPicker({
           <Box sx={{ textAlign: 'center', py: 6, color: 'text.disabled' }}>
             {query ? (
               <>
-                <Typography variant="body2">No services match "{query}".</Typography>
-                <Typography variant="caption">You can still add it as a custom item.</Typography>
+                <Typography variant="body2">
+                  No services match "{query}".
+                </Typography>
+                <Typography variant="caption">
+                  You can still add it as a custom item.
+                </Typography>
               </>
             ) : (
               <>
                 <Typography variant="body2">No services yet.</Typography>
-                {canManage && <Typography variant="caption">Use "Add Service" to create one.</Typography>}
+                {canManage && (
+                  <Typography variant="caption">
+                    Use "Add Service" to create one.
+                  </Typography>
+                )}
               </>
             )}
           </Box>
@@ -294,7 +358,11 @@ export function ServiceCatalogPicker({
       </DialogContent>
 
       {/* Row overflow menu */}
-      <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClose={closeMenu}>
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={closeMenu}
+      >
         {canManage && (
           <MenuItem
             onClick={() => {

--- a/apps/webApp/src/app/components/repair-orders/ServiceDrawer.tsx
+++ b/apps/webApp/src/app/components/repair-orders/ServiceDrawer.tsx
@@ -27,7 +27,13 @@ import {
   Delete,
   MenuBook,
 } from '@mui/icons-material';
-import { ROService, ROServiceStatus, ROServiceType, repairOrderRequests } from '../../requests/repair-order.requests';
+import {
+  ROService,
+  ROServiceStatus,
+  ROServiceType,
+  repairOrderRequests,
+} from '../../requests/repair-order.requests';
+import { NumberInput } from '../common';
 import { ROPhotoSection } from './ROPhotoSection';
 import { ServiceCatalogPicker } from './ServiceCatalogPicker';
 import { ServiceCatalogItem } from '../../requests/service-catalog.requests';
@@ -43,7 +49,10 @@ interface ServiceDrawerProps {
   currentUserId: string;
 }
 
-const STATUS_COLORS: Record<ROServiceStatus, 'default' | 'warning' | 'success' | 'error'> = {
+const STATUS_COLORS: Record<
+  ROServiceStatus,
+  'default' | 'warning' | 'success' | 'error'
+> = {
   PENDING: 'default',
   IN_PROGRESS: 'warning',
   COMPLETED: 'success',
@@ -55,15 +64,47 @@ const DEFAULT_LABOR_RATE = 100;
 
 const CANNED_JOBS = [
   { description: 'Oil Change', type: 'LABOR' as ROServiceType, unitPrice: 45 },
-  { description: 'Tire Rotation', type: 'LABOR' as ROServiceType, unitPrice: 35 },
-  { description: 'Brake Inspection', type: 'LABOR' as ROServiceType, unitPrice: 30 },
-  { description: 'Wheel Alignment', type: 'LABOR' as ROServiceType, unitPrice: 90 },
-  { description: 'Battery Test & Replacement', type: 'LABOR' as ROServiceType, unitPrice: 120 },
-  { description: 'Tire Mount & Balance (each)', type: 'LABOR' as ROServiceType, unitPrice: 25 },
-  { description: 'Brake Pad Replacement (axle)', type: 'LABOR' as ROServiceType, unitPrice: 150 },
+  {
+    description: 'Tire Rotation',
+    type: 'LABOR' as ROServiceType,
+    unitPrice: 35,
+  },
+  {
+    description: 'Brake Inspection',
+    type: 'LABOR' as ROServiceType,
+    unitPrice: 30,
+  },
+  {
+    description: 'Wheel Alignment',
+    type: 'LABOR' as ROServiceType,
+    unitPrice: 90,
+  },
+  {
+    description: 'Battery Test & Replacement',
+    type: 'LABOR' as ROServiceType,
+    unitPrice: 120,
+  },
+  {
+    description: 'Tire Mount & Balance (each)',
+    type: 'LABOR' as ROServiceType,
+    unitPrice: 25,
+  },
+  {
+    description: 'Brake Pad Replacement (axle)',
+    type: 'LABOR' as ROServiceType,
+    unitPrice: 150,
+  },
 ];
 
-function ServiceItem({ service, roId, onUpdate, onDelete, onMediaChange, canEdit, canDelete }: {
+function ServiceItem({
+  service,
+  roId,
+  onUpdate,
+  onDelete,
+  onMediaChange,
+  canEdit,
+  canDelete,
+}: {
   service: ROService;
   roId: string;
   onUpdate: (updated: ROService) => void;
@@ -80,7 +121,11 @@ function ServiceItem({ service, roId, onUpdate, onDelete, onMediaChange, canEdit
   const handleStatusChange = async (status: ROServiceStatus) => {
     setSaving(true);
     try {
-      const updated = await repairOrderRequests.updateService(roId, service.id, { status });
+      const updated = await repairOrderRequests.updateService(
+        roId,
+        service.id,
+        { status }
+      );
       onUpdate(updated);
     } finally {
       setSaving(false);
@@ -90,7 +135,11 @@ function ServiceItem({ service, roId, onUpdate, onDelete, onMediaChange, canEdit
   const handleSaveNotes = async () => {
     setSaving(true);
     try {
-      const updated = await repairOrderRequests.updateService(roId, service.id, { technicianNotes: notes });
+      const updated = await repairOrderRequests.updateService(
+        roId,
+        service.id,
+        { technicianNotes: notes }
+      );
       onUpdate(updated);
       setNotesEditing(false);
     } finally {
@@ -98,35 +147,84 @@ function ServiceItem({ service, roId, onUpdate, onDelete, onMediaChange, canEdit
     }
   };
 
-  const total = (Number(service.quantity) * Number(service.unitPrice)).toFixed(2);
+  const total = (Number(service.quantity) * Number(service.unitPrice)).toFixed(
+    2
+  );
 
   return (
     <Paper variant="outlined" sx={{ mb: 1 }}>
       <Box sx={{ p: 1.5 }}>
         <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
           {/* Status icon */}
-          <IconButton size="small" disabled={!canEdit || saving}
-            onClick={() => handleStatusChange(service.status === 'COMPLETED' ? 'PENDING' : 'COMPLETED')}
-            sx={{ mt: 0.2, color: service.status === 'COMPLETED' ? 'success.main' : 'text.disabled' }}>
-            {saving ? <CircularProgress size={16} /> : service.status === 'COMPLETED' ? <CheckCircle /> : <RadioButtonUnchecked />}
+          <IconButton
+            size="small"
+            disabled={!canEdit || saving}
+            onClick={() =>
+              handleStatusChange(
+                service.status === 'COMPLETED' ? 'PENDING' : 'COMPLETED'
+              )
+            }
+            sx={{
+              mt: 0.2,
+              color:
+                service.status === 'COMPLETED'
+                  ? 'success.main'
+                  : 'text.disabled',
+            }}
+          >
+            {saving ? (
+              <CircularProgress size={16} />
+            ) : service.status === 'COMPLETED' ? (
+              <CheckCircle />
+            ) : (
+              <RadioButtonUnchecked />
+            )}
           </IconButton>
 
           <Box sx={{ flexGrow: 1 }}>
-            <Typography variant="body2" fontWeight={500} sx={{ textDecoration: service.status === 'DECLINED' ? 'line-through' : undefined }}>
+            <Typography
+              variant="body2"
+              fontWeight={500}
+              sx={{
+                textDecoration:
+                  service.status === 'DECLINED' ? 'line-through' : undefined,
+              }}
+            >
               {service.description}
             </Typography>
-            <Box sx={{ display: 'flex', gap: 1, mt: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 1,
+                mt: 0.5,
+                flexWrap: 'wrap',
+                alignItems: 'center',
+              }}
+            >
               <Chip label={service.type} size="small" variant="outlined" />
-              <Chip label={service.status.replace('_', ' ')} size="small" color={STATUS_COLORS[service.status]} />
+              <Chip
+                label={service.status.replace('_', ' ')}
+                size="small"
+                color={STATUS_COLORS[service.status]}
+              />
               <Typography variant="caption" color="text.secondary">
                 {service.type === 'LABOR'
-                  ? `${Number(service.quantity)} hr × $${Number(service.unitPrice).toFixed(2)}/hr = $${total}`
-                  : `${Number(service.quantity)} × $${Number(service.unitPrice).toFixed(2)} = $${total}`}
+                  ? `${Number(service.quantity)} hr × $${Number(
+                      service.unitPrice
+                    ).toFixed(2)}/hr = $${total}`
+                  : `${Number(service.quantity)} × $${Number(
+                      service.unitPrice
+                    ).toFixed(2)} = $${total}`}
               </Typography>
             </Box>
             {service.completedBy && (
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
-                Completed by {service.completedBy.firstName} {service.completedBy.lastName}
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: 'block', mt: 0.25 }}
+              >
+                Completed by {service.completedBy.firstName}{' '}
+                {service.completedBy.lastName}
               </Typography>
             )}
           </Box>
@@ -136,7 +234,11 @@ function ServiceItem({ service, roId, onUpdate, onDelete, onMediaChange, canEdit
               {expanded ? <ExpandLess /> : <ExpandMore />}
             </IconButton>
             {canDelete && (
-              <IconButton size="small" color="error" onClick={() => onDelete(service.id)}>
+              <IconButton
+                size="small"
+                color="error"
+                onClick={() => onDelete(service.id)}
+              >
                 <Delete fontSize="small" />
               </IconButton>
             )}
@@ -148,18 +250,53 @@ function ServiceItem({ service, roId, onUpdate, onDelete, onMediaChange, canEdit
         <Divider />
         <Box sx={{ p: 1.5 }}>
           {/* Technician notes */}
-          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>Technician Notes</Typography>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ fontWeight: 600 }}
+          >
+            Technician Notes
+          </Typography>
           {notesEditing ? (
             <Box sx={{ mt: 0.5 }}>
-              <TextField multiline rows={2} fullWidth size="small" value={notes} onChange={(e) => setNotes(e.target.value)} placeholder="Findings, measurements, observations…" />
+              <TextField
+                multiline
+                rows={2}
+                fullWidth
+                size="small"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Findings, measurements, observations…"
+              />
               <Box sx={{ mt: 0.5, display: 'flex', gap: 1 }}>
-                <Button size="small" onClick={handleSaveNotes} disabled={saving}>Save</Button>
-                <Button size="small" onClick={() => { setNotesEditing(false); setNotes(service.technicianNotes ?? ''); }}>Cancel</Button>
+                <Button
+                  size="small"
+                  onClick={handleSaveNotes}
+                  disabled={saving}
+                >
+                  Save
+                </Button>
+                <Button
+                  size="small"
+                  onClick={() => {
+                    setNotesEditing(false);
+                    setNotes(service.technicianNotes ?? '');
+                  }}
+                >
+                  Cancel
+                </Button>
               </Box>
             </Box>
           ) : (
-            <Box sx={{ mt: 0.5, cursor: canEdit ? 'pointer' : undefined }} onClick={() => canEdit && setNotesEditing(true)}>
-              <Typography variant="body2" color={notes ? 'text.primary' : 'text.disabled'} sx={{ fontStyle: notes ? 'normal' : 'italic' }}>
+            <Box
+              sx={{ mt: 0.5, cursor: canEdit ? 'pointer' : undefined }}
+              onClick={() => canEdit && setNotesEditing(true)}
+            >
+              <Typography
+                variant="body2"
+                color={notes ? 'text.primary' : 'text.disabled'}
+                sx={{ fontStyle: notes ? 'normal' : 'italic' }}
+              >
                 {notes || (canEdit ? 'Tap to add notes…' : 'No notes')}
               </Typography>
             </Box>
@@ -181,7 +318,16 @@ function ServiceItem({ service, roId, onUpdate, onDelete, onMediaChange, canEdit
   );
 }
 
-export function ServiceDrawer({ open, onClose, roId, services, onServicesChange, canEdit, canDelete, currentUserId }: ServiceDrawerProps) {
+export function ServiceDrawer({
+  open,
+  onClose,
+  roId,
+  services,
+  onServicesChange,
+  canEdit,
+  canDelete,
+  currentUserId,
+}: ServiceDrawerProps) {
   const [showAddForm, setShowAddForm] = useState(false);
   const [newDesc, setNewDesc] = useState('');
   const [newType, setNewType] = useState<ROServiceType>('LABOR');
@@ -191,7 +337,14 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
   const [adding, setAdding] = useState(false);
   const [catalogOpen, setCatalogOpen] = useState(false);
 
-  const resetForm = () => { setNewDesc(''); setNewType('LABOR'); setNewQty(1); setNewPrice(DEFAULT_LABOR_RATE); setNewNotes(''); setShowAddForm(false); };
+  const resetForm = () => {
+    setNewDesc('');
+    setNewType('LABOR');
+    setNewQty(1);
+    setNewPrice(DEFAULT_LABOR_RATE);
+    setNewNotes('');
+    setShowAddForm(false);
+  };
 
   const handleTypeChange = (type: ROServiceType) => {
     setNewType(type);
@@ -205,7 +358,13 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
     if (!newDesc.trim()) return;
     setAdding(true);
     try {
-      const created = await repairOrderRequests.addService(roId, { description: newDesc, type: newType, quantity: newQty, unitPrice: newPrice, technicianNotes: newNotes });
+      const created = await repairOrderRequests.addService(roId, {
+        description: newDesc,
+        type: newType,
+        quantity: newQty,
+        unitPrice: newPrice,
+        technicianNotes: newNotes,
+      });
       onServicesChange([...services, created]);
       resetForm();
     } finally {
@@ -215,9 +374,9 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
 
   // Labor items default to the $100/hr rate when the catalog has no price.
   const priceFor = (type: ROServiceType, unitPrice: number) =>
-    type === 'LABOR' ? (unitPrice || DEFAULT_LABOR_RATE) : unitPrice;
+    type === 'LABOR' ? unitPrice || DEFAULT_LABOR_RATE : unitPrice;
 
-  const handleCanned = (job: typeof CANNED_JOBS[0]) => {
+  const handleCanned = (job: (typeof CANNED_JOBS)[0]) => {
     setNewDesc(job.description);
     setNewType(job.type);
     setNewQty(1);
@@ -246,19 +405,41 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
   };
 
   const handleMediaChange = (serviceId: string, media: any[]) => {
-    onServicesChange(services.map((s) => s.id === serviceId ? { ...s, media } : s));
+    onServicesChange(
+      services.map((s) => (s.id === serviceId ? { ...s, media } : s))
+    );
   };
 
   const total = services.reduce((sum, s) => sum + Number(s.total), 0);
 
   return (
-    <Drawer anchor="right" open={open} onClose={onClose} PaperProps={{ sx: { width: { xs: '100%', sm: 480 } } }}>
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { width: { xs: '100%', sm: 480 } } }}
+    >
       <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
         {/* Header */}
-        <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider', display: 'flex', alignItems: 'center' }}>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>Service Items</Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mr: 2 }}>Est. ${total.toFixed(2)}</Typography>
-          <IconButton onClick={onClose}><Close /></IconButton>
+        <Box
+          sx={{
+            px: 2,
+            py: 1.5,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Service Items
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mr: 2 }}>
+            Est. ${total.toFixed(2)}
+          </Typography>
+          <IconButton onClick={onClose}>
+            <Close />
+          </IconButton>
         </Box>
 
         <Box sx={{ flex: 1, overflowY: 'auto', p: 2 }}>
@@ -266,7 +447,9 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
           {services.length === 0 && !showAddForm && (
             <Box sx={{ textAlign: 'center', py: 4, color: 'text.disabled' }}>
               <Typography variant="body2">No service items yet.</Typography>
-              <Typography variant="caption">Add from canned jobs or create custom.</Typography>
+              <Typography variant="caption">
+                Add from canned jobs or create custom.
+              </Typography>
             </Box>
           )}
 
@@ -285,14 +468,33 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
 
           {/* Add form */}
           {showAddForm && canEdit && (
-            <Paper variant="outlined" sx={{ p: 2, mb: 2, bgcolor: 'action.hover' }}>
-              <Typography variant="subtitle2" sx={{ mb: 1.5 }}>New Service Item</Typography>
+            <Paper
+              variant="outlined"
+              sx={{ p: 2, mb: 2, bgcolor: 'action.hover' }}
+            >
+              <Typography variant="subtitle2" sx={{ mb: 1.5 }}>
+                New Service Item
+              </Typography>
               <Stack spacing={1.5}>
-                <TextField label="Description" fullWidth size="small" value={newDesc} onChange={(e) => setNewDesc(e.target.value)} placeholder="e.g. Front brake pad replacement" required />
+                <TextField
+                  label="Description"
+                  fullWidth
+                  size="small"
+                  value={newDesc}
+                  onChange={(e) => setNewDesc(e.target.value)}
+                  placeholder="e.g. Front brake pad replacement"
+                  required
+                />
                 <Box sx={{ display: 'flex', gap: 1 }}>
                   <FormControl size="small" sx={{ minWidth: 110 }}>
                     <InputLabel>Type</InputLabel>
-                    <Select value={newType} label="Type" onChange={(e) => handleTypeChange(e.target.value as ROServiceType)}>
+                    <Select
+                      value={newType}
+                      label="Type"
+                      onChange={(e) =>
+                        handleTypeChange(e.target.value as ROServiceType)
+                      }
+                    >
                       <MenuItem value="LABOR">Labor</MenuItem>
                       <MenuItem value="PART">Part</MenuItem>
                       <MenuItem value="OTHER">Other</MenuItem>
@@ -300,29 +502,111 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
                   </FormControl>
                   {newType === 'LABOR' ? (
                     <>
-                      <TextField label="Hours" type="number" size="small" sx={{ width: 90 }} value={newQty} onChange={(e) => setNewQty(Number(e.target.value))} inputProps={{ min: 0.25, step: 0.25 }} />
-                      <TextField label="Rate ($/hr)" type="number" size="small" sx={{ flex: 1 }} value={newPrice} onChange={(e) => setNewPrice(Number(e.target.value))} inputProps={{ min: 0, step: 0.01 }} InputProps={{ startAdornment: <Typography variant="caption" sx={{ mr: 0.5 }}>$</Typography> }} />
+                      <NumberInput
+                        label="Hours"
+                        allowDecimals
+                        size="small"
+                        sx={{ width: 90 }}
+                        value={newQty}
+                        onChange={(v) =>
+                          setNewQty((v ?? '') as unknown as number)
+                        }
+                        min={0.25}
+                      />
+                      <NumberInput
+                        label="Rate ($/hr)"
+                        allowDecimals
+                        size="small"
+                        sx={{ flex: 1 }}
+                        value={newPrice}
+                        onChange={(v) =>
+                          setNewPrice((v ?? '') as unknown as number)
+                        }
+                        min={0}
+                        InputProps={{
+                          startAdornment: (
+                            <Typography variant="caption" sx={{ mr: 0.5 }}>
+                              $
+                            </Typography>
+                          ),
+                        }}
+                      />
                     </>
                   ) : (
                     <>
-                      <TextField label="Qty" type="number" size="small" sx={{ width: 70 }} value={newQty} onChange={(e) => setNewQty(Number(e.target.value))} inputProps={{ min: 0.25, step: 0.25 }} />
-                      <TextField label="Unit Price" type="number" size="small" sx={{ flex: 1 }} value={newPrice} onChange={(e) => setNewPrice(Number(e.target.value))} inputProps={{ min: 0, step: 0.01 }} InputProps={{ startAdornment: <Typography variant="caption" sx={{ mr: 0.5 }}>$</Typography> }} />
+                      <NumberInput
+                        label="Qty"
+                        allowDecimals
+                        size="small"
+                        sx={{ width: 70 }}
+                        value={newQty}
+                        onChange={(v) =>
+                          setNewQty((v ?? '') as unknown as number)
+                        }
+                        min={0.25}
+                      />
+                      <NumberInput
+                        label="Unit Price"
+                        allowDecimals
+                        size="small"
+                        sx={{ flex: 1 }}
+                        value={newPrice}
+                        onChange={(v) =>
+                          setNewPrice((v ?? '') as unknown as number)
+                        }
+                        min={0}
+                        InputProps={{
+                          startAdornment: (
+                            <Typography variant="caption" sx={{ mr: 0.5 }}>
+                              $
+                            </Typography>
+                          ),
+                        }}
+                      />
                     </>
                   )}
                 </Box>
                 {/* Auto-computed, read-only total */}
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 0.5 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    px: 0.5,
+                  }}
+                >
                   <Typography variant="caption" color="text.secondary">
-                    {newType === 'LABOR' ? `${Number(newQty) || 0} hr × $${Number(newPrice).toFixed(2)}/hr` : 'Total'}
+                    {newType === 'LABOR'
+                      ? `${Number(newQty) || 0} hr × $${Number(
+                          newPrice
+                        ).toFixed(2)}/hr`
+                      : 'Total'}
                   </Typography>
-                  <Typography variant="body2" fontWeight={700}>${newTotal.toFixed(2)}</Typography>
+                  <Typography variant="body2" fontWeight={700}>
+                    ${newTotal.toFixed(2)}
+                  </Typography>
                 </Box>
-                <TextField label="Technician Notes (optional)" fullWidth size="small" multiline rows={2} value={newNotes} onChange={(e) => setNewNotes(e.target.value)} />
+                <TextField
+                  label="Technician Notes (optional)"
+                  fullWidth
+                  size="small"
+                  multiline
+                  rows={2}
+                  value={newNotes}
+                  onChange={(e) => setNewNotes(e.target.value)}
+                />
                 <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button variant="contained" size="small" onClick={handleAdd} disabled={adding || !newDesc.trim()}>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={handleAdd}
+                    disabled={adding || !newDesc.trim()}
+                  >
                     {adding ? <CircularProgress size={16} /> : 'Add'}
                   </Button>
-                  <Button size="small" onClick={resetForm}>Cancel</Button>
+                  <Button size="small" onClick={resetForm}>
+                    Cancel
+                  </Button>
                 </Box>
               </Stack>
             </Paper>
@@ -332,14 +616,33 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
           {canEdit && !showAddForm && (
             <Box sx={{ mt: 1 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5 }}>
-                <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, flexGrow: 1 }}>Quick Add</Typography>
-                <Button size="small" startIcon={<MenuBook fontSize="small" />} onClick={() => setCatalogOpen(true)}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontWeight: 600, flexGrow: 1 }}
+                >
+                  Quick Add
+                </Typography>
+                <Button
+                  size="small"
+                  startIcon={<MenuBook fontSize="small" />}
+                  onClick={() => setCatalogOpen(true)}
+                >
                   Browse All Services
                 </Button>
               </Box>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+              <Box
+                sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}
+              >
                 {CANNED_JOBS.map((j) => (
-                  <Chip key={j.description} label={j.description} size="small" clickable onClick={() => handleCanned(j)} variant="outlined" />
+                  <Chip
+                    key={j.description}
+                    label={j.description}
+                    size="small"
+                    clickable
+                    onClick={() => handleCanned(j)}
+                    variant="outlined"
+                  />
                 ))}
               </Box>
             </Box>
@@ -348,11 +651,32 @@ export function ServiceDrawer({ open, onClose, roId, services, onServicesChange,
 
         {/* Footer */}
         {canEdit && (
-          <Box sx={{ p: 2, borderTop: '1px solid', borderColor: 'divider', display: 'flex', gap: 1 }}>
-            <Button fullWidth variant="contained" startIcon={<MenuBook />} onClick={() => setCatalogOpen(true)}>
+          <Box
+            sx={{
+              p: 2,
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              display: 'flex',
+              gap: 1,
+            }}
+          >
+            <Button
+              fullWidth
+              variant="contained"
+              startIcon={<MenuBook />}
+              onClick={() => setCatalogOpen(true)}
+            >
               Browse Services
             </Button>
-            <Button fullWidth variant="outlined" startIcon={<Add />} onClick={() => { resetForm(); setShowAddForm(true); }}>
+            <Button
+              fullWidth
+              variant="outlined"
+              startIcon={<Add />}
+              onClick={() => {
+                resetForm();
+                setShowAddForm(true);
+              }}
+            >
               Custom Item
             </Button>
           </Box>

--- a/apps/webApp/src/app/components/services/ServiceDialog.tsx
+++ b/apps/webApp/src/app/components/services/ServiceDialog.tsx
@@ -11,11 +11,16 @@ import {
 } from '@mui/material';
 import { Close as CloseIcon } from '@mui/icons-material';
 import { ServiceDto } from '@gt-automotive/data';
+import { NumberInput } from '../common';
 
 interface ServiceDialogProps {
   open: boolean;
   onClose: () => void;
-  onSave: (service: { name: string; description?: string; unitPrice: number }) => void;
+  onSave: (service: {
+    name: string;
+    description?: string;
+    unitPrice: number;
+  }) => void;
   service?: ServiceDto | null;
 }
 
@@ -27,7 +32,9 @@ export const ServiceDialog: React.FC<ServiceDialogProps> = ({
 }) => {
   const [name, setName] = useState(service?.name || '');
   const [description, setDescription] = useState(service?.description || '');
-  const [unitPrice, setUnitPrice] = useState<number | string>(service?.unitPrice || '');
+  const [unitPrice, setUnitPrice] = useState<number | string>(
+    service?.unitPrice || ''
+  );
 
   React.useEffect(() => {
     if (service) {
@@ -57,7 +64,13 @@ export const ServiceDialog: React.FC<ServiceDialogProps> = ({
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         {service ? 'Edit Service' : 'Add New Service'}
         <IconButton onClick={handleClose} size="small">
           <CloseIcon />
@@ -82,14 +95,14 @@ export const ServiceDialog: React.FC<ServiceDialogProps> = ({
             rows={2}
             placeholder="Brief description of the service"
           />
-          <TextField
+          <NumberInput
             label="Unit Price"
-            type="number"
+            allowDecimals
+            min={0}
             value={unitPrice}
-            onChange={(e) => setUnitPrice(e.target.value)}
+            onChange={(v) => setUnitPrice(v ?? '')}
             fullWidth
             required
-            inputProps={{ min: 0, step: 0.01 }}
             autoComplete="off"
           />
         </Box>

--- a/apps/webApp/src/app/pages/admin/payroll/PayoutRulesManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/PayoutRulesManagement.tsx
@@ -35,6 +35,7 @@ import {
   CreatePayoutRuleDto,
   DEFAULT_PAYOUT_PERCENTAGE,
 } from '../../../requests/payout-rule.requests';
+import { NumberInput } from '../../../components/common';
 import { useConfirmation } from '../../../contexts/ConfirmationContext';
 import { useError } from '../../../contexts/ErrorContext';
 
@@ -45,7 +46,12 @@ interface RuleDialogProps {
   onSave: (dto: CreatePayoutRuleDto) => Promise<void>;
 }
 
-const RuleDialog: React.FC<RuleDialogProps> = ({ open, rule, onClose, onSave }) => {
+const RuleDialog: React.FC<RuleDialogProps> = ({
+  open,
+  rule,
+  onClose,
+  onSave,
+}) => {
   const [triggerAmount, setTriggerAmount] = useState('');
   const [payoutAmount, setPayoutAmount] = useState('');
   const [description, setDescription] = useState('');
@@ -85,7 +91,9 @@ const RuleDialog: React.FC<RuleDialogProps> = ({ open, rule, onClose, onSave }) 
       });
       onClose();
     } catch (err: any) {
-      setError(err?.response?.data?.message || err?.message || 'Failed to save rule');
+      setError(
+        err?.response?.data?.message || err?.message || 'Failed to save rule'
+      );
     } finally {
       setSaving(false);
     }
@@ -101,21 +109,31 @@ const RuleDialog: React.FC<RuleDialogProps> = ({ open, rule, onClose, onSave }) 
               {error}
             </Typography>
           )}
-          <TextField
+          <NumberInput
             label="Appointment Total (Trigger)"
-            type="number"
+            allowDecimals
+            min={0}
             value={triggerAmount}
-            onChange={(e) => setTriggerAmount(e.target.value)}
-            InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+            onChange={(v) => setTriggerAmount(v === undefined ? '' : String(v))}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">$</InputAdornment>
+              ),
+            }}
             helperText="When the appointment payment equals this amount, this rule applies"
             fullWidth
           />
-          <TextField
+          <NumberInput
             label="Total Payout (Pool)"
-            type="number"
+            allowDecimals
+            min={0}
             value={payoutAmount}
-            onChange={(e) => setPayoutAmount(e.target.value)}
-            InputProps={{ startAdornment: <InputAdornment position="start">$</InputAdornment> }}
+            onChange={(v) => setPayoutAmount(v === undefined ? '' : String(v))}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">$</InputAdornment>
+              ),
+            }}
             helperText="Pool split equally among the employees who completed the appointment"
             fullWidth
           />
@@ -127,8 +145,13 @@ const RuleDialog: React.FC<RuleDialogProps> = ({ open, rule, onClose, onSave }) 
             fullWidth
           />
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Switch checked={isActive} onChange={(e) => setIsActive(e.target.checked)} />
-            <Typography variant="body2">{isActive ? 'Active' : 'Inactive'}</Typography>
+            <Switch
+              checked={isActive}
+              onChange={(e) => setIsActive(e.target.checked)}
+            />
+            <Typography variant="body2">
+              {isActive ? 'Active' : 'Inactive'}
+            </Typography>
           </Box>
         </Stack>
       </DialogContent>
@@ -202,15 +225,26 @@ export const PayoutRulesManagement: React.FC = () => {
 
   return (
     <Box sx={{ p: { xs: 2, sm: 3 } }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, gap: 1, flexWrap: 'wrap' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+          gap: 1,
+          flexWrap: 'wrap',
+        }}
+      >
         <Box>
           <Typography variant="h5" sx={{ fontWeight: 700 }}>
             Appointment Payout Rules
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            When an appointment is completed for one of these amounts, the payout pool below
-            is split equally among the employees who completed it. Anything not in the table
-            falls back to {Math.round(DEFAULT_PAYOUT_PERCENTAGE * 100)}% of the appointment total.
+            When an appointment is completed for one of these amounts, the
+            payout pool below is split equally among the employees who completed
+            it. Anything not in the table falls back to{' '}
+            {Math.round(DEFAULT_PAYOUT_PERCENTAGE * 100)}% of the appointment
+            total.
           </Typography>
         </Box>
         <Button
@@ -234,7 +268,8 @@ export const PayoutRulesManagement: React.FC = () => {
           <Box sx={{ p: 4, textAlign: 'center' }}>
             <CalculateIcon sx={{ fontSize: 40, color: 'text.disabled' }} />
             <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              No payout rules yet. All completed appointments will use the {Math.round(DEFAULT_PAYOUT_PERCENTAGE * 100)}% default.
+              No payout rules yet. All completed appointments will use the{' '}
+              {Math.round(DEFAULT_PAYOUT_PERCENTAGE * 100)}% default.
             </Typography>
           </Box>
         ) : (
@@ -270,12 +305,22 @@ export const PayoutRulesManagement: React.FC = () => {
                       </TableCell>
                       <TableCell align="right">
                         <Tooltip title="Edit">
-                          <IconButton size="small" onClick={() => { setEditing(rule); setDialogOpen(true); }}>
+                          <IconButton
+                            size="small"
+                            onClick={() => {
+                              setEditing(rule);
+                              setDialogOpen(true);
+                            }}
+                          >
                             <EditIcon fontSize="small" />
                           </IconButton>
                         </Tooltip>
                         <Tooltip title="Delete">
-                          <IconButton size="small" color="error" onClick={() => handleDelete(rule)}>
+                          <IconButton
+                            size="small"
+                            color="error"
+                            onClick={() => handleDelete(rule)}
+                          >
                             <DeleteIcon fontSize="small" />
                           </IconButton>
                         </Tooltip>

--- a/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
@@ -45,17 +45,24 @@ import {
   WorkspacePremium,
 } from '@mui/icons-material';
 import { format, startOfMonth, endOfMonth } from 'date-fns';
-import { PayType, TimeEntryDto, TimeEntryStatus, UpsertEmployeeCompensationDto } from '@gt-automotive/data';
+import {
+  PayType,
+  TimeEntryDto,
+  TimeEntryStatus,
+  UpsertEmployeeCompensationDto,
+} from '@gt-automotive/data';
+import { NumberInput } from '../../../components/common';
 import { User, userService } from '../../../requests/user.requests';
 import { timeClockService } from '../../../requests/time-clock.requests';
 import { useAuth } from '../../../hooks/useAuth';
 import { colors } from '../../../theme/colors';
 
 const formatHours = (minutes: number) => `${(minutes / 60).toFixed(2)} hrs`;
-const formatCurrency = (amount: number) => new Intl.NumberFormat('en-CA', {
-  style: 'currency',
-  currency: 'CAD',
-}).format(amount);
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(amount);
 const formatStatus = (status: TimeEntryStatus) => {
   if (status === TimeEntryStatus.OPEN) return 'Clocked In';
   if (status === TimeEntryStatus.ON_BREAK) return 'On Break';
@@ -65,7 +72,9 @@ const formatStatus = (status: TimeEntryStatus) => {
 const toDateTimeLocal = (value?: string) => {
   if (!value) return '';
   const date = new Date(value);
-  const offsetDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  const offsetDate = new Date(
+    date.getTime() - date.getTimezoneOffset() * 60000
+  );
   return offsetDate.toISOString().slice(0, 16);
 };
 
@@ -77,7 +86,11 @@ interface TabPanelProps {
 
 function TabPanel({ children, value, index }: TabPanelProps) {
   return (
-    <div role="tabpanel" hidden={value !== index} id={`time-clock-tabpanel-${index}`}>
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`time-clock-tabpanel-${index}`}
+    >
       {value === index && <Box sx={{ pt: 3 }}>{children}</Box>}
     </div>
   );
@@ -89,7 +102,9 @@ export function TimeClockManagement() {
   const [users, setUsers] = useState<User[]>([]);
   const [entries, setEntries] = useState<TimeEntryDto[]>([]);
   const [currentEntries, setCurrentEntries] = useState<TimeEntryDto[]>([]);
-  const [myCurrentEntry, setMyCurrentEntry] = useState<TimeEntryDto | null>(null);
+  const [myCurrentEntry, setMyCurrentEntry] = useState<TimeEntryDto | null>(
+    null
+  );
   const [selectedEmployeeId, setSelectedEmployeeId] = useState('');
   const [payType, setPayType] = useState<PayType>(PayType.HOURLY);
   const [hourlyRate, setHourlyRate] = useState('');
@@ -103,7 +118,9 @@ export function TimeClockManagement() {
   const [deletingEntry, setDeletingEntry] = useState<TimeEntryDto | null>(null);
   const [deleteReason, setDeleteReason] = useState('');
   const [filterEmployeeId, setFilterEmployeeId] = useState('');
-  const [filterStatus, setFilterStatus] = useState<'ALL' | TimeEntryStatus>('ALL');
+  const [filterStatus, setFilterStatus] = useState<'ALL' | TimeEntryStatus>(
+    'ALL'
+  );
   const [filterStartDate, setFilterStartDate] = useState('');
   const [filterEndDate, setFilterEndDate] = useState('');
   const [loading, setLoading] = useState(true);
@@ -124,7 +141,9 @@ export function TimeClockManagement() {
         }),
       ]);
       const myCurrent = await timeClockService.getMyCurrent();
-      const employees = userData.filter((user) => ['ADMIN', 'SUPERVISOR', 'STAFF'].includes(user.role?.name || ''));
+      const employees = userData.filter((user) =>
+        ['ADMIN', 'SUPERVISOR', 'STAFF'].includes(user.role?.name || '')
+      );
       setUsers(employees);
       setCurrentEntries(currentData);
       setEntries(entryData);
@@ -148,7 +167,9 @@ export function TimeClockManagement() {
 
     const loadCompensation = async () => {
       try {
-        const compensation = await timeClockService.getCompensation(selectedEmployeeId);
+        const compensation = await timeClockService.getCompensation(
+          selectedEmployeeId
+        );
         if (compensation) {
           setPayType(compensation.payType);
           setHourlyRate(compensation.hourlyRate?.toString() || '');
@@ -167,61 +188,114 @@ export function TimeClockManagement() {
   }, [selectedEmployeeId]);
 
   const selectedEmployee = users.find((user) => user.id === selectedEmployeeId);
-  const currentEntryByEmployeeId = new Map(currentEntries.map((entry) => [entry.employeeId, entry]));
+  const currentEntryByEmployeeId = new Map(
+    currentEntries.map((entry) => [entry.employeeId, entry])
+  );
   const monthStart = startOfMonth(new Date()).toISOString();
   const monthEnd = endOfMonth(new Date()).toISOString();
   const monthLabel = format(new Date(), 'MMMM yyyy');
-  const selectedReadyEntries = entries.filter((entry) =>
-    entry.employeeId === selectedEmployeeId &&
-    entry.status === TimeEntryStatus.APPROVED &&
-    !entry.payrollProcessedAt
+  const selectedReadyEntries = entries.filter(
+    (entry) =>
+      entry.employeeId === selectedEmployeeId &&
+      entry.status === TimeEntryStatus.APPROVED &&
+      !entry.payrollProcessedAt
   );
-  const selectedReadyHours = selectedReadyEntries.reduce((sum, entry) => sum + entry.paidMinutes / 60, 0);
-  const selectedProcessedEntries = entries.filter((entry) =>
-    entry.employeeId === selectedEmployeeId &&
-    Boolean(entry.payrollProcessedAt)
+  const selectedReadyHours = selectedReadyEntries.reduce(
+    (sum, entry) => sum + entry.paidMinutes / 60,
+    0
   );
-  const selectedProcessedHours = selectedProcessedEntries.reduce((sum, entry) => sum + entry.paidMinutes / 60, 0);
-  const selectedEstimatedPay = payType === PayType.HOURLY ? selectedReadyHours * Number(hourlyRate || 0) : 0;
+  const selectedProcessedEntries = entries.filter(
+    (entry) =>
+      entry.employeeId === selectedEmployeeId &&
+      Boolean(entry.payrollProcessedAt)
+  );
+  const selectedProcessedHours = selectedProcessedEntries.reduce(
+    (sum, entry) => sum + entry.paidMinutes / 60,
+    0
+  );
+  const selectedEstimatedPay =
+    payType === PayType.HOURLY
+      ? selectedReadyHours * Number(hourlyRate || 0)
+      : 0;
 
   // Dashboard aggregate stats across all employees for the current month
   const totalReadyHours = useMemo(
-    () => entries
-      .filter((entry) => entry.status === TimeEntryStatus.APPROVED && !entry.payrollProcessedAt)
-      .reduce((sum, entry) => sum + entry.paidMinutes / 60, 0),
-    [entries],
+    () =>
+      entries
+        .filter(
+          (entry) =>
+            entry.status === TimeEntryStatus.APPROVED &&
+            !entry.payrollProcessedAt
+        )
+        .reduce((sum, entry) => sum + entry.paidMinutes / 60, 0),
+    [entries]
   );
   const totalProcessedHours = useMemo(
-    () => entries
-      .filter((entry) => Boolean(entry.payrollProcessedAt))
-      .reduce((sum, entry) => sum + entry.paidMinutes / 60, 0),
-    [entries],
+    () =>
+      entries
+        .filter((entry) => Boolean(entry.payrollProcessedAt))
+        .reduce((sum, entry) => sum + entry.paidMinutes / 60, 0),
+    [entries]
   );
   const pendingApprovalCount = useMemo(
-    () => entries.filter((entry) => entry.clockOutAt && entry.status !== TimeEntryStatus.APPROVED && entry.status !== TimeEntryStatus.VOIDED).length,
-    [entries],
+    () =>
+      entries.filter(
+        (entry) =>
+          entry.clockOutAt &&
+          entry.status !== TimeEntryStatus.APPROVED &&
+          entry.status !== TimeEntryStatus.VOIDED
+      ).length,
+    [entries]
   );
 
   const summaryStats = [
-    { label: 'Clocked In Now', value: String(currentEntries.length), icon: <Groups />, color: colors.primary.main },
-    { label: 'Ready for Payroll', value: `${totalReadyHours.toFixed(1)} hrs`, icon: <HourglassEmpty />, color: colors.semantic.warning },
-    { label: 'Pending Approval', value: String(pendingApprovalCount), icon: <PendingActions />, color: colors.semantic.info },
-    { label: 'Processed This Month', value: `${totalProcessedHours.toFixed(1)} hrs`, icon: <CheckCircle />, color: colors.semantic.success },
+    {
+      label: 'Clocked In Now',
+      value: String(currentEntries.length),
+      icon: <Groups />,
+      color: colors.primary.main,
+    },
+    {
+      label: 'Ready for Payroll',
+      value: `${totalReadyHours.toFixed(1)} hrs`,
+      icon: <HourglassEmpty />,
+      color: colors.semantic.warning,
+    },
+    {
+      label: 'Pending Approval',
+      value: String(pendingApprovalCount),
+      icon: <PendingActions />,
+      color: colors.semantic.info,
+    },
+    {
+      label: 'Processed This Month',
+      value: `${totalProcessedHours.toFixed(1)} hrs`,
+      icon: <CheckCircle />,
+      color: colors.semantic.success,
+    },
   ];
 
   const filteredEntries = useMemo(
-    () => entries.filter((entry) => {
-      if (filterEmployeeId && entry.employeeId !== filterEmployeeId) return false;
-      if (filterStatus !== 'ALL' && entry.status !== filterStatus) return false;
-      const entryDate = format(new Date(entry.clockInAt), 'yyyy-MM-dd');
-      if (filterStartDate && entryDate < filterStartDate) return false;
-      if (filterEndDate && entryDate > filterEndDate) return false;
-      return true;
-    }),
-    [entries, filterEmployeeId, filterStatus, filterStartDate, filterEndDate],
+    () =>
+      entries.filter((entry) => {
+        if (filterEmployeeId && entry.employeeId !== filterEmployeeId)
+          return false;
+        if (filterStatus !== 'ALL' && entry.status !== filterStatus)
+          return false;
+        const entryDate = format(new Date(entry.clockInAt), 'yyyy-MM-dd');
+        if (filterStartDate && entryDate < filterStartDate) return false;
+        if (filterEndDate && entryDate > filterEndDate) return false;
+        return true;
+      }),
+    [entries, filterEmployeeId, filterStatus, filterStartDate, filterEndDate]
   );
 
-  const hasEntryFilters = Boolean(filterEmployeeId || filterStatus !== 'ALL' || filterStartDate || filterEndDate);
+  const hasEntryFilters = Boolean(
+    filterEmployeeId ||
+      filterStatus !== 'ALL' ||
+      filterStartDate ||
+      filterEndDate
+  );
   const clearEntryFilters = () => {
     setFilterEmployeeId('');
     setFilterStatus('ALL');
@@ -234,7 +308,8 @@ export function TimeClockManagement() {
     const payload: UpsertEmployeeCompensationDto = {
       payType,
       hourlyRate: payType === PayType.HOURLY ? Number(hourlyRate) : undefined,
-      annualSalary: payType === PayType.SALARIED ? Number(annualSalary) : undefined,
+      annualSalary:
+        payType === PayType.SALARIED ? Number(annualSalary) : undefined,
     };
 
     try {
@@ -317,7 +392,9 @@ export function TimeClockManagement() {
       setError(null);
       await timeClockService.updateEntry(editingEntry.id, {
         clockInAt: new Date(editClockInAt).toISOString(),
-        clockOutAt: editClockOutAt ? new Date(editClockOutAt).toISOString() : undefined,
+        clockOutAt: editClockOutAt
+          ? new Date(editClockOutAt).toISOString()
+          : undefined,
         adjustmentReason: editReason,
       });
       setEditingEntry(null);
@@ -340,7 +417,10 @@ export function TimeClockManagement() {
     try {
       setSaving(true);
       setError(null);
-      await timeClockService.voidEntry(deletingEntry.id, deleteReason || 'Deleted by admin');
+      await timeClockService.voidEntry(
+        deletingEntry.id,
+        deleteReason || 'Deleted by admin'
+      );
       setDeletingEntry(null);
       await loadData();
       setMessage('Time entry deleted');
@@ -351,7 +431,10 @@ export function TimeClockManagement() {
     }
   };
 
-  const runMyClockAction = async (action: () => Promise<TimeEntryDto>, successMessage: string) => {
+  const runMyClockAction = async (
+    action: () => Promise<TimeEntryDto>,
+    successMessage: string
+  ) => {
     try {
       setSaving(true);
       setError(null);
@@ -370,7 +453,9 @@ export function TimeClockManagement() {
       setSaving(true);
       setError(null);
       await timeClockService.adminClockIn(employee.id, {
-        notes: `Clocked in by admin for ${employee.firstName || ''} ${employee.lastName || ''}`.trim(),
+        notes: `Clocked in by admin for ${employee.firstName || ''} ${
+          employee.lastName || ''
+        }`.trim(),
       });
       await loadData();
       setMessage(`${employee.firstName || employee.email} clocked in`);
@@ -386,7 +471,9 @@ export function TimeClockManagement() {
       setSaving(true);
       setError(null);
       await timeClockService.adminClockOut(employee.id, {
-        notes: `Clocked out by admin for ${employee.firstName || ''} ${employee.lastName || ''}`.trim(),
+        notes: `Clocked out by admin for ${employee.firstName || ''} ${
+          employee.lastName || ''
+        }`.trim(),
       });
       await loadData();
       setMessage(`${employee.firstName || employee.email} clocked out`);
@@ -410,29 +497,55 @@ export function TimeClockManagement() {
 
   return (
     <Box sx={{ px: { xs: 1, sm: 0 } }}>
-      <Box sx={{
-        mb: 3,
-        display: 'flex',
-        flexDirection: { xs: 'column', sm: 'row' },
-        alignItems: { xs: 'stretch', sm: 'center' },
-        justifyContent: 'space-between',
-        gap: 2,
-      }}>
+      <Box
+        sx={{
+          mb: 3,
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          alignItems: { xs: 'stretch', sm: 'center' },
+          justifyContent: 'space-between',
+          gap: 2,
+        }}
+      >
         <Box>
-          <Typography variant="h4" sx={{ fontWeight: 700, color: colors.primary.main, fontSize: { xs: '1.6rem', sm: '2.125rem' } }}>
+          <Typography
+            variant="h4"
+            sx={{
+              fontWeight: 700,
+              color: colors.primary.main,
+              fontSize: { xs: '1.6rem', sm: '2.125rem' },
+            }}
+          >
             Time Clock
           </Typography>
           <Typography variant="body2" color="text.secondary">
             Manage employee hours, hourly rates, salary profiles, and bonuses
           </Typography>
         </Box>
-        <Button startIcon={<Refresh />} onClick={loadData} disabled={saving} sx={{ alignSelf: { xs: 'flex-start', sm: 'center' } }}>
+        <Button
+          startIcon={<Refresh />}
+          onClick={loadData}
+          disabled={saving}
+          sx={{ alignSelf: { xs: 'flex-start', sm: 'center' } }}
+        >
           Refresh
         </Button>
       </Box>
 
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-      {message && <Alert severity="success" sx={{ mb: 2 }} onClose={() => setMessage(null)}>{message}</Alert>}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      {message && (
+        <Alert
+          severity="success"
+          sx={{ mb: 2 }}
+          onClose={() => setMessage(null)}
+        >
+          {message}
+        </Alert>
+      )}
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Tabs
@@ -448,7 +561,11 @@ export function TimeClockManagement() {
           }}
         >
           <Tab icon={<AccessTime />} iconPosition="start" label="Dashboard" />
-          <Tab icon={<Payment />} iconPosition="start" label="This Month's Entries" />
+          <Tab
+            icon={<Payment />}
+            iconPosition="start"
+            label="This Month's Entries"
+          />
         </Tabs>
       </Box>
 
@@ -457,23 +574,44 @@ export function TimeClockManagement() {
         <Grid container spacing={{ xs: 1.5, sm: 2.5 }} sx={{ mb: 3 }}>
           {summaryStats.map((stat) => (
             <Grid size={{ xs: 6, md: 3 }} key={stat.label}>
-              <Card elevation={0} sx={{ height: '100%', border: `1px solid ${colors.neutral[200]}` }}>
+              <Card
+                elevation={0}
+                sx={{
+                  height: '100%',
+                  border: `1px solid ${colors.neutral[200]}`,
+                }}
+              >
                 <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, mb: 1 }}>
-                    <Box sx={{
+                  <Box
+                    sx={{
                       display: 'flex',
                       alignItems: 'center',
-                      justifyContent: 'center',
-                      width: 40,
-                      height: 40,
-                      borderRadius: 1.5,
-                      color: stat.color,
-                      backgroundColor: `${stat.color}1A`,
-                    }}>
+                      gap: 1.25,
+                      mb: 1,
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: 40,
+                        height: 40,
+                        borderRadius: 1.5,
+                        color: stat.color,
+                        backgroundColor: `${stat.color}1A`,
+                      }}
+                    >
                       {stat.icon}
                     </Box>
                   </Box>
-                  <Typography variant="h4" sx={{ fontWeight: 700, fontSize: { xs: '1.5rem', sm: '2rem' } }}>
+                  <Typography
+                    variant="h4"
+                    sx={{
+                      fontWeight: 700,
+                      fontSize: { xs: '1.5rem', sm: '2rem' },
+                    }}
+                  >
                     {stat.value}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
@@ -485,21 +623,49 @@ export function TimeClockManagement() {
           ))}
         </Grid>
 
-        <Card elevation={0} sx={{ mb: 3, border: `1px solid ${colors.neutral[200]}` }}>
+        <Card
+          elevation={0}
+          sx={{ mb: 3, border: `1px solid ${colors.neutral[200]}` }}
+        >
           <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
             <Grid container spacing={2.5} alignItems="center">
               <Grid size={{ xs: 12, md: 6 }}>
                 <Typography variant="h6" sx={{ fontWeight: 700 }}>
                   My Time Clock
                 </Typography>
-                <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1.25, mt: 1 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    flexWrap: 'wrap',
+                    gap: 1.25,
+                    mt: 1,
+                  }}
+                >
                   <Chip
-                    color={isOnBreak ? 'warning' : isClockedIn ? 'success' : 'default'}
-                    label={isOnBreak ? 'On Break' : isClockedIn ? 'Clocked In' : 'Clocked Out'}
+                    color={
+                      isOnBreak
+                        ? 'warning'
+                        : isClockedIn
+                        ? 'success'
+                        : 'default'
+                    }
+                    label={
+                      isOnBreak
+                        ? 'On Break'
+                        : isClockedIn
+                        ? 'Clocked In'
+                        : 'Clocked Out'
+                    }
                   />
                   {myCurrentEntry && (
                     <Typography variant="body2" color="text.secondary">
-                      Since {format(new Date(myCurrentEntry.clockInAt), 'MMM d, h:mm a')} · {formatHours(myCurrentEntry.paidMinutes)}
+                      Since{' '}
+                      {format(
+                        new Date(myCurrentEntry.clockInAt),
+                        'MMM d, h:mm a'
+                      )}{' '}
+                      · {formatHours(myCurrentEntry.paidMinutes)}
                     </Typography>
                   )}
                   {!myCurrentEntry && user && (
@@ -510,13 +676,26 @@ export function TimeClockManagement() {
                 </Box>
               </Grid>
               <Grid size={{ xs: 12, md: 6 }}>
-                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, flexWrap: 'wrap', justifyContent: { xs: 'flex-start', md: 'flex-end' }, gap: 1.25 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: { xs: 'column', sm: 'row' },
+                    flexWrap: 'wrap',
+                    justifyContent: { xs: 'flex-start', md: 'flex-end' },
+                    gap: 1.25,
+                  }}
+                >
                   {!isClockedIn && (
                     <Button
                       variant="contained"
                       startIcon={<Login />}
                       disabled={saving}
-                      onClick={() => runMyClockAction(() => timeClockService.clockIn(), 'Clocked in')}
+                      onClick={() =>
+                        runMyClockAction(
+                          () => timeClockService.clockIn(),
+                          'Clocked in'
+                        )
+                      }
                       sx={{ width: { xs: '100%', sm: 'auto' } }}
                     >
                       Clock In
@@ -527,7 +706,12 @@ export function TimeClockManagement() {
                       variant="outlined"
                       startIcon={<Coffee />}
                       disabled={saving}
-                      onClick={() => runMyClockAction(() => timeClockService.startBreak(), 'Break started')}
+                      onClick={() =>
+                        runMyClockAction(
+                          () => timeClockService.startBreak(),
+                          'Break started'
+                        )
+                      }
                       sx={{ width: { xs: '100%', sm: 'auto' } }}
                     >
                       Start Break
@@ -538,7 +722,12 @@ export function TimeClockManagement() {
                       variant="outlined"
                       startIcon={<PlayArrow />}
                       disabled={saving}
-                      onClick={() => runMyClockAction(() => timeClockService.endBreak(), 'Break ended')}
+                      onClick={() =>
+                        runMyClockAction(
+                          () => timeClockService.endBreak(),
+                          'Break ended'
+                        )
+                      }
                       sx={{ width: { xs: '100%', sm: 'auto' } }}
                     >
                       End Break
@@ -550,7 +739,12 @@ export function TimeClockManagement() {
                       color="error"
                       startIcon={<Logout />}
                       disabled={saving}
-                      onClick={() => runMyClockAction(() => timeClockService.clockOut(), 'Clocked out')}
+                      onClick={() =>
+                        runMyClockAction(
+                          () => timeClockService.clockOut(),
+                          'Clocked out'
+                        )
+                      }
                       sx={{ width: { xs: '100%', sm: 'auto' } }}
                     >
                       Clock Out
@@ -562,7 +756,10 @@ export function TimeClockManagement() {
           </CardContent>
         </Card>
 
-        <Card elevation={0} sx={{ mb: 4, border: `1px solid ${colors.neutral[200]}` }}>
+        <Card
+          elevation={0}
+          sx={{ mb: 4, border: `1px solid ${colors.neutral[200]}` }}
+        >
           <CardContent sx={{ p: { xs: 2, sm: 3 } }}>
             <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
               Compensation & Bonus
@@ -574,7 +771,9 @@ export function TimeClockManagement() {
                   fullWidth
                   label="Employee"
                   value={selectedEmployeeId}
-                  onChange={(event) => setSelectedEmployeeId(event.target.value)}
+                  onChange={(event) =>
+                    setSelectedEmployeeId(event.target.value)
+                  }
                 >
                   {users.map((user) => (
                     <MenuItem key={user.id} value={user.id}>
@@ -589,33 +788,52 @@ export function TimeClockManagement() {
                   fullWidth
                   label="Pay Type"
                   value={payType}
-                  onChange={(event) => setPayType(event.target.value as PayType)}
+                  onChange={(event) =>
+                    setPayType(event.target.value as PayType)
+                  }
                 >
                   <MenuItem value={PayType.HOURLY}>Hourly</MenuItem>
                   <MenuItem value={PayType.SALARIED}>Salaried</MenuItem>
                 </TextField>
               </Grid>
               <Grid size={{ xs: 12, md: 3 }}>
-                <TextField
+                <NumberInput
                   fullWidth
-                  type="number"
-                  label={payType === PayType.HOURLY ? 'Hourly Rate' : 'Annual Salary'}
+                  allowDecimals
+                  min={0}
+                  label={
+                    payType === PayType.HOURLY ? 'Hourly Rate' : 'Annual Salary'
+                  }
                   value={payType === PayType.HOURLY ? hourlyRate : annualSalary}
-                  onChange={(event) => payType === PayType.HOURLY ? setHourlyRate(event.target.value) : setAnnualSalary(event.target.value)}
+                  onChange={(v) => {
+                    const next = v === undefined ? '' : String(v);
+                    payType === PayType.HOURLY
+                      ? setHourlyRate(next)
+                      : setAnnualSalary(next);
+                  }}
                 />
               </Grid>
               <Grid size={{ xs: 12, md: 2 }}>
-                <Button fullWidth variant="contained" startIcon={<Save />} onClick={saveCompensation} disabled={saving || !selectedEmployeeId}>
+                <Button
+                  fullWidth
+                  variant="contained"
+                  startIcon={<Save />}
+                  onClick={saveCompensation}
+                  disabled={saving || !selectedEmployeeId}
+                >
                   Save
                 </Button>
               </Grid>
               <Grid size={{ xs: 12, md: 3 }}>
-                <TextField
+                <NumberInput
                   fullWidth
-                  type="number"
+                  allowDecimals
+                  min={0}
                   label="Bonus Amount"
                   value={bonusAmount}
-                  onChange={(event) => setBonusAmount(event.target.value)}
+                  onChange={(v) =>
+                    setBonusAmount(v === undefined ? '' : String(v))
+                  }
                 />
               </Grid>
               <Grid size={{ xs: 12, md: 7 }}>
@@ -632,17 +850,33 @@ export function TimeClockManagement() {
                   variant="outlined"
                   startIcon={<WorkspacePremium />}
                   onClick={addBonus}
-                  disabled={saving || !selectedEmployeeId || !bonusAmount || !bonusReason}
+                  disabled={
+                    saving ||
+                    !selectedEmployeeId ||
+                    !bonusAmount ||
+                    !bonusReason
+                  }
                 >
                   Bonus
                 </Button>
               </Grid>
             </Grid>
             {selectedEmployee && (
-              <Box sx={{ mt: 2.5, p: 2, border: `1px solid ${colors.neutral[200]}`, borderRadius: 1 }}>
+              <Box
+                sx={{
+                  mt: 2.5,
+                  p: 2,
+                  border: `1px solid ${colors.neutral[200]}`,
+                  borderRadius: 1,
+                }}
+              >
                 <Grid container spacing={2} alignItems="center">
                   <Grid size={{ xs: 12, md: 4 }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block' }}
+                    >
                       Ready for Payroll
                     </Typography>
                     <Typography variant="h6" sx={{ fontWeight: 700 }}>
@@ -650,15 +884,26 @@ export function TimeClockManagement() {
                     </Typography>
                   </Grid>
                   <Grid size={{ xs: 12, md: 3 }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block' }}
+                    >
                       Estimated Pay
                     </Typography>
-                    <Typography variant="h6" sx={{ fontWeight: 700, color: colors.semantic.success }}>
+                    <Typography
+                      variant="h6"
+                      sx={{ fontWeight: 700, color: colors.semantic.success }}
+                    >
                       {formatCurrency(selectedEstimatedPay)}
                     </Typography>
                   </Grid>
                   <Grid size={{ xs: 12, md: 3 }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block' }}
+                    >
                       Processed This Month
                     </Typography>
                     <Typography variant="h6" sx={{ fontWeight: 700 }}>
@@ -677,8 +922,14 @@ export function TimeClockManagement() {
                     </Button>
                   </Grid>
                 </Grid>
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1.5 }}>
-                  Approved hours for {selectedEmployee.firstName} {selectedEmployee.lastName} stay ready until payroll is processed.
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: 'block', mt: 1.5 }}
+                >
+                  Approved hours for {selectedEmployee.firstName}{' '}
+                  {selectedEmployee.lastName} stay ready until payroll is
+                  processed.
                 </Typography>
               </Box>
             )}
@@ -693,26 +944,60 @@ export function TimeClockManagement() {
             const activeEntry = currentEntryByEmployeeId.get(employee.id);
             return (
               <Grid size={{ xs: 12, sm: 6, lg: 4 }} key={employee.id}>
-                <Card elevation={0} sx={{ height: '100%', border: `1px solid ${colors.neutral[200]}` }}>
+                <Card
+                  elevation={0}
+                  sx={{
+                    height: '100%',
+                    border: `1px solid ${colors.neutral[200]}`,
+                  }}
+                >
                   <CardContent sx={{ p: { xs: 2, sm: 2.5 } }}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1.5, alignItems: 'flex-start' }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        gap: 1.5,
+                        alignItems: 'flex-start',
+                      }}
+                    >
                       <Box sx={{ minWidth: 0 }}>
-                        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                        <Typography
+                          variant="subtitle1"
+                          sx={{ fontWeight: 700 }}
+                        >
                           {employee.firstName} {employee.lastName}
                         </Typography>
-                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ display: 'block' }}
+                        >
                           {employee.role?.name} · {employee.email}
                         </Typography>
                       </Box>
                       <Chip
                         size="small"
-                        color={activeEntry ? activeEntry.status === TimeEntryStatus.ON_BREAK ? 'warning' : 'success' : 'default'}
-                        label={activeEntry ? formatStatus(activeEntry.status) : 'Out'}
+                        color={
+                          activeEntry
+                            ? activeEntry.status === TimeEntryStatus.ON_BREAK
+                              ? 'warning'
+                              : 'success'
+                            : 'default'
+                        }
+                        label={
+                          activeEntry ? formatStatus(activeEntry.status) : 'Out'
+                        }
                       />
                     </Box>
                     {activeEntry && (
-                      <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
-                        Since {format(new Date(activeEntry.clockInAt), 'h:mm a')} · {formatHours(activeEntry.paidMinutes)}
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ mt: 2 }}
+                      >
+                        Since{' '}
+                        {format(new Date(activeEntry.clockInAt), 'h:mm a')} ·{' '}
+                        {formatHours(activeEntry.paidMinutes)}
                       </Typography>
                     )}
                     {activeEntry ? (
@@ -749,14 +1034,16 @@ export function TimeClockManagement() {
 
       {/* This Month's Entries tab */}
       <TabPanel value={activeTab} index={1}>
-        <Box sx={{
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          alignItems: { xs: 'stretch', sm: 'center' },
-          justifyContent: 'space-between',
-          gap: 2,
-          mb: 2.5,
-        }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            alignItems: { xs: 'stretch', sm: 'center' },
+            justifyContent: 'space-between',
+            gap: 2,
+            mb: 2.5,
+          }}
+        >
           <Box>
             <Typography variant="h6" sx={{ fontWeight: 700 }}>
               Time Entries · {monthLabel}
@@ -765,7 +1052,14 @@ export function TimeClockManagement() {
               Showing {filteredEntries.length} of {entries.length} entries
             </Typography>
           </Box>
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5, width: { xs: '100%', sm: 'auto' } }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 1.5,
+              width: { xs: '100%', sm: 'auto' },
+            }}
+          >
             <TextField
               select
               size="small"
@@ -786,7 +1080,9 @@ export function TimeClockManagement() {
               size="small"
               label="Status"
               value={filterStatus}
-              onChange={(event) => setFilterStatus(event.target.value as 'ALL' | TimeEntryStatus)}
+              onChange={(event) =>
+                setFilterStatus(event.target.value as 'ALL' | TimeEntryStatus)
+              }
               sx={{ minWidth: { sm: 150 }, flex: { xs: 1, sm: 'none' } }}
             >
               <MenuItem value="ALL">All Statuses</MenuItem>
@@ -803,7 +1099,11 @@ export function TimeClockManagement() {
               value={filterStartDate}
               onChange={(event) => setFilterStartDate(event.target.value)}
               InputLabelProps={{ shrink: true }}
-              inputProps={{ min: format(startOfMonth(new Date()), 'yyyy-MM-dd'), max: filterEndDate || format(endOfMonth(new Date()), 'yyyy-MM-dd') }}
+              inputProps={{
+                min: format(startOfMonth(new Date()), 'yyyy-MM-dd'),
+                max:
+                  filterEndDate || format(endOfMonth(new Date()), 'yyyy-MM-dd'),
+              }}
               sx={{ minWidth: { sm: 150 }, flex: { xs: 1, sm: 'none' } }}
             />
             <TextField
@@ -813,11 +1113,20 @@ export function TimeClockManagement() {
               value={filterEndDate}
               onChange={(event) => setFilterEndDate(event.target.value)}
               InputLabelProps={{ shrink: true }}
-              inputProps={{ min: filterStartDate || format(startOfMonth(new Date()), 'yyyy-MM-dd'), max: format(endOfMonth(new Date()), 'yyyy-MM-dd') }}
+              inputProps={{
+                min:
+                  filterStartDate ||
+                  format(startOfMonth(new Date()), 'yyyy-MM-dd'),
+                max: format(endOfMonth(new Date()), 'yyyy-MM-dd'),
+              }}
               sx={{ minWidth: { sm: 150 }, flex: { xs: 1, sm: 'none' } }}
             />
             {hasEntryFilters && (
-              <Button size="small" onClick={clearEntryFilters} sx={{ alignSelf: 'center' }}>
+              <Button
+                size="small"
+                onClick={clearEntryFilters}
+                sx={{ alignSelf: 'center' }}
+              >
                 Clear
               </Button>
             )}
@@ -826,9 +1135,21 @@ export function TimeClockManagement() {
 
         <Box sx={{ display: { xs: 'grid', lg: 'none' }, gap: 1.5 }}>
           {filteredEntries.map((entry) => (
-            <Card key={entry.id} elevation={0} sx={{ border: `1px solid ${colors.neutral[200]}` }}>
+            <Card
+              key={entry.id}
+              elevation={0}
+              sx={{ border: `1px solid ${colors.neutral[200]}` }}
+            >
               <CardContent sx={{ p: 2 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1.5, alignItems: 'flex-start', mb: 1.5 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: 1.5,
+                    alignItems: 'flex-start',
+                    mb: 1.5,
+                  }}
+                >
                   <Box sx={{ minWidth: 0 }}>
                     <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
                       {entry.employee?.firstName} {entry.employee?.lastName}
@@ -837,14 +1158,25 @@ export function TimeClockManagement() {
                       {format(new Date(entry.clockInAt), 'MMM d, yyyy')}
                     </Typography>
                   </Box>
-                  <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.75 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-end',
+                      gap: 0.75,
+                    }}
+                  >
                     <Chip size="small" label={formatStatus(entry.status)} />
                     {entry.status === TimeEntryStatus.APPROVED && (
                       <Chip
                         size="small"
                         color={entry.payrollProcessedAt ? 'success' : 'info'}
                         variant="outlined"
-                        label={entry.payrollProcessedAt ? 'Processed' : 'Ready for Payroll'}
+                        label={
+                          entry.payrollProcessedAt
+                            ? 'Processed'
+                            : 'Ready for Payroll'
+                        }
                       />
                     )}
                   </Box>
@@ -852,16 +1184,30 @@ export function TimeClockManagement() {
 
                 <Grid container spacing={1.5} sx={{ mb: 1.5 }}>
                   <Grid size={6}>
-                    <Typography variant="caption" color="text.secondary">Clock In</Typography>
-                    <Typography variant="body2" sx={{ fontWeight: 700 }}>{format(new Date(entry.clockInAt), 'h:mm a')}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Clock In
+                    </Typography>
+                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                      {format(new Date(entry.clockInAt), 'h:mm a')}
+                    </Typography>
                   </Grid>
                   <Grid size={6}>
-                    <Typography variant="caption" color="text.secondary">Clock Out</Typography>
-                    <Typography variant="body2" sx={{ fontWeight: 700 }}>{entry.clockOutAt ? format(new Date(entry.clockOutAt), 'h:mm a') : 'Open'}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Clock Out
+                    </Typography>
+                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                      {entry.clockOutAt
+                        ? format(new Date(entry.clockOutAt), 'h:mm a')
+                        : 'Open'}
+                    </Typography>
                   </Grid>
                   <Grid size={6}>
-                    <Typography variant="caption" color="text.secondary">Paid Hours</Typography>
-                    <Typography variant="body2" sx={{ fontWeight: 700 }}>{formatHours(entry.paidMinutes)}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Paid Hours
+                    </Typography>
+                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                      {formatHours(entry.paidMinutes)}
+                    </Typography>
                   </Grid>
                 </Grid>
 
@@ -871,7 +1217,9 @@ export function TimeClockManagement() {
                     variant="outlined"
                     startIcon={<Edit />}
                     onClick={() => openEditEntry(entry)}
-                    disabled={saving || entry.status === TimeEntryStatus.APPROVED}
+                    disabled={
+                      saving || entry.status === TimeEntryStatus.APPROVED
+                    }
                   >
                     Edit
                   </Button>
@@ -885,23 +1233,37 @@ export function TimeClockManagement() {
                   >
                     Delete
                   </Button>
-                  {entry.clockOutAt && entry.status !== TimeEntryStatus.APPROVED && (
-                    <Button size="small" variant="contained" startIcon={<CheckCircle />} onClick={() => approveEntry(entry.id)} disabled={saving}>
-                      Approve
-                    </Button>
-                  )}
+                  {entry.clockOutAt &&
+                    entry.status !== TimeEntryStatus.APPROVED && (
+                      <Button
+                        size="small"
+                        variant="contained"
+                        startIcon={<CheckCircle />}
+                        onClick={() => approveEntry(entry.id)}
+                        disabled={saving}
+                      >
+                        Approve
+                      </Button>
+                    )}
                 </Box>
               </CardContent>
             </Card>
           ))}
           {filteredEntries.length === 0 && (
-            <Paper variant="outlined" sx={{ p: 3, textAlign: 'center', color: 'text.secondary' }}>
+            <Paper
+              variant="outlined"
+              sx={{ p: 3, textAlign: 'center', color: 'text.secondary' }}
+            >
               No time entries found for this month
             </Paper>
           )}
         </Box>
 
-        <TableContainer component={Paper} variant="outlined" sx={{ display: { xs: 'none', lg: 'block' } }}>
+        <TableContainer
+          component={Paper}
+          variant="outlined"
+          sx={{ display: { xs: 'none', lg: 'block' } }}
+        >
           <Table size="small">
             <TableHead>
               <TableRow>
@@ -918,11 +1280,23 @@ export function TimeClockManagement() {
             <TableBody>
               {filteredEntries.map((entry) => (
                 <TableRow key={entry.id}>
-                  <TableCell>{entry.employee?.firstName} {entry.employee?.lastName}</TableCell>
-                  <TableCell>{format(new Date(entry.clockInAt), 'MMM d, yyyy')}</TableCell>
-                  <TableCell>{format(new Date(entry.clockInAt), 'h:mm a')}</TableCell>
-                  <TableCell>{entry.clockOutAt ? format(new Date(entry.clockOutAt), 'h:mm a') : '-'}</TableCell>
-                  <TableCell><Chip size="small" label={formatStatus(entry.status)} /></TableCell>
+                  <TableCell>
+                    {entry.employee?.firstName} {entry.employee?.lastName}
+                  </TableCell>
+                  <TableCell>
+                    {format(new Date(entry.clockInAt), 'MMM d, yyyy')}
+                  </TableCell>
+                  <TableCell>
+                    {format(new Date(entry.clockInAt), 'h:mm a')}
+                  </TableCell>
+                  <TableCell>
+                    {entry.clockOutAt
+                      ? format(new Date(entry.clockOutAt), 'h:mm a')
+                      : '-'}
+                  </TableCell>
+                  <TableCell>
+                    <Chip size="small" label={formatStatus(entry.status)} />
+                  </TableCell>
                   <TableCell>
                     {entry.status === TimeEntryStatus.APPROVED ? (
                       <Chip
@@ -935,29 +1309,54 @@ export function TimeClockManagement() {
                       '-'
                     )}
                   </TableCell>
-                  <TableCell align="right">{formatHours(entry.paidMinutes)}</TableCell>
+                  <TableCell align="right">
+                    {formatHours(entry.paidMinutes)}
+                  </TableCell>
                   <TableCell align="right">
                     <Tooltip title="Edit time entry">
-                      <IconButton size="small" onClick={() => openEditEntry(entry)} disabled={saving || entry.status === TimeEntryStatus.APPROVED}>
+                      <IconButton
+                        size="small"
+                        onClick={() => openEditEntry(entry)}
+                        disabled={
+                          saving || entry.status === TimeEntryStatus.APPROVED
+                        }
+                      >
                         <Edit fontSize="small" />
                       </IconButton>
                     </Tooltip>
                     <Tooltip title="Delete time entry">
-                      <IconButton size="small" color="error" onClick={() => openDeleteEntry(entry)} disabled={saving || entry.status === TimeEntryStatus.VOIDED}>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => openDeleteEntry(entry)}
+                        disabled={
+                          saving || entry.status === TimeEntryStatus.VOIDED
+                        }
+                      >
                         <Delete fontSize="small" />
                       </IconButton>
                     </Tooltip>
-                    {entry.clockOutAt && entry.status !== TimeEntryStatus.APPROVED && (
-                      <Button size="small" startIcon={<CheckCircle />} onClick={() => approveEntry(entry.id)} disabled={saving}>
-                        Approve
-                      </Button>
-                    )}
+                    {entry.clockOutAt &&
+                      entry.status !== TimeEntryStatus.APPROVED && (
+                        <Button
+                          size="small"
+                          startIcon={<CheckCircle />}
+                          onClick={() => approveEntry(entry.id)}
+                          disabled={saving}
+                        >
+                          Approve
+                        </Button>
+                      )}
                   </TableCell>
                 </TableRow>
               ))}
               {filteredEntries.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={8} align="center" sx={{ py: 4, color: 'text.secondary' }}>
+                  <TableCell
+                    colSpan={8}
+                    align="center"
+                    sx={{ py: 4, color: 'text.secondary' }}
+                  >
                     No time entries found for this month
                   </TableCell>
                 </TableRow>
@@ -967,7 +1366,12 @@ export function TimeClockManagement() {
         </TableContainer>
       </TabPanel>
 
-      <Dialog open={Boolean(editingEntry)} onClose={() => setEditingEntry(null)} maxWidth="sm" fullWidth>
+      <Dialog
+        open={Boolean(editingEntry)}
+        onClose={() => setEditingEntry(null)}
+        maxWidth="sm"
+        fullWidth
+      >
         <DialogTitle>Edit Time Entry</DialogTitle>
         <DialogContent sx={{ pt: 2 }}>
           <Grid container spacing={2} sx={{ mt: 0.5 }}>
@@ -1005,7 +1409,9 @@ export function TimeClockManagement() {
           </Grid>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setEditingEntry(null)} disabled={saving}>Cancel</Button>
+          <Button onClick={() => setEditingEntry(null)} disabled={saving}>
+            Cancel
+          </Button>
           <Button
             variant="contained"
             onClick={saveEntryEdit}
@@ -1016,7 +1422,12 @@ export function TimeClockManagement() {
         </DialogActions>
       </Dialog>
 
-      <Dialog open={Boolean(deletingEntry)} onClose={() => setDeletingEntry(null)} maxWidth="xs" fullWidth>
+      <Dialog
+        open={Boolean(deletingEntry)}
+        onClose={() => setDeletingEntry(null)}
+        maxWidth="xs"
+        fullWidth
+      >
         <DialogTitle>Delete Time Entry</DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
@@ -1033,7 +1444,9 @@ export function TimeClockManagement() {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setDeletingEntry(null)} disabled={saving}>Cancel</Button>
+          <Button onClick={() => setDeletingEntry(null)} disabled={saving}>
+            Cancel
+          </Button>
           <Button
             variant="contained"
             color="error"

--- a/apps/webApp/src/app/pages/customers/VehicleForm.tsx
+++ b/apps/webApp/src/app/pages/customers/VehicleForm.tsx
@@ -22,7 +22,12 @@ import {
   Search as SearchIcon,
 } from '@mui/icons-material';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { vehicleService, CreateVehicleDto, UpdateVehicleDto } from '../../requests/vehicle.requests';
+import { NumberInput } from '../../components/common';
+import {
+  vehicleService,
+  CreateVehicleDto,
+  UpdateVehicleDto,
+} from '../../requests/vehicle.requests';
 import { customerService, Customer } from '../../requests/customer.requests';
 import { useAuth } from '../../hooks/useAuth';
 import { useError } from '../../contexts/ErrorContext';
@@ -32,16 +37,42 @@ const years = Array.from({ length: 50 }, (_, i) => currentYear - i);
 
 // Common vehicle makes
 const vehicleMakes = [
-  'Acura', 'Audi', 'BMW', 'Buick', 'Cadillac', 'Chevrolet', 'Chrysler',
-  'Dodge', 'Ford', 'GMC', 'Honda', 'Hyundai', 'Infiniti', 'Jeep', 'Kia',
-  'Lexus', 'Lincoln', 'Mazda', 'Mercedes-Benz', 'Mitsubishi', 'Nissan',
-  'Ram', 'Subaru', 'Tesla', 'Toyota', 'Volkswagen', 'Volvo'
+  'Acura',
+  'Audi',
+  'BMW',
+  'Buick',
+  'Cadillac',
+  'Chevrolet',
+  'Chrysler',
+  'Dodge',
+  'Ford',
+  'GMC',
+  'Honda',
+  'Hyundai',
+  'Infiniti',
+  'Jeep',
+  'Kia',
+  'Lexus',
+  'Lincoln',
+  'Mazda',
+  'Mercedes-Benz',
+  'Mitsubishi',
+  'Nissan',
+  'Ram',
+  'Subaru',
+  'Tesla',
+  'Toyota',
+  'Volkswagen',
+  'Volvo',
 ];
 
 const VIN_PATTERN = /^[A-HJ-NPR-Z0-9]{17}$/;
 
 const normalizeVin = (value: string) =>
-  value.toUpperCase().replace(/[^A-HJ-NPR-Z0-9]/g, '').slice(0, 17);
+  value
+    .toUpperCase()
+    .replace(/[^A-HJ-NPR-Z0-9]/g, '')
+    .slice(0, 17);
 
 const getCustomerName = (customer: Customer) =>
   [customer.firstName, customer.lastName].filter(Boolean).join(' ');
@@ -54,7 +85,9 @@ const getCustomerLabel = (customer: Customer) => {
     return `${business} - ${name}`;
   }
 
-  return business || name || customer.email || customer.phone || 'Unnamed customer';
+  return (
+    business || name || customer.email || customer.phone || 'Unnamed customer'
+  );
 };
 
 const getCustomerSearchText = (customer: Customer) =>
@@ -96,9 +129,13 @@ export function VehicleForm() {
     mileage: 0,
   });
 
-  const routePrefix = location.pathname.match(/^\/(admin|staff|supervisor|customer)(?=\/)/)?.[0] || '';
+  const routePrefix =
+    location.pathname.match(
+      /^\/(admin|staff|supervisor|customer)(?=\/)/
+    )?.[0] || '';
   const vehiclesPath = `${routePrefix}/vehicles`;
-  const selectedCustomer = customers.find((customer) => customer.id === formData.customerId) || null;
+  const selectedCustomer =
+    customers.find((customer) => customer.id === formData.customerId) || null;
 
   useEffect(() => {
     loadCustomers();
@@ -115,13 +152,13 @@ export function VehicleForm() {
     try {
       const data = await customerService.getAllCustomers();
       setCustomers(data);
-      
+
       // If customer role, they should only see their own data
       // Note: Customer-specific filtering should be handled on the backend
       if (role === 'customer' && data.length > 0) {
         // For now, if there's only one customer, use that
         if (data.length === 1) {
-          setFormData(prev => ({ ...prev, customerId: data[0].id }));
+          setFormData((prev) => ({ ...prev, customerId: data[0].id }));
         }
       }
     } catch (err: any) {
@@ -170,7 +207,7 @@ export function VehicleForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     try {
       setSaving(true);
       setError(null);
@@ -227,7 +264,7 @@ export function VehicleForm() {
         year: decoded.year || formData.year,
       };
 
-      setFormData(prev => ({
+      setFormData((prev) => ({
         ...prev,
         ...decodedUpdates,
       }));
@@ -242,12 +279,13 @@ export function VehicleForm() {
       setDecodeMessage(
         vehicleName
           ? `Decoded ${vehicleName}.${warningText}`
-          : `VIN decoded, but no make/model/year was returned.${warningText}`,
+          : `VIN decoded, but no make/model/year was returned.${warningText}`
       );
     } catch (err: any) {
       showError({
         title: 'VIN Decode Failed',
-        message: err.response?.data?.message || 'Unable to decode this VIN right now.',
+        message:
+          err.response?.data?.message || 'Unable to decode this VIN right now.',
         details: err.message,
       });
     } finally {
@@ -255,24 +293,32 @@ export function VehicleForm() {
     }
   };
 
-  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = field === 'vin' ? normalizeVin(e.target.value) : e.target.value;
+  const handleChange =
+    (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value =
+        field === 'vin' ? normalizeVin(e.target.value) : e.target.value;
 
-    setFormData(prev => ({
-      ...prev,
-      [field]: field === 'year' || field === 'mileage' ? 
-        parseInt(value) || 0 :
-        value,
-    }));
+      setFormData((prev) => ({
+        ...prev,
+        [field]:
+          field === 'year' || field === 'mileage'
+            ? parseInt(value) || 0
+            : value,
+      }));
 
-    if (field === 'vin') {
-      setDecodeMessage(null);
-    }
-  };
+      if (field === 'vin') {
+        setDecodeMessage(null);
+      }
+    };
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="60vh"
+      >
         <CircularProgress />
       </Box>
     );
@@ -291,7 +337,11 @@ export function VehicleForm() {
       )}
 
       {decodeMessage && (
-        <Alert severity="info" sx={{ mb: 3 }} onClose={() => setDecodeMessage(null)}>
+        <Alert
+          severity="info"
+          sx={{ mb: 3 }}
+          onClose={() => setDecodeMessage(null)}
+        >
           {decodeMessage}
         </Alert>
       )}
@@ -307,7 +357,9 @@ export function VehicleForm() {
                     options={customers}
                     value={selectedCustomer}
                     getOptionLabel={getCustomerLabel}
-                    isOptionEqualToValue={(option, value) => option.id === value.id}
+                    isOptionEqualToValue={(option, value) =>
+                      option.id === value.id
+                    }
                     filterOptions={(options, state) => {
                       const search = state.inputValue.trim().toLowerCase();
 
@@ -316,11 +368,14 @@ export function VehicleForm() {
                       }
 
                       return options.filter((customer) =>
-                        getCustomerSearchText(customer).includes(search),
+                        getCustomerSearchText(customer).includes(search)
                       );
                     }}
                     onChange={(_, customer) =>
-                      setFormData(prev => ({ ...prev, customerId: customer?.id || '' }))
+                      setFormData((prev) => ({
+                        ...prev,
+                        customerId: customer?.id || '',
+                      }))
                     }
                     disabled={saving || role === 'customer'}
                     renderOption={(props, customer) => (
@@ -330,7 +385,9 @@ export function VehicleForm() {
                             {getCustomerLabel(customer)}
                           </Typography>
                           <Typography variant="caption" color="text.secondary">
-                            {[customer.phone, customer.email].filter(Boolean).join(' - ') || 'No contact info'}
+                            {[customer.phone, customer.email]
+                              .filter(Boolean)
+                              .join(' - ') || 'No contact info'}
                           </Typography>
                         </Box>
                       </Box>
@@ -352,8 +409,20 @@ export function VehicleForm() {
                   freeSolo
                   options={vehicleMakes}
                   value={formData.make}
-                  onChange={(_, value) => setFormData(prev => ({ ...prev, make: value || '', model: '' }))}
-                  onInputChange={(_, value) => setFormData(prev => ({ ...prev, make: value, model: value === prev.make ? prev.model : '' }))}
+                  onChange={(_, value) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      make: value || '',
+                      model: '',
+                    }))
+                  }
+                  onInputChange={(_, value) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      make: value,
+                      model: value === prev.make ? prev.model : '',
+                    }))
+                  }
                   renderInput={(params) => (
                     <TextField
                       {...params}
@@ -371,8 +440,12 @@ export function VehicleForm() {
                   options={modelOptions}
                   value={formData.model}
                   loading={loadingModels}
-                  onChange={(_, value) => setFormData(prev => ({ ...prev, model: value || '' }))}
-                  onInputChange={(_, value) => setFormData(prev => ({ ...prev, model: value }))}
+                  onChange={(_, value) =>
+                    setFormData((prev) => ({ ...prev, model: value || '' }))
+                  }
+                  onInputChange={(_, value) =>
+                    setFormData((prev) => ({ ...prev, model: value }))
+                  }
                   disabled={saving || !formData.make}
                   renderInput={(params) => (
                     <TextField
@@ -384,7 +457,9 @@ export function VehicleForm() {
                         ...params.InputProps,
                         endAdornment: (
                           <>
-                            {loadingModels ? <CircularProgress color="inherit" size={20} /> : null}
+                            {loadingModels ? (
+                              <CircularProgress color="inherit" size={20} />
+                            ) : null}
                             {params.InputProps.endAdornment}
                           </>
                         ),
@@ -399,7 +474,12 @@ export function VehicleForm() {
                   <InputLabel>Year</InputLabel>
                   <Select
                     value={formData.year}
-                    onChange={(e) => setFormData(prev => ({ ...prev, year: Number(e.target.value) }))}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        year: Number(e.target.value),
+                      }))
+                    }
                     label="Year"
                     disabled={saving}
                   >
@@ -420,7 +500,10 @@ export function VehicleForm() {
                   onChange={handleChange('vin')}
                   disabled={saving || decodingVin}
                   placeholder="Vehicle Identification Number"
-                  inputProps={{ maxLength: 17, style: { textTransform: 'uppercase' } }}
+                  inputProps={{
+                    maxLength: 17,
+                    style: { textTransform: 'uppercase' },
+                  }}
                   helperText={
                     formData.vin && formData.vin.length < 17
                       ? `${17 - formData.vin.length} characters remaining`
@@ -432,9 +515,19 @@ export function VehicleForm() {
                         <Button
                           size="small"
                           variant="outlined"
-                          startIcon={decodingVin ? <CircularProgress size={16} /> : <SearchIcon />}
+                          startIcon={
+                            decodingVin ? (
+                              <CircularProgress size={16} />
+                            ) : (
+                              <SearchIcon />
+                            )
+                          }
                           onClick={handleDecodeVin}
-                          disabled={saving || decodingVin || !VIN_PATTERN.test(formData.vin)}
+                          disabled={
+                            saving ||
+                            decodingVin ||
+                            !VIN_PATTERN.test(formData.vin)
+                          }
                         >
                           Decode
                         </Button>
@@ -456,16 +549,18 @@ export function VehicleForm() {
               </Grid>
 
               <Grid size={{ xs: 12, md: 6 }}>
-                <TextField
+                <NumberInput
                   fullWidth
-                  type="number"
+                  min={0}
                   label="Current Mileage"
                   value={formData.mileage}
-                  onChange={handleChange('mileage')}
+                  onChange={(v) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      mileage: (v ?? '') as unknown as number,
+                    }))
+                  }
                   disabled={saving}
-                  InputProps={{
-                    inputProps: { min: 0 }
-                  }}
                 />
               </Grid>
 
@@ -485,7 +580,7 @@ export function VehicleForm() {
                     startIcon={<SaveIcon />}
                     disabled={saving || !formData.customerId}
                   >
-                    {saving ? 'Saving...' : (isEdit ? 'Update' : 'Create')}
+                    {saving ? 'Saving...' : isEdit ? 'Update' : 'Create'}
                   </Button>
                 </Box>
               </Grid>

--- a/apps/webApp/src/app/pages/inspections/InspectionList.tsx
+++ b/apps/webApp/src/app/pages/inspections/InspectionList.tsx
@@ -51,6 +51,7 @@ import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { useConfirmation } from '../../contexts/ConfirmationContext';
 import { useAuth } from '../../hooks/useAuth';
 import { GenerateInvoiceDialog } from '../../components/inspections/GenerateInvoiceDialog';
+import { NumberInput } from '../../components/common';
 
 const statusColor = (status: string) => {
   if (status === 'COMPLETED' || status === 'FINALIZED') return 'success';
@@ -421,12 +422,12 @@ export function InspectionList() {
               />
             </Grid>
             <Grid size={{ xs: 6, md: 1.5 }}>
-              <TextField
+              <NumberInput
                 fullWidth
                 label="Mileage"
-                type="number"
+                min={0}
                 value={mileage}
-                onChange={(event) => setMileage(event.target.value)}
+                onChange={(v) => setMileage(v === undefined ? '' : String(v))}
               />
             </Grid>
             <Grid size={{ xs: 12 }}>

--- a/apps/webApp/src/app/pages/inventory/TireForm.tsx
+++ b/apps/webApp/src/app/pages/inventory/TireForm.tsx
@@ -45,23 +45,36 @@ import {
   TIRE_TYPE_OPTIONS,
 } from '../../constants/enum-mappings';
 import { useAuth } from '../../hooks/useAuth';
-import { 
-  useTire, 
-  useCreateTire, 
+import {
+  useTire,
+  useCreateTire,
   useUpdateTire,
   useTireBrands,
-  useTireSizeSuggestions 
+  useTireSizeSuggestions,
 } from '../../hooks/useTires';
 import TireImageUpload from '../../components/inventory/TireImageUpload';
+import { NumberInput } from '../../components/common';
 
 // Validation schema
 const validationSchema = Yup.object({
-  brand: Yup.string().required('Brand is required').min(2, 'Brand must be at least 2 characters'),
+  brand: Yup.string()
+    .required('Brand is required')
+    .min(2, 'Brand must be at least 2 characters'),
   size: Yup.string()
     .required('Size is required')
     .matches(/^\d{3}\/\d{2}R\d{2}$/, 'Size must be in format like 225/45R17'),
-  type: Yup.string().oneOf(TIRE_TYPE_OPTIONS.map(({ value }) => value), 'Invalid tire type').required('Type is required'),
-  condition: Yup.string().oneOf(TIRE_CONDITION_OPTIONS.map(({ value }) => value), 'Invalid condition').required('Condition is required'),
+  type: Yup.string()
+    .oneOf(
+      TIRE_TYPE_OPTIONS.map(({ value }) => value),
+      'Invalid tire type'
+    )
+    .required('Type is required'),
+  condition: Yup.string()
+    .oneOf(
+      TIRE_CONDITION_OPTIONS.map(({ value }) => value),
+      'Invalid condition'
+    )
+    .required('Condition is required'),
   quantity: Yup.number()
     .required('Quantity is required')
     .min(0, 'Quantity cannot be negative')
@@ -71,10 +84,14 @@ const validationSchema = Yup.object({
     .min(0.01, 'Price must be greater than 0'),
   cost: Yup.number()
     .min(0, 'Cost cannot be negative')
-    .test('cost-less-than-price', 'Cost should be less than price', function(cost) {
-      if (!cost || !this.parent.price) return true;
-      return cost <= this.parent.price;
-    }),
+    .test(
+      'cost-less-than-price',
+      'Cost should be less than price',
+      function (cost) {
+        if (!cost || !this.parent.price) return true;
+        return cost <= this.parent.price;
+      }
+    ),
   minStock: Yup.number()
     .min(0, 'Minimum stock cannot be negative')
     .integer('Minimum stock must be a whole number'),
@@ -86,7 +103,7 @@ export function TireForm() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { isAdmin } = useAuth();
-  
+
   const isEditing = Boolean(id && id !== 'new');
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [sizeQuery, setSizeQuery] = useState('');
@@ -204,10 +221,9 @@ export function TireForm() {
             {isEditing ? 'Edit Tire' : 'Add New Tire'}
           </Typography>
           <Typography variant="body1" color="text.secondary">
-            {isEditing 
+            {isEditing
               ? `Update details for ${tire?.brand} - ${tire?.size}`
-              : 'Enter tire information to add to inventory'
-            }
+              : 'Enter tire information to add to inventory'}
           </Typography>
         </Box>
       </Box>
@@ -221,26 +237,31 @@ export function TireForm() {
                 <Typography variant="h6" gutterBottom>
                   Basic Information
                 </Typography>
-                
+
                 <Grid container spacing={2}>
                   {/* Brand */}
                   <Grid size={{ xs: 12, sm: 6 }}>
                     <Autocomplete
                       options={brands}
                       value={formik.values.brand}
-                      onChange={(_, value) => formik.setFieldValue('brand', value || '')}
+                      onChange={(_, value) =>
+                        formik.setFieldValue('brand', value || '')
+                      }
                       renderInput={(params) => (
                         <TextField
                           {...params}
                           label="Brand *"
-                          error={formik.touched.brand && Boolean(formik.errors.brand)}
-                          helperText={formik.touched.brand && formik.errors.brand}
+                          error={
+                            formik.touched.brand && Boolean(formik.errors.brand)
+                          }
+                          helperText={
+                            formik.touched.brand && formik.errors.brand
+                          }
                         />
                       )}
                       freeSolo
                     />
                   </Grid>
-
 
                   {/* Size */}
                   <Grid size={{ xs: 12, sm: 6 }}>
@@ -254,7 +275,9 @@ export function TireForm() {
                           {...params}
                           label="Size *"
                           placeholder="e.g., 225/45R17"
-                          error={formik.touched.size && Boolean(formik.errors.size)}
+                          error={
+                            formik.touched.size && Boolean(formik.errors.size)
+                          }
                           helperText={formik.touched.size && formik.errors.size}
                         />
                       )}
@@ -271,7 +294,9 @@ export function TireForm() {
                         value={formik.values.type}
                         label="Type *"
                         onChange={formik.handleChange}
-                        error={formik.touched.type && Boolean(formik.errors.type)}
+                        error={
+                          formik.touched.type && Boolean(formik.errors.type)
+                        }
                       >
                         {TIRE_TYPE_OPTIONS.map(({ value, label }) => (
                           <MenuItem key={value} value={value}>
@@ -291,7 +316,10 @@ export function TireForm() {
                         value={formik.values.condition}
                         label="Condition *"
                         onChange={formik.handleChange}
-                        error={formik.touched.condition && Boolean(formik.errors.condition)}
+                        error={
+                          formik.touched.condition &&
+                          Boolean(formik.errors.condition)
+                        }
                       >
                         {TIRE_CONDITION_OPTIONS.map(({ value, label }) => (
                           <MenuItem key={value} value={value}>
@@ -310,8 +338,13 @@ export function TireForm() {
                       name="location"
                       value={formik.values.location}
                       onChange={formik.handleChange}
-                      error={formik.touched.location && Boolean(formik.errors.location)}
-                      helperText={formik.touched.location && formik.errors.location}
+                      error={
+                        formik.touched.location &&
+                        Boolean(formik.errors.location)
+                      }
+                      helperText={
+                        formik.touched.location && formik.errors.location
+                      }
                       placeholder="e.g., Aisle A, Shelf 3"
                     />
                   </Grid>
@@ -326,51 +359,78 @@ export function TireForm() {
                 <Grid container spacing={2}>
                   {/* Quantity */}
                   <Grid size={{ xs: 12, sm: 4 }}>
-                    <TextField
+                    <NumberInput
                       fullWidth
                       label="Quantity *"
                       name="quantity"
-                      type="number"
                       value={formik.values.quantity}
-                      onChange={formik.handleChange}
-                      error={formik.touched.quantity && Boolean(formik.errors.quantity)}
-                      helperText={formik.touched.quantity && formik.errors.quantity}
-                      inputProps={{ min: 0 }}
+                      onChange={(v) =>
+                        formik.setFieldValue(
+                          'quantity',
+                          (v ?? '') as unknown as number
+                        )
+                      }
+                      error={
+                        formik.touched.quantity &&
+                        Boolean(formik.errors.quantity)
+                      }
+                      helperText={
+                        formik.touched.quantity && formik.errors.quantity
+                      }
+                      min={0}
                       autoComplete="off"
                     />
                   </Grid>
 
                   {/* Min Stock */}
                   <Grid size={{ xs: 12, sm: 4 }}>
-                    <TextField
+                    <NumberInput
                       fullWidth
                       label="Minimum Stock Level"
                       name="minStock"
-                      type="number"
                       value={formik.values.minStock}
-                      onChange={formik.handleChange}
-                      error={formik.touched.minStock && Boolean(formik.errors.minStock)}
-                      helperText={formik.touched.minStock && formik.errors.minStock}
-                      inputProps={{ min: 0 }}
+                      onChange={(v) =>
+                        formik.setFieldValue(
+                          'minStock',
+                          (v ?? '') as unknown as number
+                        )
+                      }
+                      error={
+                        formik.touched.minStock &&
+                        Boolean(formik.errors.minStock)
+                      }
+                      helperText={
+                        formik.touched.minStock && formik.errors.minStock
+                      }
+                      min={0}
                       autoComplete="off"
                     />
                   </Grid>
 
                   {/* Price */}
                   <Grid size={{ xs: 12, sm: 4 }}>
-                    <TextField
+                    <NumberInput
                       fullWidth
                       label="Selling Price *"
                       name="price"
-                      type="number"
+                      allowDecimals
                       value={formik.values.price}
-                      onChange={formik.handleChange}
-                      error={formik.touched.price && Boolean(formik.errors.price)}
+                      onChange={(v) =>
+                        formik.setFieldValue(
+                          'price',
+                          (v ?? '') as unknown as number
+                        )
+                      }
+                      error={
+                        formik.touched.price && Boolean(formik.errors.price)
+                      }
                       helperText={formik.touched.price && formik.errors.price}
                       InputProps={{
-                        startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                        startAdornment: (
+                          <InputAdornment position="start">$</InputAdornment>
+                        ),
                       }}
-                      inputProps={{ min: 0, step: 0.01 }}
+                      min={0}
                       autoComplete="off"
                     />
                   </Grid>
@@ -378,19 +438,28 @@ export function TireForm() {
                   {/* Cost (Admin only) */}
                   {isAdmin && (
                     <Grid size={{ xs: 12, sm: 4 }}>
-                      <TextField
+                      <NumberInput
                         fullWidth
                         label="Cost"
                         name="cost"
-                        type="number"
+                        allowDecimals
                         value={formik.values.cost}
-                        onChange={formik.handleChange}
-                        error={formik.touched.cost && Boolean(formik.errors.cost)}
+                        onChange={(v) =>
+                          formik.setFieldValue(
+                            'cost',
+                            (v ?? '') as unknown as number
+                          )
+                        }
+                        error={
+                          formik.touched.cost && Boolean(formik.errors.cost)
+                        }
                         helperText={formik.touched.cost && formik.errors.cost}
                         InputProps={{
-                          startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                          startAdornment: (
+                            <InputAdornment position="start">$</InputAdornment>
+                          ),
                         }}
-                        inputProps={{ min: 0, step: 0.01 }}
+                        min={0}
                         autoComplete="off"
                       />
                     </Grid>
@@ -452,8 +521,20 @@ export function TireForm() {
                       {formik.values.size}
                     </Typography>
                     <Stack direction="row" spacing={0.5}>
-                      <Chip label={getEnumLabel(TIRE_TYPE_DISPLAY, formik.values.type)} size="small" />
-                      <Chip label={getEnumLabel(TIRE_CONDITION_DISPLAY, formik.values.condition)} size="small" />
+                      <Chip
+                        label={getEnumLabel(
+                          TIRE_TYPE_DISPLAY,
+                          formik.values.type
+                        )}
+                        size="small"
+                      />
+                      <Chip
+                        label={getEnumLabel(
+                          TIRE_CONDITION_DISPLAY,
+                          formik.values.condition
+                        )}
+                        size="small"
+                      />
                     </Stack>
                     <Typography variant="h6" color="primary">
                       ${formik.values.price.toFixed(2)}
@@ -478,7 +559,7 @@ export function TireForm() {
             >
               Cancel
             </Button>
-            
+
             <Button
               variant="outlined"
               onClick={handleSaveDraft}
@@ -487,7 +568,7 @@ export function TireForm() {
             >
               Save as Draft
             </Button>
-            
+
             <LoadingButton
               type="submit"
               variant="contained"
@@ -503,11 +584,15 @@ export function TireForm() {
       </form>
 
       {/* Cancel Confirmation Dialog */}
-      <Dialog open={showCancelDialog} onClose={() => setShowCancelDialog(false)}>
+      <Dialog
+        open={showCancelDialog}
+        onClose={() => setShowCancelDialog(false)}
+      >
         <DialogTitle>Discard Changes?</DialogTitle>
         <DialogContent>
           <Typography>
-            You have unsaved changes. Are you sure you want to leave without saving?
+            You have unsaved changes. Are you sure you want to leave without
+            saving?
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/apps/webApp/src/app/pages/inventory/TireFormSimple.tsx
+++ b/apps/webApp/src/app/pages/inventory/TireFormSimple.tsx
@@ -22,10 +22,7 @@ import {
   InputAdornment,
   Chip,
 } from '@mui/material';
-import {
-  Save as SaveIcon,
-  ArrowBack as BackIcon,
-} from '@mui/icons-material';
+import { Save as SaveIcon, ArrowBack as BackIcon } from '@mui/icons-material';
 import {
   ITireCreateInput,
   ITireUpdateInput,
@@ -40,17 +37,14 @@ import {
   TIRE_TYPE_OPTIONS,
 } from '../../constants/enum-mappings';
 import { useAuth } from '../../hooks/useAuth';
-import { 
-  useTire, 
-  useCreateTire, 
-  useUpdateTire,
-} from '../../hooks/useTires';
+import { useTire, useCreateTire, useUpdateTire } from '../../hooks/useTires';
+import { NumberInput } from '../../components/common';
 
 export function TireFormSimple() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { isAdmin } = useAuth();
-  
+
   const isEditing = Boolean(id && id !== 'new');
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [formData, setFormData] = useState({
@@ -104,7 +98,8 @@ export function TireFormSimple() {
 
     if (!formData.brand.trim()) newErrors.brand = 'Brand is required';
     if (!formData.size.trim()) newErrors.size = 'Size is required';
-    if (formData.quantity < 0) newErrors.quantity = 'Quantity cannot be negative';
+    if (formData.quantity < 0)
+      newErrors.quantity = 'Quantity cannot be negative';
     if (formData.price <= 0) newErrors.price = 'Price must be greater than 0';
     if (isAdmin && formData.cost !== undefined && formData.cost < 0) {
       newErrors.cost = 'Cost cannot be negative';
@@ -116,7 +111,7 @@ export function TireFormSimple() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!validateForm()) return;
 
     setIsSubmitting(true);
@@ -144,21 +139,32 @@ export function TireFormSimple() {
   };
 
   const handleChange = (field: string, value: any) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+    setFormData((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) {
-      setErrors(prev => ({ ...prev, [field]: '' }));
+      setErrors((prev) => ({ ...prev, [field]: '' }));
     }
   };
 
   const handleCancel = () => {
-    const hasChanges = Object.keys(formData).some(key => {
+    const hasChanges = Object.keys(formData).some((key) => {
       if (tire && isEditing) {
-        return formData[key as keyof typeof formData] !== tire[key as keyof typeof tire];
+        return (
+          formData[key as keyof typeof formData] !==
+          tire[key as keyof typeof tire]
+        );
       }
-      return formData[key as keyof typeof formData] !== (key === 'type' ? TireType.ALL_SEASON : 
-        key === 'condition' ? TireCondition.NEW : 
-        key === 'minStock' ? 5 : 
-        typeof formData[key as keyof typeof formData] === 'number' ? 0 : '');
+      return (
+        formData[key as keyof typeof formData] !==
+        (key === 'type'
+          ? TireType.ALL_SEASON
+          : key === 'condition'
+          ? TireCondition.NEW
+          : key === 'minStock'
+          ? 5
+          : typeof formData[key as keyof typeof formData] === 'number'
+          ? 0
+          : '')
+      );
     });
 
     if (hasChanges) {
@@ -188,10 +194,9 @@ export function TireFormSimple() {
             {isEditing ? 'Edit Tire' : 'Add New Tire'}
           </Typography>
           <Typography variant="body1" color="text.secondary">
-            {isEditing 
+            {isEditing
               ? `Update details for ${tire?.brand} - ${tire?.size}`
-              : 'Enter tire information to add to inventory'
-            }
+              : 'Enter tire information to add to inventory'}
           </Typography>
         </Box>
       </Box>
@@ -205,7 +210,7 @@ export function TireFormSimple() {
                 <Typography variant="h6" gutterBottom>
                   Basic Information
                 </Typography>
-                
+
                 <Grid container spacing={2}>
                   {/* Name (Optional) */}
                   <Grid size={{ xs: 12, sm: 6 }}>
@@ -281,7 +286,9 @@ export function TireFormSimple() {
                       <Select
                         value={formData.condition}
                         label="Condition *"
-                        onChange={(e) => handleChange('condition', e.target.value)}
+                        onChange={(e) =>
+                          handleChange('condition', e.target.value)
+                        }
                       >
                         {TIRE_CONDITION_OPTIONS.map(({ value, label }) => (
                           <MenuItem key={value} value={value}>
@@ -313,46 +320,52 @@ export function TireFormSimple() {
                 <Grid container spacing={2}>
                   {/* Quantity */}
                   <Grid size={{ xs: 12, sm: 4 }}>
-                    <TextField
+                    <NumberInput
                       fullWidth
                       label="Quantity *"
-                      type="number"
                       value={formData.quantity}
-                      onChange={(e) => handleChange('quantity', e.target.value === '' ? '' : parseInt(e.target.value) || 0)}
+                      onChange={(v) =>
+                        handleChange('quantity', (v ?? '') as unknown as number)
+                      }
                       error={!!errors.quantity}
                       helperText={errors.quantity}
-                      inputProps={{ min: 0 }}
+                      min={0}
                       autoComplete="off"
                     />
                   </Grid>
 
                   {/* Min Stock */}
                   <Grid size={{ xs: 12, sm: 4 }}>
-                    <TextField
+                    <NumberInput
                       fullWidth
                       label="Minimum Stock Level"
-                      type="number"
                       value={formData.minStock}
-                      onChange={(e) => handleChange('minStock', parseInt(e.target.value) || 0)}
-                      inputProps={{ min: 0 }}
+                      onChange={(v) =>
+                        handleChange('minStock', (v ?? '') as unknown as number)
+                      }
+                      min={0}
                       autoComplete="off"
                     />
                   </Grid>
 
                   {/* Price */}
                   <Grid size={{ xs: 12, sm: 4 }}>
-                    <TextField
+                    <NumberInput
                       fullWidth
                       label="Selling Price *"
-                      type="number"
+                      allowDecimals
                       value={formData.price}
-                      onChange={(e) => handleChange('price', e.target.value === '' ? '' : parseFloat(e.target.value) || 0)}
+                      onChange={(v) =>
+                        handleChange('price', (v ?? '') as unknown as number)
+                      }
                       error={!!errors.price}
                       helperText={errors.price}
                       InputProps={{
-                        startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                        startAdornment: (
+                          <InputAdornment position="start">$</InputAdornment>
+                        ),
                       }}
-                      inputProps={{ min: 0, step: 0.01 }}
+                      min={0}
                       autoComplete="off"
                     />
                   </Grid>
@@ -360,18 +373,22 @@ export function TireFormSimple() {
                   {/* Cost (Admin only) */}
                   {isAdmin && (
                     <Grid size={{ xs: 12, sm: 4 }}>
-                      <TextField
+                      <NumberInput
                         fullWidth
                         label="Cost"
-                        type="number"
+                        allowDecimals
                         value={formData.cost}
-                        onChange={(e) => handleChange('cost', e.target.value === '' ? '' : parseFloat(e.target.value) || 0)}
+                        onChange={(v) =>
+                          handleChange('cost', (v ?? '') as unknown as number)
+                        }
                         error={!!errors.cost}
                         helperText={errors.cost}
                         InputProps={{
-                          startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                          startAdornment: (
+                            <InputAdornment position="start">$</InputAdornment>
+                          ),
                         }}
-                        inputProps={{ min: 0, step: 0.01 }}
+                        min={0}
                         autoComplete="off"
                       />
                     </Grid>
@@ -409,8 +426,17 @@ export function TireFormSimple() {
                     {formData.size}
                   </Typography>
                   <Stack direction="row" spacing={0.5}>
-                    <Chip label={getEnumLabel(TIRE_TYPE_DISPLAY, formData.type)} size="small" />
-                    <Chip label={getEnumLabel(TIRE_CONDITION_DISPLAY, formData.condition)} size="small" />
+                    <Chip
+                      label={getEnumLabel(TIRE_TYPE_DISPLAY, formData.type)}
+                      size="small"
+                    />
+                    <Chip
+                      label={getEnumLabel(
+                        TIRE_CONDITION_DISPLAY,
+                        formData.condition
+                      )}
+                      size="small"
+                    />
                   </Stack>
                   <Typography variant="h6" color="primary">
                     ${formData.price.toFixed(2)}
@@ -434,25 +460,33 @@ export function TireFormSimple() {
             >
               Cancel
             </Button>
-            
+
             <Button
               type="submit"
               variant="contained"
               disabled={isSubmitting}
               startIcon={<SaveIcon />}
             >
-              {isSubmitting ? 'Saving...' : (isEditing ? 'Update Tire' : 'Add Tire')}
+              {isSubmitting
+                ? 'Saving...'
+                : isEditing
+                ? 'Update Tire'
+                : 'Add Tire'}
             </Button>
           </Stack>
         </Card>
       </form>
 
       {/* Cancel Confirmation Dialog */}
-      <Dialog open={showCancelDialog} onClose={() => setShowCancelDialog(false)}>
+      <Dialog
+        open={showCancelDialog}
+        onClose={() => setShowCancelDialog(false)}
+      >
         <DialogTitle>Discard Changes?</DialogTitle>
         <DialogContent>
           <Typography>
-            You have unsaved changes. Are you sure you want to leave without saving?
+            You have unsaved changes. Are you sure you want to leave without
+            saving?
           </Typography>
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
## Summary

Adds a reusable `NumberInput` component and migrates **all** numeric inputs across the app to it. Resolves [GA-35](https://gt-automotives.atlassian.net/browse/GA-35) under the **UI Enhancement** epic (GA-34).

### Problem
Every numeric `TextField` fell back to `0` (or `1`) when cleared, so deleting the value with backspace immediately showed `0` again — awkward on both mobile and desktop.

### The component — `apps/webApp/src/app/components/common/NumberInput.tsx`
- **Empty-able**: clearing with backspace stays blank (not `0`); parent receives `undefined`.
- **Focus guard**: external value never clobbers in-progress typing (e.g. `"12."`), which is what stops the `0` snapping back while you type.
- Numeric-only sanitizing; `allowDecimals` / `allowNegative` / `min` / `max` (clamped on blur).
- `inputMode="numeric"/"decimal"` so phones show the number pad.
- Passes through standard `TextField` props (adornments, `sx`, `size`, `error`, …).

### Migration
Replaced every `<TextField type="number">` and removed `|| 0` / `|| 1` fallbacks and redundant `onKeyDown` e/E/+/- blockers across:
- Invoices & Quotations (qty, unit price, discount, GST/PST)
- Inventory / Tires (qty, price, cost, min stock, stock adjustment)
- Purchase & Expense invoices (amount, rates, levy, total)
- Appointments & Inspections (service amount, tips, duration, fees, mileage)
- Repair orders (hours, rate, qty, unit price, mileage)
- Payroll, Services, Vehicle forms

Tax-rate fields (GST/PST) keep their numeric default since they feed tax math, but no longer snap to `0` while typing.

## Test plan
- [x] `nx run webApp:typecheck` — passes (0 errors)
- [x] `nx lint webApp` — 0 errors
- [ ] Manual: clear a quantity/price field with backspace on **mobile** and **desktop** — stays empty, numeric keyboard appears on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)