### PR TITLE
fix(square): Terminal API device-code pairing + fix listDeviceCodes query

### DIFF
--- a/apps/webApp/src/app/components/payments/TerminalPaymentDialog.tsx
+++ b/apps/webApp/src/app/components/payments/TerminalPaymentDialog.tsx
@@ -58,6 +58,8 @@ export const TerminalPaymentDialog: React.FC<TerminalPaymentDialogProps> = ({
     useState<TerminalCheckoutResponse | null>(null);
   const [checkoutStatus, setCheckoutStatus] = useState<string>('');
   const [polling, setPolling] = useState(false);
+  const [pairingCode, setPairingCode] = useState<string | null>(null);
+  const [pairing, setPairing] = useState(false);
 
   const numericAmount =
     typeof amount === 'number' ? amount : parseFloat(String(amount));
@@ -113,6 +115,8 @@ export const TerminalPaymentDialog: React.FC<TerminalPaymentDialogProps> = ({
     setCheckoutStatus('');
     setPolling(false);
     setLoading(false);
+    setPairingCode(null);
+    setPairing(false);
   };
 
   const loadDevices = async () => {
@@ -131,6 +135,23 @@ export const TerminalPaymentDialog: React.FC<TerminalPaymentDialogProps> = ({
       );
     } finally {
       setLoadingDevices(false);
+    }
+  };
+
+  const handlePairDevice = async () => {
+    setPairing(true);
+    setError(null);
+    try {
+      const result = await squareTerminalService.createDeviceCode();
+      setPairingCode(result.code);
+    } catch (err: any) {
+      setError(
+        err.response?.data?.message ||
+          err.message ||
+          'Failed to generate a pairing code. Please try again.'
+      );
+    } finally {
+      setPairing(false);
     }
   };
 
@@ -295,10 +316,43 @@ export const TerminalPaymentDialog: React.FC<TerminalPaymentDialogProps> = ({
                 </Typography>
               </Box>
             ) : devices.length === 0 ? (
-              <Alert severity="warning">
-                No paired Square Terminal devices found. Please pair a device in
-                your Square dashboard.
-              </Alert>
+              <Box>
+                {pairingCode ? (
+                  <Alert severity="info" sx={{ mb: 2 }}>
+                    <Typography variant="body2" gutterBottom>
+                      On your Square Terminal, go to{' '}
+                      <strong>Settings → Sign in with a device code</strong> and
+                      enter:
+                    </Typography>
+                    <Typography
+                      variant="h4"
+                      fontWeight="bold"
+                      letterSpacing={4}
+                      sx={{ my: 1 }}
+                    >
+                      {pairingCode}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      After pairing, reopen this dialog and the device will
+                      appear. The code expires in 5 minutes.
+                    </Typography>
+                  </Alert>
+                ) : (
+                  <>
+                    <Alert severity="warning" sx={{ mb: 2 }}>
+                      No paired Square Terminal devices found. Generate a
+                      pairing code and enter it on your Terminal to connect it.
+                    </Alert>
+                    <Button
+                      variant="outlined"
+                      onClick={handlePairDevice}
+                      disabled={pairing}
+                    >
+                      {pairing ? 'Generating…' : 'Pair a device'}
+                    </Button>
+                  </>
+                )}
+              </Box>
             ) : (
               <>
                 <FormControl fullWidth sx={{ mb: 2 }}>

--- a/apps/webApp/src/app/requests/square-terminal.requests.ts
+++ b/apps/webApp/src/app/requests/square-terminal.requests.ts
@@ -27,6 +27,13 @@ export interface TerminalDevice {
   deviceType: string;
 }
 
+export interface TerminalDeviceCode {
+  id: string;
+  code: string;
+  status: string;
+  name?: string;
+}
+
 export const squareTerminalService = {
   /**
    * List available Square Terminal devices at the location
@@ -35,6 +42,24 @@ export const squareTerminalService = {
     const token = await getAuthToken();
     const response = await axios.get<TerminalDevice[]>(
       `${API_URL}/api/square/payments/terminal/devices`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return response.data;
+  },
+
+  /**
+   * Create a Terminal API device code to pair a Square reader.
+   * The returned code is entered on the physical Terminal to complete pairing.
+   */
+  async createDeviceCode(name?: string): Promise<TerminalDeviceCode> {
+    const token = await getAuthToken();
+    const response = await axios.post<TerminalDeviceCode>(
+      `${API_URL}/api/square/payments/terminal/device-code`,
+      { name },
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/libs/data/src/lib/square-terminal.dto.ts
+++ b/libs/data/src/lib/square-terminal.dto.ts
@@ -65,3 +65,22 @@ export class TerminalDeviceDto {
     Object.assign(this, partial);
   }
 }
+
+// Generate a Terminal API device code to pair a Square reader. The returned
+// `code` is entered on the physical Terminal to complete pairing.
+export class CreateTerminalDeviceCodeDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+}
+
+export class TerminalDeviceCodeResponseDto {
+  id!: string;
+  code!: string;
+  status!: string;
+  name?: string;
+
+  constructor(partial: Partial<TerminalDeviceCodeResponseDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/square/square-payment.controller.ts
+++ b/server/src/square/square-payment.controller.ts
@@ -23,6 +23,8 @@ import {
   CreateBulkTerminalCheckoutDto,
   TerminalCheckoutResponseDto,
   TerminalDeviceDto,
+  CreateTerminalDeviceCodeDto,
+  TerminalDeviceCodeResponseDto,
 } from '@gt-automotive/data';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleGuard } from '../auth/guards/role.guard';
@@ -229,5 +231,23 @@ export class SquarePaymentController {
           deviceType: deviceCode.productType || 'TERMINAL_API',
         })
     );
+  }
+
+  /**
+   * Create a Terminal API device code for pairing a Square reader.
+   * POST /api/square/payments/terminal/device-code
+   * Returns a code to enter on the physical Terminal to complete pairing.
+   */
+  @Post('terminal/device-code')
+  @HttpCode(HttpStatus.CREATED)
+  @Roles('ADMIN', 'SUPERVISOR')
+  async createTerminalDeviceCode(
+    @Body() dto: CreateTerminalDeviceCodeDto
+  ): Promise<TerminalDeviceCodeResponseDto> {
+    this.logger.log('Creating Terminal API device code for pairing');
+    const result = await this.squarePaymentService.createTerminalDeviceCode(
+      dto.name
+    );
+    return new TerminalDeviceCodeResponseDto(result);
   }
 }

--- a/server/src/square/square-payment.service.ts
+++ b/server/src/square/square-payment.service.ts
@@ -939,8 +939,13 @@ export class SquarePaymentService {
    */
   async listTerminalDevices(): Promise<any[]> {
     try {
+      // Signature is listDeviceCodes(cursor?, locationId?, productType?, status?).
+      // The location id must go in the 2nd arg — passing it first sends it as a
+      // pagination cursor, which Square rejects. Filter to TERMINAL_API codes.
       const response: any = await this.squareClient.devicesApi.listDeviceCodes(
-        this.locationId
+        undefined,
+        this.locationId,
+        'TERMINAL_API'
       );
 
       return response.result.deviceCodes || [];
@@ -950,6 +955,55 @@ export class SquarePaymentService {
         error.stack
       );
       return [];
+    }
+  }
+
+  /**
+   * Create a Terminal API device code for pairing a Square reader.
+   *
+   * Square gates TERMINAL_API device codes to the API (the Dashboard only
+   * offers Point of Sale / KDS), so this is the only way to pair a reader for
+   * Terminal checkouts. The returned `code` is entered on the physical Terminal
+   * (Settings → Sign in with a device code); once paired it appears in
+   * listTerminalDevices() with status PAIRED and a usable deviceId.
+   */
+  async createTerminalDeviceCode(
+    name = 'GT Terminal'
+  ): Promise<{ id: string; code: string; status: string; name?: string }> {
+    try {
+      const response: any = await this.squareClient.devicesApi.createDeviceCode(
+        {
+          idempotencyKey: randomUUID(),
+          deviceCode: {
+            name,
+            productType: 'TERMINAL_API',
+            locationId: this.locationId,
+          },
+        }
+      );
+
+      const deviceCode = response.result.deviceCode;
+      this.logger.log(
+        `Created Terminal API device code ${deviceCode.code} (${deviceCode.status}) for location ${this.locationId}`
+      );
+
+      return {
+        id: deviceCode.id,
+        code: deviceCode.code,
+        status: deviceCode.status,
+        name: deviceCode.name,
+      };
+    } catch (error: any) {
+      this.logger.error(
+        `Failed to create Terminal device code: ${error.message}`,
+        error.stack
+      );
+      if (error instanceof ApiError) {
+        const detail =
+          error.errors?.[0]?.detail || 'Device code creation failed';
+        throw new BadRequestException(`Device code creation failed: ${detail}`);
+      }
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Why this PR

PR #81 was merged with **only its first commit** (the device field-mapping fix). The **second commit — which never landed in main — contains two essential pieces** that are the actual reason production still shows *"No paired Square Terminal devices found."*

## What's missing from main (and included here)

1. **`listDeviceCodes` cursor bug** — the SDK signature is `listDeviceCodes(cursor?, locationId?, productType?, status?)`. The code passed the location id as the **first** arg (cursor), so Square rejects the query and the `catch` silently returns `[]`. Fixed to pass `locationId` in the correct position and filter to `TERMINAL_API` codes.

2. **In-app Terminal API pairing** — Square gates `TERMINAL_API` device codes to the API (the Dashboard only offers *Point of Sale* / *Kitchen Display*), so a reader that's only signed into Square POS can never be paired for Terminal checkouts from the UI. Adds:
   - `POST /api/square/payments/terminal/device-code` (ADMIN/SUPERVISOR) — creates a `TERMINAL_API` device code.
   - A **"Pair a device"** button in the Terminal payment dialog's empty state that shows a code to enter on the physical reader (Settings → Sign in with a device code). Once paired, the reader appears in the dropdown as `PAIRED`.

## Files

- `libs/data` — `CreateTerminalDeviceCodeDto`, `TerminalDeviceCodeResponseDto`
- `server` — `createTerminalDeviceCode()`, `listDeviceCodes` arg fix, controller endpoint
- `webApp` — `createDeviceCode()` request + pairing UI

## Deploy + test in production

1. Deploy **both** frontend and backend (frontend carries the new button/text; backend carries the query fix + endpoint).
2. Open an invoice → pay via **Square Terminal**.
3. If no device is listed, click **Pair a device**, enter the shown code on the Terminal 2015 (sign out of POS first if needed), then reopen — it should appear as `PAIRED`.
4. Send the checkout and complete the tap.

**Prereqs:** production must use a **production** Square token, `SQUARE_ENVIRONMENT=production`, and the GT Automotives `SQUARE_LOCATION_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)