### PR TITLE
fix(square): show + pair Terminal devices for in-person invoice payments

### DIFF
--- a/apps/webApp/src/app/components/payments/TerminalPaymentDialog.tsx
+++ b/apps/webApp/src/app/components/payments/TerminalPaymentDialog.tsx
@@ -119,9 +119,10 @@ export const TerminalPaymentDialog: React.FC<TerminalPaymentDialogProps> = ({
     setLoadingDevices(true);
     try {
       const deviceList = await squareTerminalService.listDevices();
-      setDevices(deviceList.filter((d) => d.status === 'PAIRED'));
-      if (deviceList.length === 1) {
-        setSelectedDeviceId(deviceList[0].id);
+      const pairedDevices = deviceList.filter((d) => d.status === 'PAIRED');
+      setDevices(pairedDevices);
+      if (pairedDevices.length === 1) {
+        setSelectedDeviceId(pairedDevices[0].id);
       }
     } catch (err: any) {
       setError(

--- a/server/src/square/square-payment.controller.ts
+++ b/server/src/square/square-payment.controller.ts
@@ -214,16 +214,19 @@ export class SquarePaymentController {
   @Get('terminal/devices')
   @Roles('ADMIN', 'SUPERVISOR', 'STAFF')
   async listTerminalDevices(): Promise<TerminalDeviceDto[]> {
-    const devices = await this.squarePaymentService.listTerminalDevices();
+    const deviceCodes = await this.squarePaymentService.listTerminalDevices();
 
-    return devices.map(
-      (device) =>
+    // listDeviceCodes returns DeviceCode objects directly (no `.deviceCode`
+    // wrapper). For a paired reader, `deviceId` holds the id Terminal checkout
+    // needs and `status` is 'PAIRED'; both are undefined until pairing completes.
+    return deviceCodes.map(
+      (deviceCode) =>
         new TerminalDeviceDto({
-          id: device.deviceCode?.deviceId || '',
-          name: device.deviceCode?.name || 'Unknown Device',
-          code: device.deviceCode?.code || '',
-          status: device.deviceCode?.status || 'UNKNOWN',
-          deviceType: device.deviceCode?.productType || 'TERMINAL_API',
+          id: deviceCode.deviceId || '',
+          name: deviceCode.name || 'Unknown Device',
+          code: deviceCode.code || '',
+          status: deviceCode.status || 'UNKNOWN',
+          deviceType: deviceCode.productType || 'TERMINAL_API',
         })
     );
   }


### PR DESCRIPTION
## Problem

Sending an invoice payment to the Square Terminal showed **"No paired Square Terminal devices found"** even though a reader (Square Terminal 2015) was online in the Square account.

## Root causes (two backend bugs)

1. **Wrong `listDeviceCodes` args.** The SDK signature is `listDeviceCodes(cursor?, locationId?, productType?, status?)`. The code passed the location id as the **first** arg (cursor), so Square rejected the query and the `catch` silently returned `[]`.
2. **Wrong response mapping.** `listDeviceCodes()` returns `DeviceCode` objects with fields at the top level, but the controller read them off a non-existent `.deviceCode` wrapper — so every device mapped to `status: 'UNKNOWN'` with an empty id and was filtered out by the frontend (`status === 'PAIRED'`).

## Also: no way to pair for Terminal API

Square gates **`TERMINAL_API`** device codes to the API — the Dashboard only offers *Point of Sale* / *Kitchen Display System*. So a reader can't be paired for Terminal checkouts from the UI at all.

## Changes

**Fixes**
- Pass `locationId` in the correct position and filter to `TERMINAL_API` codes.
- Map `DeviceCode` fields directly (`deviceId`, `status`, `name`, `code`, `productType`).
- Frontend auto-selects a single device from the *filtered* paired list.

**New: in-app pairing**
- `POST /api/square/payments/terminal/device-code` (ADMIN/SUPERVISOR) — creates a `TERMINAL_API` device code.
- "**Pair a device**" button in the Terminal payment dialog's empty state: generates a code, shows instructions to enter it on the reader (Settings → Sign in with a device code). Once paired, the reader appears in the dropdown.

## How to test in production

1. Deploy (backend rebuild required).
2. Open an invoice → pay via **Square Terminal**.
3. If no device is listed, click **Pair a device**, enter the shown code on the Terminal 2015, then reopen — it should appear as `PAIRED`.
4. Send a checkout and complete the tap on the reader.

**Prereqs:** production must use a **production** Square token, `SQUARE_ENVIRONMENT=production`, and the `SQUARE_LOCATION_ID` for GT Automotives (local `.env` is sandbox — production values live in Azure app settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)