### PR TITLE
Camera VIN scanner + calendar-day default for appointments

### DIFF
--- a/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
+++ b/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
@@ -46,7 +46,19 @@ interface AppointmentDialogProps {
   preselectedServiceType?: string;
   preselectedAppointmentType?: 'AT_GARAGE' | 'MOBILE_SERVICE';
   preselectedServiceAddress?: string;
+  /**
+   * Date to prefill when creating a new appointment (e.g. the day clicked on the
+   * calendar). A past date is clamped up to today; the past is never bookable.
+   */
+  initialDate?: Date;
 }
+
+/** Local midnight of today — the earliest date an appointment can be booked. */
+const startOfToday = (): Date => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
 
 export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
   open,
@@ -57,6 +69,7 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
   preselectedServiceType,
   preselectedAppointmentType,
   preselectedServiceAddress,
+  initialDate,
 }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -157,8 +170,14 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
         if (preselectedCustomerId) {
           loadCustomerDetails(preselectedCustomerId);
         }
+        // Default to the selected calendar day, but never book in the past:
+        // a past day is clamped up to today. Future days pass through as-is.
+        const today = startOfToday();
+        const scheduledDate =
+          initialDate && initialDate >= today ? initialDate : today;
         setFormData((prev) => ({
           ...prev,
+          scheduledDate,
           serviceType: preselectedServiceType || prev.serviceType,
           appointmentType: preselectedAppointmentType || 'AT_GARAGE',
           serviceAddress: preselectedServiceAddress || '',
@@ -175,6 +194,7 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
     preselectedServiceType,
     preselectedAppointmentType,
     preselectedServiceAddress,
+    initialDate,
   ]);
 
   // Auto-adjust time if date changes to today and selected time is in the past
@@ -299,6 +319,15 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
 
       if (!formData.customerId) {
         setError('Please select a customer');
+        return;
+      }
+
+      // New appointments cannot be booked in the past. Editing an existing
+      // (possibly past) appointment is still allowed.
+      if (!appointment && formData.scheduledDate < startOfToday()) {
+        setError(
+          'Appointment date cannot be in the past. Please choose today or a future date.'
+        );
         return;
       }
 
@@ -572,6 +601,7 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
             <DateTimeSelector
               date={formData.scheduledDate}
               time={formData.scheduledTime}
+              minDate={appointment ? undefined : startOfToday()}
               onDateChange={(date) =>
                 date &&
                 setFormData((prev) => ({ ...prev, scheduledDate: date }))

--- a/apps/webApp/src/app/components/appointments/DateTimeSelector.tsx
+++ b/apps/webApp/src/app/components/appointments/DateTimeSelector.tsx
@@ -8,6 +8,8 @@ interface DateTimeSelectorProps {
   time: string;
   onDateChange: (date: Date | null) => void;
   onTimeChange: (time: string) => void;
+  /** Earliest selectable date. Past days before this are disabled. */
+  minDate?: Date;
 }
 
 export const DateTimeSelector: React.FC<DateTimeSelectorProps> = ({
@@ -15,6 +17,7 @@ export const DateTimeSelector: React.FC<DateTimeSelectorProps> = ({
   time,
   onDateChange,
   onTimeChange,
+  minDate,
 }) => {
   const timeOptions = generateTimeOptions();
 
@@ -26,6 +29,7 @@ export const DateTimeSelector: React.FC<DateTimeSelectorProps> = ({
           label="Date"
           value={date}
           onChange={onDateChange}
+          minDate={minDate}
           slotProps={{
             textField: {
               fullWidth: true,

--- a/apps/webApp/src/app/components/repair-orders/AddVehicleDialog.tsx
+++ b/apps/webApp/src/app/components/repair-orders/AddVehicleDialog.tsx
@@ -22,16 +22,11 @@ import {
 } from '../../requests/vehicle.requests';
 import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { NumberInput } from '../common';
+import { VinScanButton } from '../vehicles/VinScanButton';
+import { VIN_PATTERN, normalizeVin } from '../../utils/vin.util';
 
 const CURRENT_YEAR = new Date().getFullYear() + 1;
 const YEARS = Array.from({ length: 60 }, (_, i) => CURRENT_YEAR - i);
-
-const VIN_PATTERN = /^[A-HJ-NPR-Z0-9]{17}$/;
-const normalizeVin = (value: string) =>
-  value
-    .toUpperCase()
-    .replace(/[^A-HJ-NPR-Z0-9]/g, '')
-    .slice(0, 17);
 
 interface AddVehicleDialogProps {
   open: boolean;
@@ -130,8 +125,8 @@ export function AddVehicleDialog({
     onClose();
   };
 
-  const handleDecodeVin = async () => {
-    const normalized = normalizeVin(vin);
+  const handleDecodeVin = async (vinValue?: string) => {
+    const normalized = normalizeVin(vinValue ?? vin);
     if (!VIN_PATTERN.test(normalized)) {
       showValidationError(
         'Enter a 17-character VIN. VINs cannot contain I, O, or Q.'
@@ -150,6 +145,16 @@ export function AddVehicleDialog({
       showApiError(error, 'Failed to decode VIN.');
     } finally {
       setDecoding(false);
+    }
+  };
+
+  // A camera scan already produced a validated 17-character VIN, so set the
+  // field and immediately run the NHTSA decode to autofill make/model/year.
+  const handleScannedVin = (scanned: string) => {
+    const normalized = normalizeVin(scanned);
+    setVin(normalized);
+    if (VIN_PATTERN.test(normalized)) {
+      handleDecodeVin(normalized);
     }
   };
 
@@ -245,9 +250,10 @@ export function AddVehicleDialog({
             InputProps={{
               endAdornment: (
                 <InputAdornment position="end">
+                  <VinScanButton onScanned={handleScannedVin} />
                   <Button
                     size="small"
-                    onClick={handleDecodeVin}
+                    onClick={() => handleDecodeVin()}
                     disabled={decoding || !vin}
                     startIcon={
                       decoding ? (

--- a/apps/webApp/src/app/components/vehicles/VinScanButton.tsx
+++ b/apps/webApp/src/app/components/vehicles/VinScanButton.tsx
@@ -1,0 +1,59 @@
+import { lazy, Suspense, useState } from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import { QrCodeScanner } from '@mui/icons-material';
+
+// The scanner pulls in the ZXing barcode engine, so it is code-split and only
+// downloaded the first time a user opens the scanner — it never bloats the
+// initial bundle.
+const VinScanDialog = lazy(() => import('./VinScanDialog'));
+
+interface VinScanButtonProps {
+  /** Called with the confirmed 17-character VIN when a scan is accepted. */
+  onScanned: (vin: string) => void;
+  disabled?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  tooltip?: string;
+}
+
+/**
+ * Camera button that opens the live VIN barcode scanner. Drop it next to a VIN
+ * input; on a successful scan it hands back the 17-character VIN via onScanned.
+ */
+export function VinScanButton({
+  onScanned,
+  disabled = false,
+  size = 'small',
+  tooltip = 'Scan VIN with camera',
+}: VinScanButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Tooltip title={tooltip}>
+        <span>
+          <IconButton
+            size={size}
+            disabled={disabled}
+            onClick={() => setOpen(true)}
+            aria-label={tooltip}
+          >
+            <QrCodeScanner fontSize={size === 'large' ? 'medium' : 'small'} />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      {open && (
+        <Suspense fallback={null}>
+          <VinScanDialog
+            open={open}
+            onClose={() => setOpen(false)}
+            onScanned={(vin) => {
+              setOpen(false);
+              onScanned(vin);
+            }}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/apps/webApp/src/app/components/vehicles/VinScanDialog.tsx
+++ b/apps/webApp/src/app/components/vehicles/VinScanDialog.tsx
@@ -1,0 +1,352 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Button,
+  IconButton,
+  Typography,
+  Stack,
+  Alert,
+  CircularProgress,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import {
+  Close,
+  FlashlightOn,
+  FlashlightOff,
+  Replay,
+  CheckCircle,
+  QrCodeScanner,
+} from '@mui/icons-material';
+import { BrowserMultiFormatReader, IScannerControls } from '@zxing/browser';
+import {
+  DecodeHintType,
+  BarcodeFormat,
+  NotFoundException,
+} from '@zxing/library';
+import { colors } from '../../theme/colors';
+import { extractVinFromScan, VinScanCandidate } from '../../utils/vin.util';
+
+interface VinScanDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the confirmed 17-character VIN when the user accepts a scan. */
+  onScanned: (vin: string) => void;
+}
+
+type ScanStatus = 'starting' | 'scanning' | 'result' | 'error';
+
+// VIN barcodes are almost always Code 39; newer vehicles occasionally use Code
+// 128 or Data Matrix. Restricting the format set makes decoding faster and less
+// prone to false positives.
+const VIN_FORMATS = [
+  BarcodeFormat.CODE_39,
+  BarcodeFormat.CODE_128,
+  BarcodeFormat.DATA_MATRIX,
+];
+
+export default function VinScanDialog({
+  open,
+  onClose,
+  onScanned,
+}: VinScanDialogProps) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const controlsRef = useRef<IScannerControls | null>(null);
+  // Guards against the continuous decode callback firing again after we've
+  // already captured a valid VIN.
+  const capturedRef = useRef(false);
+
+  const [status, setStatus] = useState<ScanStatus>('starting');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [candidate, setCandidate] = useState<VinScanCandidate | null>(null);
+  const [torchOn, setTorchOn] = useState(false);
+  const [torchSupported, setTorchSupported] = useState(false);
+
+  const stopCamera = useCallback(() => {
+    try {
+      controlsRef.current?.stop();
+    } catch {
+      /* no-op */
+    }
+    controlsRef.current = null;
+  }, []);
+
+  const startScanning = useCallback(async () => {
+    capturedRef.current = false;
+    setCandidate(null);
+    setErrorMsg('');
+    setTorchOn(false);
+    setStatus('starting');
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setErrorMsg(
+        'Camera access is not supported on this device or browser. Enter the VIN manually.'
+      );
+      setStatus('error');
+      return;
+    }
+
+    const hints = new Map();
+    hints.set(DecodeHintType.POSSIBLE_FORMATS, VIN_FORMATS);
+    hints.set(DecodeHintType.TRY_HARDER, true);
+    const reader = new BrowserMultiFormatReader(hints);
+
+    try {
+      const controls = await reader.decodeFromConstraints(
+        {
+          video: {
+            facingMode: { ideal: 'environment' },
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
+          },
+        },
+        videoRef.current as HTMLVideoElement,
+        (result, err) => {
+          if (capturedRef.current) return;
+          if (result) {
+            const found = extractVinFromScan(result.getText());
+            if (found) {
+              capturedRef.current = true;
+              if (navigator.vibrate) navigator.vibrate(120);
+              setCandidate(found);
+              setStatus('result');
+              stopCamera();
+            }
+            return;
+          }
+          // NotFoundException just means "no barcode in this frame" — expected
+          // on nearly every frame; only surface real errors.
+          if (err && !(err instanceof NotFoundException)) {
+            // Non-fatal decode hiccup; keep scanning.
+          }
+        }
+      );
+      controlsRef.current = controls;
+      setStatus('scanning');
+
+      // Torch is experimental in ZXing/browsers: expose the toggle when the
+      // control is present, and hide it later if actually switching it rejects.
+      setTorchSupported(typeof controls.switchTorch === 'function');
+    } catch (err) {
+      const name = (err as Error)?.name;
+      if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
+        setErrorMsg(
+          'Camera permission was denied. Allow camera access in your browser settings, or enter the VIN manually.'
+        );
+      } else if (name === 'NotFoundError' || name === 'DevicesNotFoundError') {
+        setErrorMsg('No camera was found on this device.');
+      } else {
+        setErrorMsg(
+          'Could not start the camera. Enter the VIN manually or try again.'
+        );
+      }
+      setStatus('error');
+    }
+  }, [stopCamera]);
+
+  // Start the camera when the dialog opens; always release it when it closes.
+  useEffect(() => {
+    if (open) {
+      startScanning();
+    }
+    return () => stopCamera();
+  }, [open, startScanning, stopCamera]);
+
+  const handleToggleTorch = async () => {
+    const controls = controlsRef.current;
+    if (!controls?.switchTorch) return;
+    try {
+      const next = !torchOn;
+      await controls.switchTorch(next);
+      setTorchOn(next);
+    } catch {
+      setTorchSupported(false);
+    }
+  };
+
+  const handleRescan = () => {
+    startScanning();
+  };
+
+  const handleAccept = () => {
+    if (candidate) {
+      onScanned(candidate.vin);
+    }
+    handleClose();
+  };
+
+  const handleClose = () => {
+    stopCamera();
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      fullScreen={fullScreen}
+      fullWidth
+      maxWidth="sm"
+    >
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <QrCodeScanner sx={{ color: colors.primary.main }} />
+        Scan VIN
+        <IconButton
+          onClick={handleClose}
+          size="small"
+          sx={{ ml: 'auto' }}
+          aria-label="Close scanner"
+        >
+          <Close />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent>
+        {status === 'error' ? (
+          <Alert severity="warning" sx={{ my: 1 }}>
+            {errorMsg}
+          </Alert>
+        ) : status === 'result' && candidate ? (
+          <Stack spacing={2} sx={{ py: 1 }} alignItems="center">
+            <CheckCircle
+              sx={{ fontSize: 48, color: colors.semantic.success }}
+            />
+            <Typography variant="overline" color="text.secondary">
+              Scanned VIN
+            </Typography>
+            <Typography
+              variant="h5"
+              sx={{
+                fontFamily: 'monospace',
+                letterSpacing: 1,
+                fontWeight: 700,
+                wordBreak: 'break-all',
+                textAlign: 'center',
+              }}
+            >
+              {candidate.vin}
+            </Typography>
+            {candidate.checkDigitValid ? (
+              <Alert severity="success" sx={{ width: '100%' }}>
+                Check digit verified — this is a valid VIN.
+              </Alert>
+            ) : (
+              <Alert severity="warning" sx={{ width: '100%' }}>
+                Couldn&apos;t verify the check digit. Please confirm the VIN
+                matches the vehicle before using it.
+              </Alert>
+            )}
+          </Stack>
+        ) : (
+          <Box>
+            <Box
+              sx={{
+                position: 'relative',
+                width: '100%',
+                aspectRatio: '4 / 3',
+                bgcolor: 'black',
+                borderRadius: 1,
+                overflow: 'hidden',
+              }}
+            >
+              <video
+                ref={videoRef}
+                muted
+                playsInline
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'cover',
+                }}
+              />
+              {/* Framing guide */}
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: '50%',
+                  left: '50%',
+                  transform: 'translate(-50%, -50%)',
+                  width: '85%',
+                  height: '28%',
+                  border: `3px solid ${colors.secondary.main}`,
+                  borderRadius: 1,
+                  boxShadow: '0 0 0 9999px rgba(0,0,0,0.35)',
+                }}
+              />
+              {status === 'starting' && (
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    inset: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <CircularProgress sx={{ color: 'white' }} />
+                </Box>
+              )}
+            </Box>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 1.5, textAlign: 'center' }}
+            >
+              Point the camera at the VIN barcode — usually on the driver&apos;s
+              door jamb or the bottom of the windshield.
+            </Typography>
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        {status === 'result' ? (
+          <>
+            <Button startIcon={<Replay />} onClick={handleRescan}>
+              Scan again
+            </Button>
+            <Button
+              variant="contained"
+              startIcon={<CheckCircle />}
+              onClick={handleAccept}
+            >
+              Use this VIN
+            </Button>
+          </>
+        ) : status === 'error' ? (
+          <>
+            <Button onClick={handleClose}>Close</Button>
+            <Button
+              variant="contained"
+              startIcon={<Replay />}
+              onClick={handleRescan}
+            >
+              Try again
+            </Button>
+          </>
+        ) : (
+          <>
+            {torchSupported && (
+              <Button
+                startIcon={torchOn ? <FlashlightOff /> : <FlashlightOn />}
+                onClick={handleToggleTorch}
+              >
+                {torchOn ? 'Torch off' : 'Torch on'}
+              </Button>
+            )}
+            <Button onClick={handleClose} sx={{ ml: 'auto' }}>
+              Cancel
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/webApp/src/app/pages/admin/appointments/AppointmentsManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/appointments/AppointmentsManagement.tsx
@@ -260,7 +260,10 @@ export const AppointmentsManagement: React.FC = () => {
     loadTodayAppointments();
   };
 
-  const handleCreate = () => {
+  // `date` is the day to prefill (e.g. the clicked calendar day). Omitted from
+  // the toolbar buttons, which default to today.
+  const handleCreate = (date?: Date) => {
+    setSelectedDate(date ?? new Date());
     setSelectedAppointment(undefined);
     setDialogOpen(true);
   };
@@ -604,7 +607,7 @@ export const AppointmentsManagement: React.FC = () => {
               </Typography>
               <IconButton
                 color="primary"
-                onClick={handleCreate}
+                onClick={() => handleCreate()}
                 sx={{
                   bgcolor: 'primary.main',
                   color: 'white',
@@ -852,7 +855,7 @@ export const AppointmentsManagement: React.FC = () => {
                     color="primary"
                     size="small"
                     startIcon={<AddIcon />}
-                    onClick={handleCreate}
+                    onClick={() => handleCreate()}
                   >
                     Add Appointment
                   </Button>
@@ -2014,6 +2017,7 @@ export const AppointmentsManagement: React.FC = () => {
           onClose={() => setDialogOpen(false)}
           onSuccess={handleDialogSuccess}
           appointment={selectedAppointment}
+          initialDate={selectedDate}
         />
 
         {/* Day Appointments Dialog */}
@@ -2027,7 +2031,7 @@ export const AppointmentsManagement: React.FC = () => {
           onStatusChange={handleStatusChange}
           onCreateRepairOrder={handleCreateRepairOrder}
           onViewRepairOrder={handleViewRepairOrder}
-          onAddAppointment={handleCreate}
+          onAddAppointment={() => handleCreate(selectedDate)}
           onRefresh={async () => {
             // Reload appointments and payment data when payment is received in dialog
             await loadMonthAppointments();

--- a/apps/webApp/src/app/utils/vin.util.spec.ts
+++ b/apps/webApp/src/app/utils/vin.util.spec.ts
@@ -1,0 +1,91 @@
+import {
+  VIN_PATTERN,
+  normalizeVin,
+  isValidVin,
+  isValidVinCheckDigit,
+  extractVinFromScan,
+} from './vin.util';
+
+describe('vin.util', () => {
+  describe('normalizeVin', () => {
+    it('uppercases, strips invalid chars, and caps at 17', () => {
+      expect(normalizeVin('1hgcm82633a004352')).toBe('1HGCM82633A004352');
+      expect(normalizeVin('1HG-CM8 2633A00435 2')).toBe('1HGCM82633A004352');
+    });
+
+    it('drops the disallowed letters I, O, Q', () => {
+      expect(normalizeVin('IOQ1HGCM82633A0043')).toBe('1HGCM82633A0043');
+    });
+
+    it('never returns more than 17 characters', () => {
+      expect(normalizeVin('1HGCM82633A004352EXTRA').length).toBe(17);
+    });
+  });
+
+  describe('VIN_PATTERN / isValidVin', () => {
+    it('accepts a well-formed 17-character VIN', () => {
+      expect(VIN_PATTERN.test('1HGCM82633A004352')).toBe(true);
+      expect(isValidVin('1HGCM82633A004352')).toBe(true);
+    });
+
+    it('rejects wrong length or forbidden letters', () => {
+      expect(isValidVin('1HGCM82633A00435')).toBe(false); // 16 chars
+      expect(isValidVin('1HGCM82633A0043I2')).toBe(false); // contains I
+    });
+  });
+
+  describe('isValidVinCheckDigit', () => {
+    it('accepts VINs with a correct ISO 3779 check digit', () => {
+      // Well-known valid sample VINs.
+      expect(isValidVinCheckDigit('1HGCM82633A004352')).toBe(true);
+      expect(isValidVinCheckDigit('11111111111111111')).toBe(true);
+    });
+
+    it('accepts a VIN whose check digit is X', () => {
+      expect(isValidVinCheckDigit('1M8GDM9AXKP042788')).toBe(true);
+    });
+
+    it('rejects a VIN with an incorrect check digit', () => {
+      // Same as the valid sample but with the check digit (pos 9) altered.
+      expect(isValidVinCheckDigit('1HGCM82653A004352')).toBe(false);
+    });
+
+    it('rejects structurally invalid input', () => {
+      expect(isValidVinCheckDigit('NOTAVIN')).toBe(false);
+    });
+  });
+
+  describe('extractVinFromScan', () => {
+    it('extracts a clean 17-character VIN', () => {
+      const result = extractVinFromScan('1HGCM82633A004352');
+      expect(result).toEqual({
+        vin: '1HGCM82633A004352',
+        checkDigitValid: true,
+      });
+    });
+
+    it('strips delimiter characters wrapping the VIN', () => {
+      // Some Code 39 door-jamb barcodes wrap the VIN with delimiters.
+      const result = extractVinFromScan('I1HGCM82633A004352*');
+      expect(result?.vin).toBe('1HGCM82633A004352');
+      expect(result?.checkDigitValid).toBe(true);
+    });
+
+    it('prefers the window whose check digit validates', () => {
+      // Leading junk digit means two 17-char windows exist; the valid one wins.
+      const result = extractVinFromScan('91HGCM82633A004352');
+      expect(result?.vin).toBe('1HGCM82633A004352');
+      expect(result?.checkDigitValid).toBe(true);
+    });
+
+    it('still returns a structurally valid VIN when no check digit matches', () => {
+      const raw = '1HGCM82653A004352'; // valid shape, bad check digit
+      const result = extractVinFromScan(raw);
+      expect(result).toEqual({ vin: raw, checkDigitValid: false });
+    });
+
+    it('returns null when no 17-character VIN is present', () => {
+      expect(extractVinFromScan('SHORT123')).toBeNull();
+    });
+  });
+});

--- a/apps/webApp/src/app/utils/vin.util.ts
+++ b/apps/webApp/src/app/utils/vin.util.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared VIN (Vehicle Identification Number) helpers.
+ *
+ * Previously the VIN regex and normalize helper were copy-pasted across
+ * AddVehicleDialog, VehicleForm and CreateRepairOrderDialog. This module is the
+ * single source of truth, and adds ISO 3779 check-digit validation used to
+ * verify camera scans before we trust them.
+ */
+
+/** A VIN is exactly 17 chars; the letters I, O and Q are never used. */
+export const VIN_PATTERN = /^[A-HJ-NPR-Z0-9]{17}$/;
+
+/**
+ * Normalize free-text/typed input into VIN shape: uppercase, drop any character
+ * that can't appear in a VIN, and cap at 17 characters. Safe to call on every
+ * keystroke.
+ */
+export const normalizeVin = (value: string): string =>
+  value
+    .toUpperCase()
+    .replace(/[^A-HJ-NPR-Z0-9]/g, '')
+    .slice(0, 17);
+
+/** True when the value is a structurally valid 17-character VIN. */
+export const isValidVin = (value: string): boolean => VIN_PATTERN.test(value);
+
+// --- ISO 3779 check-digit (position 9) -------------------------------------
+// Transliteration table: letters map to numeric values, digits map to
+// themselves. I, O, Q are excluded (never valid in a VIN).
+const TRANSLITERATION: Record<string, number> = {
+  A: 1,
+  B: 2,
+  C: 3,
+  D: 4,
+  E: 5,
+  F: 6,
+  G: 7,
+  H: 8,
+  J: 1,
+  K: 2,
+  L: 3,
+  M: 4,
+  N: 5,
+  P: 7,
+  R: 9,
+  S: 2,
+  T: 3,
+  U: 4,
+  V: 5,
+  W: 6,
+  X: 7,
+  Y: 8,
+  Z: 9,
+  '0': 0,
+  '1': 1,
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5,
+  '6': 6,
+  '7': 7,
+  '8': 8,
+  '9': 9,
+};
+
+// Positional weights (position 9 — the check digit itself — has weight 0).
+const WEIGHTS = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2];
+
+/**
+ * Validate the ISO 3779 check digit (9th character).
+ *
+ * NOTE: The check digit is mandatory for North American vehicles but not for
+ * every market, so a `false` result means "could not verify", NOT necessarily
+ * "invalid VIN". Use it as a confidence signal, not a hard gate.
+ */
+export const isValidVinCheckDigit = (vin: string): boolean => {
+  if (!VIN_PATTERN.test(vin)) return false;
+  let sum = 0;
+  for (let i = 0; i < 17; i++) {
+    const value = TRANSLITERATION[vin[i]];
+    if (value === undefined) return false;
+    sum += value * WEIGHTS[i];
+  }
+  const remainder = sum % 11;
+  const expected = remainder === 10 ? 'X' : String(remainder);
+  return vin[8] === expected;
+};
+
+export interface VinScanCandidate {
+  /** The 17-character VIN extracted from the scanned barcode payload. */
+  vin: string;
+  /** Whether the ISO 3779 check digit validated (confidence signal). */
+  checkDigitValid: boolean;
+}
+
+/**
+ * Extract a VIN from a raw barcode payload.
+ *
+ * Door-jamb / windshield Code 39 barcodes sometimes wrap the VIN with delimiter
+ * characters (e.g. a leading "I" or a trailing "*"), so the payload can be
+ * longer than 17 chars. We scan every 17-character window and prefer the one
+ * whose check digit validates; otherwise we fall back to the first structurally
+ * valid window. Returns null when no 17-character VIN can be found.
+ */
+export const extractVinFromScan = (raw: string): VinScanCandidate | null => {
+  const cleaned = raw.toUpperCase().replace(/[^A-HJ-NPR-Z0-9]/g, '');
+  if (cleaned.length < 17) return null;
+
+  let firstValid: VinScanCandidate | null = null;
+  for (let start = 0; start + 17 <= cleaned.length; start++) {
+    const candidate = cleaned.slice(start, start + 17);
+    if (!VIN_PATTERN.test(candidate)) continue;
+    if (isValidVinCheckDigit(candidate)) {
+      return { vin: candidate, checkDigitValid: true };
+    }
+    if (!firstValid) {
+      firstValid = { vin: candidate, checkDigitValid: false };
+    }
+  }
+  return firstValid;
+};

--- a/package.json
+++ b/package.json
@@ -148,6 +148,8 @@
     "@tanstack/react-query-devtools": "^5.85.3",
     "@types/bcryptjs": "^3.0.0",
     "@types/pdfkit": "^0.17.3",
+    "@zxing/browser": "^0.2.1",
+    "@zxing/library": "^0.23.0",
     "autosuggest-highlight": "^3.3.4",
     "axios": "^1.6.0",
     "bcryptjs": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,6 +5680,27 @@
   dependencies:
     argparse "^2.0.1"
 
+"@zxing/browser@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@zxing/browser/-/browser-0.2.1.tgz#41ca0b80648d131dec5d8cc18efbd62fae4646e7"
+  integrity sha512-92pVfVDUXbc15xu9vIEmhNyqIEASMEkDF92CwT6T+7sg2EHXJRktH9CQKoQSXe51UtbNsj+Fm09H/JBWHMs/Sw==
+  optionalDependencies:
+    "@zxing/text-encoding" "^0.9.0"
+
+"@zxing/library@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@zxing/library/-/library-0.23.0.tgz#cc1a341f064b36fc24631cc13797bcd329e36ca7"
+  integrity sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA==
+  dependencies:
+    ts-custom-error "^3.3.1"
+  optionalDependencies:
+    "@zxing/text-encoding" "~0.9.0"
+
+"@zxing/text-encoding@^0.9.0", "@zxing/text-encoding@~0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
+
 JSONStream@1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -15446,6 +15467,11 @@ ts-api-utils@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
+
+ts-custom-error@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.3.1.tgz#8bd3c8fc6b8dc8e1cb329267c45200f1e17a65d1"
+  integrity sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==
 
 ts-jest@^29.4.0:
   version "29.4.2"


### PR DESCRIPTION
## Summary

Two changes:

### 1. Scan a VIN with the device camera (`feat`)
Adds a live barcode VIN scanner next to the VIN field in **Add/Edit Vehicle**. Tapping the camera icon opens a rear-camera dialog that continuously decodes the door-jamb / windshield VIN barcode, validates it, and on confirmation fills the field and auto-runs the existing NHTSA decode to populate make/model/year/engine.

- **`vin.util.ts`** — single source of truth for VIN helpers: `VIN_PATTERN`, `normalizeVin`, ISO 3779 **check-digit validation**, and barcode-payload extraction (strips delimiter chars, prefers the check-digit-valid window). Replaces the copy-pasted helpers in `AddVehicleDialog`. Unit-tested.
- **`VinScanDialog`** — `getUserMedia` live scan via ZXing (Code 39 / 128 / Data Matrix), framing overlay, torch toggle, check-digit confirmation step, and graceful fallback when the camera is denied/unavailable (manual entry always remains).
- **`VinScanButton`** — `React.lazy` wrapper so the ZXing engine is **code-split** out of the main bundle (≈119 KB gzip, downloaded only on first use).

Phase 1 (barcode). OCR fallback + rollout into `VehicleForm` / `CreateRepairOrderDialog` can follow.

### 2. Default new appointment to the clicked calendar day (`fix`)
Clicking a calendar day → **Add appointment** now prefills **that day** instead of today. A **past** day is clamped up to today and the date picker disables past days, so appointments can never be booked in the past; any future date is allowed. Editing an existing (possibly past) appointment is unaffected. Toolbar **Book Appointment** buttons still default to today.

## Testing
- `tsc --noEmit` ✅
- `nx build webApp` ✅ (ZXing confirmed code-split into its own chunk)
- `nx test webApp` ✅ (incl. new VIN util spec)
- `eslint` ✅ (0 errors)
- ⚠️ Camera + torch need a real-device smoke test (iPhone/Android) over HTTPS.

## New dependencies
- `@zxing/browser@^0.2.1`, `@zxing/library@^0.23.0` (MIT, free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)