### PR TITLE
fix(vehicles): show live camera preview in the VIN scanner

### DIFF
--- a/apps/webApp/src/app/components/vehicles/VinScanDialog.tsx
+++ b/apps/webApp/src/app/components/vehicles/VinScanDialog.tsx
@@ -59,9 +59,15 @@ export default function VinScanDialog({
 
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const controlsRef = useRef<IScannerControls | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
   // Guards against the continuous decode callback firing again after we've
   // already captured a valid VIN.
   const capturedRef = useRef(false);
+  // Identifies the current camera session. StrictMode (and rapid re-opens) can
+  // start a second session while the first is still awaiting getUserMedia; any
+  // session whose id no longer matches must release its stream instead of
+  // attaching it.
+  const runIdRef = useRef(0);
 
   const [status, setStatus] = useState<ScanStatus>('starting');
   const [errorMsg, setErrorMsg] = useState('');
@@ -70,19 +76,43 @@ export default function VinScanDialog({
   const [torchSupported, setTorchSupported] = useState(false);
 
   const stopCamera = useCallback(() => {
+    // Invalidate any camera session still in flight so it releases its stream
+    // instead of attaching it after we've torn down.
+    runIdRef.current += 1;
     try {
       controlsRef.current?.stop();
     } catch {
       /* no-op */
     }
     controlsRef.current = null;
+    // controls.stop() disposes the stream it was given, but a session that
+    // never reached that point still holds live tracks — stop them explicitly
+    // so the camera indicator always goes out.
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
   }, []);
 
   const startScanning = useCallback(async () => {
+    const video = videoRef.current;
+    // The <video> is mounted inside a MUI portal, so it does not exist on the
+    // dialog's first commit. startScanning is driven by the video's ref
+    // callback (below), which fires the moment the element is really in the
+    // DOM — never start without it, or ZXing quietly decodes into a detached
+    // element it creates itself and the preview stays black.
+    if (!video) return;
+
+    stopCamera();
+    const runId = ++runIdRef.current;
+    const isStale = () => runId !== runIdRef.current;
+
     capturedRef.current = false;
     setCandidate(null);
     setErrorMsg('');
     setTorchOn(false);
+    setTorchSupported(false);
     setStatus('starting');
 
     if (!navigator.mediaDevices?.getUserMedia) {
@@ -99,17 +129,25 @@ export default function VinScanDialog({
     const reader = new BrowserMultiFormatReader(hints);
 
     try {
-      const controls = await reader.decodeFromConstraints(
-        {
-          video: {
-            facingMode: { ideal: 'environment' },
-            width: { ideal: 1280 },
-            height: { ideal: 720 },
-          },
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: { ideal: 'environment' },
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
         },
-        videoRef.current as HTMLVideoElement,
+      });
+
+      if (isStale()) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+      streamRef.current = stream;
+
+      const controls = await reader.decodeFromStream(
+        stream,
+        video,
         (result, err) => {
-          if (capturedRef.current) return;
+          if (capturedRef.current || isStale()) return;
           if (result) {
             const found = extractVinFromScan(result.getText());
             if (found) {
@@ -128,6 +166,11 @@ export default function VinScanDialog({
           }
         }
       );
+
+      if (isStale()) {
+        controls.stop();
+        return;
+      }
       controlsRef.current = controls;
       setStatus('scanning');
 
@@ -135,6 +178,8 @@ export default function VinScanDialog({
       // control is present, and hide it later if actually switching it rejects.
       setTorchSupported(typeof controls.switchTorch === 'function');
     } catch (err) {
+      if (isStale()) return;
+      stopCamera();
       const name = (err as Error)?.name;
       if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
         setErrorMsg(
@@ -151,13 +196,49 @@ export default function VinScanDialog({
     }
   }, [stopCamera]);
 
-  // Start the camera when the dialog opens; always release it when it closes.
+  // The video element only exists while we're starting/scanning, so its ref
+  // callback is the reliable signal for "the preview is in the DOM now" —
+  // including after Scan again / Try again remounts it.
+  const attachVideo = useCallback(
+    (node: HTMLVideoElement | null) => {
+      videoRef.current = node;
+      if (node) {
+        startScanning();
+      } else {
+        stopCamera();
+      }
+    },
+    [startScanning, stopCamera]
+  );
+
   useEffect(() => {
-    if (open) {
+    // If the preview is already mounted when effects run — which is what
+    // happens when StrictMode tears the session down and re-runs them — make
+    // sure a session is live again. Redundant calls are safe: startScanning
+    // invalidates and releases whatever came before it.
+    if (videoRef.current) {
       startScanning();
     }
-    return () => stopCamera();
-  }, [open, startScanning, stopCamera]);
+    // Belt-and-braces: always release the camera when the dialog unmounts.
+    return stopCamera;
+  }, [startScanning, stopCamera]);
+
+  // A stream can attach and still never deliver frames (camera held by another
+  // app, some virtual-camera drivers). Surface that instead of leaving the user
+  // staring at a black rectangle with no explanation.
+  useEffect(() => {
+    if (status !== 'scanning') return;
+    const timer = setTimeout(() => {
+      if (!videoRef.current || videoRef.current.videoWidth === 0) {
+        stopCamera();
+        setErrorMsg(
+          'The camera started but is not sending any video. Close any other app that may be using the camera, then try again — or enter the VIN manually.'
+        );
+        setStatus('error');
+      }
+    }, 6000);
+    return () => clearTimeout(timer);
+  }, [status, stopCamera]);
 
   const handleToggleTorch = async () => {
     const controls = controlsRef.current;
@@ -172,7 +253,10 @@ export default function VinScanDialog({
   };
 
   const handleRescan = () => {
-    startScanning();
+    // Remounts the preview; its ref callback restarts the camera.
+    setCandidate(null);
+    setErrorMsg('');
+    setStatus('starting');
   };
 
   const handleAccept = () => {
@@ -257,7 +341,8 @@ export default function VinScanDialog({
               }}
             >
               <video
-                ref={videoRef}
+                ref={attachVideo}
+                autoPlay
                 muted
                 playsInline
                 style={{


### PR DESCRIPTION
## Problem

The Scan VIN dialog opened to a permanently black rectangle — no error, no spinner, camera permission granted. The camera was actually running; it just wasn't attached to the element the user could see.

## Root cause

The `<video>` lives inside MUI's `Dialog`, which renders through a **portal**, so it isn't in the DOM on the dialog's first commit. `videoRef.current` was still `null` when the mount effect called `startScanning()`, and ZXing's `createVideoElement` silently falls back to `document.createElement('video')` when handed a falsy preview. It attached the stream to that **detached** element, decoded happily and reported success, while the on-screen `<video>` kept `srcObject === null`.

React `StrictMode` compounded it: effects run twice, and the cleanup couldn't stop a session that hadn't finished starting — so every open **leaked a live camera track** that only stopped on page reload.

## Changes

- Drive `startScanning()` from the video's **ref callback** instead of a mount effect, so a session can only begin once the element is genuinely in the DOM. This also covers *Scan again* / *Try again*, which remount the preview.
- **Own the stream**: `getUserMedia` + `decodeFromStream(stream, video, cb)` rather than `decodeFromConstraints`, so the element is passed explicitly and can never be substituted.
- **Session ids** (`runIdRef`) so a superseded start (StrictMode, rapid reopen) releases its own tracks. `stopCamera` now stops tracks directly and clears `srcObject`.
- **6s watchdog**: if a stream attaches but never delivers frames (camera held by another app, some virtual-camera drivers), show a real error instead of an unexplained black rectangle.
- Add `autoPlay` to the `<video>`.

## Verification

Reproduced and verified headlessly with a fake camera device (`--use-fake-device-for-media-stream`).

Before:

```
in-DOM video:   hasSrcObject: false, videoWidth: 0, paused: true   <- what the user saw
DETACHED video: hasSrcObject: true,  1280x720, playing
DETACHED video: hasSrcObject: true,  1280x720, playing             <- leaked, x2
```

After, across open -> cancel -> reopen:

```
after open:       liveTracks: 1, in-DOM video hasStream: true, 1280x720, playing
after cancel:     liveTracks: 0, video unmounted        <- camera fully released
after reopen:     liveTracks: 1, in-DOM video hasStream: true, 1280x720, playing
```

`yarn typecheck:web` and ESLint pass.

**Not covered by the automated check:** a fake camera device can't validate actual barcode decoding, so this is worth a quick confirm against a real VIN sticker on a phone.

## Scope

Barcode scanning only. OCR of printed/stamped VIN characters is a separate piece of work and is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
