### PR TITLE
Bill inspection fee as an editable RO service line

### DIFF
--- a/apps/webApp/src/app/components/repair-orders/ServiceCatalogPicker.tsx
+++ b/apps/webApp/src/app/components/repair-orders/ServiceCatalogPicker.tsx
@@ -218,7 +218,7 @@ export function ServiceCatalogPicker({
       PaperProps={{ sx: { height: '80vh' } }}
     >
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', pb: 1 }}>
-        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+        <Typography variant="h6" component="span" sx={{ flexGrow: 1 }}>
           Choose a Service
         </Typography>
         <IconButton onClick={handleClose} size="small">

--- a/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
+++ b/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
@@ -66,10 +66,7 @@ import { formatBusinessDate } from '../../utils/dateUtils';
 import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
 import { companyService, Company } from '../../requests/company.requests';
 import { vehicleService, Vehicle } from '../../requests/vehicle.requests';
-import {
-  inspectionService,
-  InspectionFeeItem,
-} from '../../requests/inspection.requests';
+import { inspectionService } from '../../requests/inspection.requests';
 import { invoiceService } from '../../requests/invoice.requests';
 import {
   PAYMENT_METHOD_SELECT_OPTIONS,
@@ -144,7 +141,7 @@ function CurrentTab({
   baseRoute: string;
 }) {
   const navigate = useNavigate();
-  const { showApiError, showValidationError } = useErrorHelpers();
+  const { showApiError } = useErrorHelpers();
   const { confirm } = useConfirmationHelpers();
   const [serviceDrawerOpen, setServiceDrawerOpen] = useState(false);
   const [editingConcern, setEditingConcern] = useState(false);
@@ -160,8 +157,6 @@ function CurrentTab({
   const [companies, setCompanies] = useState<Company[]>([]);
   const [companiesLoading, setCompaniesLoading] = useState(false);
   const [selectedCompanyId, setSelectedCompanyId] = useState('');
-  const [feeItems, setFeeItems] = useState<InspectionFeeItem[]>([]);
-  const [selectedFeeItemId, setSelectedFeeItemId] = useState('');
   // Optional payment method tagged onto the generated invoice. The invoice is
   // saved as PENDING (not marked paid) — payment is recorded later through the
   // invoice flow. CASH_NO_TAX drops GST/PST from the invoice total.
@@ -254,7 +249,6 @@ function CurrentTab({
     (i) =>
       (i.status === 'COMPLETED' || i.status === 'FINALIZED') && !i.invoiceId
   );
-  const selectedFeeItem = feeItems.find((f) => f.id === selectedFeeItemId);
   const hasInvoiceableWork =
     billableServices.length > 0 || Boolean(invoiceableInspection);
 
@@ -278,7 +272,9 @@ function CurrentTab({
   const inspectionDisabledReason = vehicleResolved
     ? ''
     : 'Add a vehicle to this repair order, or mark it as no-vehicle';
-  // The running estimate excludes customer-declined items.
+  // The running estimate excludes customer-declined items. The inspection fee is
+  // included here automatically because it lives on ro.services (a real service
+  // line added when the inspection is completed).
   const estimatedTotal =
     ro.services
       ?.filter((s) => s.customerApproval !== 'DECLINED')
@@ -378,24 +374,10 @@ function CurrentTab({
     setCloseDialogOpen(true);
     setCompaniesLoading(true);
     try {
-      const requests: [Promise<Company[]>, Promise<InspectionFeeItem[]>] = [
-        companyService.getCompanies(),
-        invoiceableInspection
-          ? inspectionService.getFeeItems()
-          : Promise.resolve([] as InspectionFeeItem[]),
-      ];
-      const [list, fees] = await Promise.all(requests);
+      const list = await companyService.getCompanies();
       setCompanies(list);
       const preset = list.find((c) => c.isDefault) ?? list[0];
       if (preset) setSelectedCompanyId(preset.id);
-
-      if (invoiceableInspection) {
-        const activeFees = fees.filter((f) => f.isActive);
-        setFeeItems(activeFees);
-        const inspType = invoiceableInspection.template?.type;
-        const match = activeFees.find((f) => f.type && f.type === inspType);
-        setSelectedFeeItemId(match?.id ?? activeFees[0]?.id ?? '');
-      }
     } catch (error) {
       showApiError(error, 'Failed to load companies.');
     } finally {
@@ -405,10 +387,6 @@ function CurrentTab({
 
   const handleConfirmClose = async () => {
     if (!selectedCompanyId) return;
-    if (invoiceableInspection && !selectedFeeItemId) {
-      showValidationError('Select an inspection fee to invoice.');
-      return;
-    }
     // Captured before the refresh clears the "invoiceable" inspection.
     const inspectionToPrint = invoiceableInspection?.id ?? null;
     setClosing(true);
@@ -416,7 +394,9 @@ function CurrentTab({
       await repairOrderRequests.close(
         ro.id,
         selectedCompanyId,
-        invoiceableInspection ? selectedFeeItemId : undefined,
+        // Inspection fees are already real service lines on the RO, so no fee
+        // item is selected at close time.
+        undefined,
         // A Square Terminal choice resolves to its real Credit/Debit method —
         // the RO close only tags the invoice, it doesn't run a card-reader charge.
         selectedPaymentMethod
@@ -441,7 +421,6 @@ function CurrentTab({
     setCreatedInvoiceId(null);
     setCreatedInvoiceNumber('');
     setInvoicedInspectionId(null);
-    setSelectedFeeItemId('');
   };
 
   const handlePrintCreatedInvoice = async () => {
@@ -1361,13 +1340,7 @@ function CurrentTab({
             <DialogTitle>Close & Invoice {ro.roNumber}</DialogTitle>
             <DialogContent>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                {invoiceableInspection
-                  ? `A draft invoice will be created from the inspection fee${
-                      billableServices.length > 0
-                        ? ` plus ${billableServices.length} completed item(s)`
-                        : ''
-                    }. Select the inspection fee and company to invoice under.`
-                  : `A draft invoice will be created from the ${billableServices.length} completed item(s). Select the company to invoice under.`}
+                {`A draft invoice will be created from the ${billableServices.length} completed item(s). Select the company to invoice under.`}
               </Typography>
               {companiesLoading ? (
                 <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
@@ -1375,28 +1348,6 @@ function CurrentTab({
                 </Box>
               ) : (
                 <Stack spacing={2}>
-                  {invoiceableInspection && (
-                    <FormControl fullWidth size="small">
-                      <InputLabel>Inspection Fee</InputLabel>
-                      <Select
-                        value={selectedFeeItemId}
-                        label="Inspection Fee"
-                        onChange={(e) => setSelectedFeeItemId(e.target.value)}
-                      >
-                        {feeItems.length === 0 && (
-                          <MenuItem value="" disabled>
-                            No active inspection fee items — add them under
-                            Inspection Items &amp; Pricing
-                          </MenuItem>
-                        )}
-                        {feeItems.map((f) => (
-                          <MenuItem key={f.id} value={f.id}>
-                            {f.name} — ${Number(f.price).toFixed(2)}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
-                  )}
                   <FormControl fullWidth size="small">
                     <InputLabel>Company</InputLabel>
                     <Select
@@ -1430,17 +1381,12 @@ function CurrentTab({
                 </Stack>
               )}
               {(() => {
-                const feePrice = selectedFeeItem
-                  ? Number(selectedFeeItem.price)
-                  : 0;
-                const rawBase = completedSubtotal + feePrice;
-                // The inspection fee bills as a SERVICE, so it's part of the base
+                const rawBase = completedSubtotal;
+                // Service items (incl. the inspection fee line) form the base that
                 // shop supplies / fleet discount are computed from.
-                const completedServiceBase =
-                  billableServices
-                    .filter((s) => s.type !== 'PART')
-                    .reduce((sum, s) => sum + Number(s.total ?? 0), 0) +
-                  feePrice;
+                const completedServiceBase = billableServices
+                  .filter((s) => s.type !== 'PART')
+                  .reduce((sum, s) => sum + Number(s.total ?? 0), 0);
                 const previewShop =
                   completedServiceBase > 0
                     ? round2(completedServiceBase * SHOP_SUPPLIES_RATE)
@@ -1558,11 +1504,7 @@ function CurrentTab({
                   )
                 }
                 onClick={handleConfirmClose}
-                disabled={
-                  closing ||
-                  !selectedCompanyId ||
-                  (Boolean(invoiceableInspection) && !selectedFeeItemId)
-                }
+                disabled={closing || !selectedCompanyId}
               >
                 Create Invoice
               </Button>

--- a/libs/database/src/lib/prisma/migrations/20260724174545_add_roservice_inspection_link/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260724174545_add_roservice_inspection_link/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."ro_services" ADD COLUMN     "inspectionId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ro_services_inspectionId_idx" ON "public"."ro_services"("inspectionId");

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -1600,6 +1600,9 @@ model ROService {
   customerApproval ROServiceApproval @default(PENDING)
   // When true, this item should be quoted (via a quotation) rather than billed on the RO invoice
   isQuotation     Boolean         @default(false)
+  // Set when this line is the fee auto-added from a completed inspection, so it
+  // can be kept in sync (and not duplicated) with that inspection.
+  inspectionId    String?
   completedById   String?
   completedAt     DateTime?
   createdAt       DateTime        @default(now())
@@ -1611,6 +1614,7 @@ model ROService {
 
   @@index([repairOrderId])
   @@index([status])
+  @@index([inspectionId])
   @@map("ro_services")
 }
 

--- a/server/src/inspections/inspections.service.spec.ts
+++ b/server/src/inspections/inspections.service.spec.ts
@@ -49,6 +49,14 @@ describe('InspectionsService', () => {
         findFirst: jest.fn(),
         update: jest.fn(),
       },
+      inspectionFeeItem: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      rOService: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({}),
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
       customer: { findUnique: jest.fn() },
       vehicle: { findUnique: jest.fn() },
     };
@@ -274,6 +282,69 @@ describe('InspectionsService', () => {
       );
       expect(updateArgs.data.finalizedById).toBe('u-1');
       expect(updateArgs.data.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('adds the inspection fee as a repair-order service line when RO-linked', async () => {
+      prisma.inspection.findUnique.mockResolvedValue({
+        id: 'i-1',
+        repairOrderId: 'ro-1',
+        results: [],
+        template: { type: 'PEACE_OF_MIND', sections: [] },
+      });
+      prisma.inspection.update.mockResolvedValue({});
+      prisma.rOService.findFirst.mockResolvedValue(null);
+      prisma.inspectionFeeItem.findMany.mockResolvedValue([
+        {
+          id: 'fee-1',
+          name: 'Inspection Fee',
+          type: 'PEACE_OF_MIND',
+          price: 89,
+        },
+      ]);
+
+      await service.complete('i-1', 'u-1', 'STAFF');
+
+      expect(prisma.rOService.create).toHaveBeenCalledTimes(1);
+      const createArgs = prisma.rOService.create.mock.calls[0][0];
+      expect(createArgs.data).toMatchObject({
+        repairOrderId: 'ro-1',
+        inspectionId: 'i-1',
+        description: 'Inspection Fee',
+        unitPrice: 89,
+        total: 89,
+        status: 'COMPLETED',
+        customerApproval: 'APPROVED',
+        isQuotation: false,
+      });
+    });
+
+    it('does not add a fee line when the inspection is not RO-linked', async () => {
+      prisma.inspection.findUnique.mockResolvedValue({
+        id: 'i-1',
+        repairOrderId: null,
+        results: [],
+        template: { type: 'PEACE_OF_MIND', sections: [] },
+      });
+      prisma.inspection.update.mockResolvedValue({});
+
+      await service.complete('i-1', 'u-1', 'STAFF');
+
+      expect(prisma.rOService.create).not.toHaveBeenCalled();
+    });
+
+    it('does not duplicate the fee line if one already exists', async () => {
+      prisma.inspection.findUnique.mockResolvedValue({
+        id: 'i-1',
+        repairOrderId: 'ro-1',
+        results: [],
+        template: { type: 'PEACE_OF_MIND', sections: [] },
+      });
+      prisma.inspection.update.mockResolvedValue({});
+      prisma.rOService.findFirst.mockResolvedValue({ id: 'existing-fee' });
+
+      await service.complete('i-1', 'u-1', 'STAFF');
+
+      expect(prisma.rOService.create).not.toHaveBeenCalled();
     });
 
     it('sets ATTENTION_SOON when FAIR but no POOR, and GOOD otherwise', async () => {

--- a/server/src/inspections/inspections.service.ts
+++ b/server/src/inspections/inspections.service.ts
@@ -298,7 +298,67 @@ export class InspectionsService {
       },
     });
 
+    // When the inspection belongs to a repair order, add its fee as a real
+    // service line so it shows in the RO's Services & Parts, feeds the estimate,
+    // and flows onto the invoice through the normal close path (billed once — the
+    // RO close no longer injects a separate inspection-fee line).
+    if (inspection.repairOrderId) {
+      await this.syncInspectionFeeService(
+        inspection.repairOrderId,
+        inspection.id,
+        inspection.template.type,
+        userId
+      );
+    }
+
     return this.findOne(id, userRole);
+  }
+
+  /** The active inspection fee item best matching a template type (else any). */
+  private async resolveInspectionFeeItem(type?: InspectionType | null) {
+    const active = await this.prisma.inspectionFeeItem.findMany({
+      where: { isActive: true },
+      orderBy: { createdAt: 'asc' },
+    });
+    if (active.length === 0) return null;
+    return active.find((f) => f.type && f.type === type) ?? active[0];
+  }
+
+  /**
+   * Ensure a completed RO-linked inspection has exactly one fee service line on
+   * the repair order. Creates it once; leaves an existing (possibly user-edited)
+   * line untouched so we never duplicate or clobber a manual price change.
+   */
+  private async syncInspectionFeeService(
+    repairOrderId: string,
+    inspectionId: string,
+    type: InspectionType | null | undefined,
+    userId: string
+  ): Promise<void> {
+    const existing = await this.prisma.rOService.findFirst({
+      where: { repairOrderId, inspectionId },
+    });
+    if (existing) return;
+
+    const feeItem = await this.resolveInspectionFeeItem(type);
+    if (!feeItem) return; // No fee configured — nothing to bill.
+
+    await this.prisma.rOService.create({
+      data: {
+        repairOrderId,
+        inspectionId,
+        description: feeItem.name,
+        type: 'OTHER',
+        quantity: 1,
+        unitPrice: feeItem.price,
+        total: feeItem.price,
+        status: 'COMPLETED',
+        customerApproval: 'APPROVED',
+        isQuotation: false,
+        completedById: userId,
+        completedAt: new Date(),
+      },
+    });
   }
 
   async remove(id: string, userId: string, userRole: string): Promise<void> {
@@ -307,6 +367,10 @@ export class InspectionsService {
     }
 
     const inspection = await this.ensureInspection(id);
+
+    // Remove the auto-added fee service line so a deleted inspection doesn't
+    // leave a dangling charge on the repair order.
+    await this.prisma.rOService.deleteMany({ where: { inspectionId: id } });
 
     // Results and media cascade on delete via the schema relations.
     await this.prisma.inspection.delete({ where: { id } });

--- a/server/src/repair-orders/repair-orders.service.ts
+++ b/server/src/repair-orders/repair-orders.service.ts
@@ -7,7 +7,6 @@ import {
 import { PrismaService } from '@gt-automotive/database';
 import { AzureBlobService } from '../common/services/azure-blob.service';
 import { ROStatus } from '@prisma/client';
-import { InspectionsService } from '../inspections/inspections.service';
 import { QuotationsService } from '../quotations/quotations.service';
 import { PdfService } from '../pdf/pdf.service';
 import { EmailService } from '../email/email.service';
@@ -79,7 +78,6 @@ export class RepairOrdersService {
   constructor(
     private prisma: PrismaService,
     private azureBlob: AzureBlobService,
-    private inspectionsService: InspectionsService,
     private quotationsService: QuotationsService,
     private pdfService: PdfService,
     private emailService: EmailService
@@ -867,41 +865,16 @@ export class RepairOrdersService {
       );
     }
 
-    // If the existing invoice was generated from an inspection, its fee item is
-    // not stored on the RO services, so we can't safely rebuild it here. Block the
-    // re-sync and tell the user to edit the invoice directly.
-    if (
-      existingInvoice &&
-      ro.inspections.some((i: any) => i.invoiceId === existingInvoice.id)
-    ) {
-      throw new BadRequestException(
-        "This repair order's invoice was generated from an inspection. Edit the invoice directly to change it."
-      );
-    }
-
-    // When a completed, not-yet-invoiced inspection is linked, the inspection
-    // drives the invoice: its fee becomes a line item alongside any completed RO
-    // services/parts. Delegate so tax rules, the PST-exempt gate, numbering, and
-    // the inspection<->invoice<->RO linkage all stay consistent in one place.
-    // (Only for the initial close — a re-sync with an existing invoice is handled
-    // by the guard above.)
-    const linkedInspection = ro.inspections.find(
-      (i: any) =>
-        !i.invoiceId && (i.status === 'COMPLETED' || i.status === 'FINALIZED')
-    );
-    if (!existingInvoice && linkedInspection) {
-      if (!feeItemId) {
-        throw new BadRequestException(
-          'Select an inspection fee to invoice this repair order'
-        );
-      }
-      return this.inspectionsService.generateInvoice(
-        linkedInspection.id,
-        { feeItemId, companyId },
-        userId,
-        roleName
-      );
-    }
+    // The inspection fee is now a normal completed service line on the RO (added
+    // when the inspection is completed), so every RO invoices the same way. Any
+    // completed, not-yet-invoiced inspection is linked to the invoice below so it
+    // is marked as billed (its fee is already in the RO services).
+    const inspectionIdsToLink: string[] = ro.inspections
+      .filter(
+        (i: any) =>
+          !i.invoiceId && (i.status === 'COMPLETED' || i.status === 'FINALIZED')
+      )
+      .map((i: any) => i.id);
 
     const noTax = paymentMethod === 'CASH_NO_TAX';
     const { items, subtotal, gstRate, pstRate, gstAmount, pstAmount, total } =
@@ -938,6 +911,16 @@ export class RepairOrdersService {
             items: { create: items as any },
           },
         });
+        if (inspectionIdsToLink.length) {
+          await tx.inspection.updateMany({
+            where: { id: { in: inspectionIdsToLink } },
+            data: {
+              invoiceId: existingInvoice.id,
+              status: 'FINALIZED',
+              finalizedAt: new Date(),
+            },
+          });
+        }
         await tx.repairOrder.update({
           where: { id },
           data: { status: ROStatus.INVOICED, closedAt: new Date() },
@@ -975,6 +958,17 @@ export class RepairOrdersService {
         },
       },
     });
+
+    if (inspectionIdsToLink.length) {
+      await this.prisma.inspection.updateMany({
+        where: { id: { in: inspectionIdsToLink } },
+        data: {
+          invoiceId: invoice.id,
+          status: 'FINALIZED',
+          finalizedAt: new Date(),
+        },
+      });
+    }
 
     await this.prisma.repairOrder.update({
       where: { id },


### PR DESCRIPTION
## Summary

When an inspection is completed inside a Repair Order, its fee now appears as a **real, editable service line** in the RO's Services & Parts — so it shows up, feeds the Estimated Total, and flows onto the invoice through the normal close path. Previously the fee was injected only at close time and never appeared on the RO, so the Estimated Total read $0.00 and the charge was invisible until invoicing.

## Behaviour
Complete an RO-linked inspection → fee line added to Services & Parts → Estimated Total reflects it immediately → billed once on close. No fee selection step at close, no manual "add to invoice".

## Changes
- **schema**: add `ROService.inspectionId` (+ index) — migration `20260724174545_add_roservice_inspection_link`
- **inspections.complete()**: upsert the fee service using the active fee item matching the inspection's template type. Idempotent (no duplicate on re-complete) and price-preserving (won't clobber a manual edit)
- **inspections.remove()**: delete the fee service so a deleted inspection leaves no dangling charge
- **repair-orders.closeAndConvert()**: drop the inspection-fee special-case — every RO now invoices uniformly from `ro.services`, and completed inspections are linked to that invoice (billed **once**, no double-count). Removed the now-unused `feeItemId` requirement and `InspectionsService` dependency
- **RODetail.tsx**: removed the close-dialog inspection-fee selector; the estimate/close preview pick the fee up automatically from `ro.services`

## Testing
- `nx run-many --target=typecheck,lint,test` (server + webApp): typecheck clean, lint 0 errors, **283 server tests + 107 webApp tests pass**
- New unit tests: fee line created when RO-linked, skipped when standalone, never duplicated

## Deploy note
Introduces a DB migration — run `prisma migrate deploy`. Inspections completed *before* this change won't get a fee line retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)