### PR TITLE
fix(invoices): invoiceDate stored as business calendar date (after-5-PM-PST bug)

### DIFF
--- a/libs/database/src/lib/prisma/migrations/20260724190000_backfill_invoice_date_business_tz/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260724190000_backfill_invoice_date_business_tz/migration.sql
@@ -1,0 +1,11 @@
+-- Backfill: normalize existing invoiceDate values that were stored as raw UTC
+-- instants (created via RO-close / quotation paths that didn't set invoiceDate)
+-- to the business (America/Vancouver) calendar date at midnight UTC.
+--
+-- Invoices created after ~5 PM PST are stored as the next UTC day and therefore
+-- displayed one day late. Rows already stored at midnight UTC (correct calendar
+-- dates) are skipped. Idempotent: re-running affects no already-normalized rows.
+UPDATE "Invoice"
+SET "invoiceDate" =
+  (DATE("invoiceDate" AT TIME ZONE 'UTC' AT TIME ZONE 'America/Vancouver'))::timestamp
+WHERE "invoiceDate"::time <> TIME '00:00:00';

--- a/server/src/quotations/quotations.service.ts
+++ b/server/src/quotations/quotations.service.ts
@@ -9,6 +9,7 @@ import { Quotation, QuotationItem, Tire } from '@prisma/client';
 import { PrismaService } from '@gt-automotive/database';
 import { PdfService } from '../pdf/pdf.service';
 import { EmailService } from '../email/email.service';
+import { toBusinessCalendarDate } from '../config/timezone.config';
 
 type QuotationWithItems = Quotation & {
   items: (QuotationItem & {
@@ -248,6 +249,9 @@ export class QuotationsService {
         status: 'PENDING',
         notes: quotation.notes,
         createdBy: quotation.createdBy,
+        // Business calendar date (midnight UTC), not a raw instant, so an invoice
+        // created from a quote after 5 PM PST isn't dated to the next (UTC) day.
+        invoiceDate: toBusinessCalendarDate(),
         items: {
           create: quotation.items.map((item) => ({
             tireId: item.tireId,

--- a/server/src/repair-orders/repair-orders.service.ts
+++ b/server/src/repair-orders/repair-orders.service.ts
@@ -22,7 +22,10 @@ import {
   CreateServiceCatalogItemDto,
   UpdateServiceCatalogItemDto,
 } from '@gt-automotive/data';
-import { businessDayUtcRange } from '../config/timezone.config';
+import {
+  businessDayUtcRange,
+  toBusinessCalendarDate,
+} from '../config/timezone.config';
 
 @Injectable()
 export class RepairOrdersService {
@@ -935,6 +938,9 @@ export class RepairOrdersService {
             status: 'PENDING',
             paymentMethod: (paymentMethod as any) ?? null,
             notes: invoiceNotes,
+            // Normalize the invoice date to the business day (midnight UTC) so an
+            // RO re-closed after 5 PM PST isn't dated to the next (UTC) day.
+            invoiceDate: toBusinessCalendarDate(),
             items: { create: items as any },
           },
         });
@@ -970,6 +976,10 @@ export class RepairOrdersService {
         paymentMethod: (paymentMethod as any) ?? undefined,
         notes: invoiceNotes,
         createdBy: 'system',
+        // invoiceDate is a business calendar date (midnight UTC), not a raw
+        // instant — otherwise an RO closed after 5 PM PST is dated to the next
+        // (UTC) day. Matches invoicesService.create().
+        invoiceDate: toBusinessCalendarDate(),
         items: {
           create: items as any,
         },


### PR DESCRIPTION
## Problem
Invoices created after ~5 PM PST were displayed one day late (dated to the next day). The regular invoice flow was already fixed (PR #89), but two other creation paths were missed:
- **RO close** (`closeAndConvert` — both the new-invoice create and the reopen re-sync update)
- **Quotation → invoice** conversion

These created the invoice without setting `invoiceDate`, so it fell back to the Prisma `@default(now())` — a raw UTC instant. After 5 PM PST that instant is already the next UTC day, and the frontend formats `invoiceDate` in UTC, so it renders as tomorrow.

## Fix
- Set `invoiceDate: toBusinessCalendarDate()` (midnight-UTC business calendar date) on all three paths, matching `invoicesService.create()`.
- **Data migration** backfills existing rows: any `invoiceDate` stored as a raw UTC instant is normalized to the America/Vancouver calendar date at midnight UTC. Rows already at midnight UTC are skipped. Idempotent (verified locally: 43 rows normalized, second run 0).

## Testing
- `nx typecheck server` clean; pre-push gate (lint + typecheck + tests) green.
- Backfill dry-run + apply validated on a local copy.

## Scope note
This is the targeted invoice fix. A broader **app-wide date-handling standardization** (all remaining display/format/filter paths across the app) is tracked separately in Jira — not included here.

## Deploy
Runs a data migration via `prisma migrate deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)