### PR TITLE
feat(ui): CrudAutocomplete standard + Day Summary invoice detail

### DIFF
--- a/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
+++ b/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
@@ -79,6 +79,11 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
   const [employeesLoading, setEmployeesLoading] = useState(false);
   const [availableSlots, setAvailableSlots] = useState<AvailableSlot[]>([]);
   const [customerDialogOpen, setCustomerDialogOpen] = useState(false);
+  // Set when the customer dialog is opened to edit an existing customer from
+  // the picker; null means it is open to create a new one.
+  const [editingCustomerId, setEditingCustomerId] = useState<string | null>(
+    null
+  );
   const [addVehicleOpen, setAddVehicleOpen] = useState(false);
 
   const [formData, setFormData] = useState({
@@ -578,7 +583,18 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
                 customers={customers}
                 selectedCustomer={selectedCustomer}
                 onCustomerChange={handleCustomerChange}
-                onAddCustomer={() => setCustomerDialogOpen(true)}
+                onAddCustomer={() => {
+                  setEditingCustomerId(null);
+                  setCustomerDialogOpen(true);
+                }}
+                onEditCustomer={
+                  appointment
+                    ? undefined
+                    : (customer) => {
+                        setEditingCustomerId(customer.id);
+                        setCustomerDialogOpen(true);
+                      }
+                }
                 loading={customersLoading}
                 disabled={!!appointment}
                 showAddButton={!appointment}
@@ -667,13 +683,24 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
         </DialogActions>
       </Dialog>
 
-      {/* Customer Dialog for Adding New Customers */}
+      {/* Customer Dialog — adds a new customer, or edits one from the picker */}
       <CustomerDialog
+        key={editingCustomerId ?? 'new'}
         open={customerDialogOpen}
-        onClose={() => setCustomerDialogOpen(false)}
+        customerId={editingCustomerId ?? undefined}
+        onClose={() => {
+          setCustomerDialogOpen(false);
+          setEditingCustomerId(null);
+        }}
         onSuccess={async () => {
           setCustomerDialogOpen(false);
           await loadCustomers();
+          // An edit can change the name shown in the field, so refresh the
+          // selected record too.
+          if (editingCustomerId && selectedCustomer?.id === editingCustomerId) {
+            await loadCustomerDetails(editingCustomerId);
+          }
+          setEditingCustomerId(null);
         }}
       />
 

--- a/apps/webApp/src/app/components/appointments/CustomerSelectionField.tsx
+++ b/apps/webApp/src/app/components/appointments/CustomerSelectionField.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
-import {
-  Box,
-  TextField,
-  Autocomplete,
-  CircularProgress,
-  Tooltip,
-  IconButton,
-  FormControl,
-  FormLabel,
-} from '@mui/material';
-import { Add as AddIcon } from '@mui/icons-material';
+import { Box, FormControl, FormLabel } from '@mui/material';
+import { CrudAutocomplete } from '../common/CrudAutocomplete';
 import { Customer } from '../../requests/customer.requests';
 
 interface CustomerSelectionFieldProps {
@@ -17,16 +8,24 @@ interface CustomerSelectionFieldProps {
   selectedCustomer: Customer | null;
   onCustomerChange: (customer: Customer | null) => void;
   onAddCustomer: () => void;
+  /** Opens the customer dialog for the row's customer. Omit to hide edit. */
+  onEditCustomer?: (customer: Customer) => void;
   loading: boolean;
   disabled?: boolean;
   showAddButton?: boolean;
 }
+
+const customerLabel = (customer: Customer) =>
+  customer.businessName
+    ? `${customer.businessName} (${customer.firstName} ${customer.lastName})`
+    : `${customer.firstName} ${customer.lastName}`;
 
 export const CustomerSelectionField: React.FC<CustomerSelectionFieldProps> = ({
   customers,
   selectedCustomer,
   onCustomerChange,
   onAddCustomer,
+  onEditCustomer,
   loading,
   disabled = false,
   showAddButton = true,
@@ -34,89 +33,44 @@ export const CustomerSelectionField: React.FC<CustomerSelectionFieldProps> = ({
   return (
     <FormControl component="fieldset" required fullWidth>
       <FormLabel component="legend">Search or Add Customer</FormLabel>
-      <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start', mt: 1 }}>
-        <Autocomplete
-          fullWidth
+      <Box sx={{ mt: 1 }}>
+        <CrudAutocomplete<Customer>
+          label="Customer (search by name or phone)"
+          entityLabel="customer"
           options={customers}
           value={selectedCustomer}
-          onChange={(_, value) => onCustomerChange(value)}
-          getOptionLabel={(customer) =>
-            customer.businessName
-              ? `${customer.businessName} (${customer.firstName} ${customer.lastName})`
-              : `${customer.firstName} ${customer.lastName}`
+          onChange={onCustomerChange}
+          getOptionId={(customer) => customer.id}
+          getOptionLabel={customerLabel}
+          // Staff search by whatever they have to hand — phone as often as name.
+          getOptionSearchText={(customer) =>
+            [customer.businessName, customer.phone].filter(Boolean).join(' ')
           }
-          filterOptions={(options, { inputValue }) => {
-            // Filter by name, business name, or phone number
-            const filterValue = inputValue.toLowerCase();
-            return options.filter((customer) => {
-              const fullName = `${customer.firstName} ${customer.lastName}`.toLowerCase();
-              const businessName = customer.businessName?.toLowerCase() || '';
-              const phone = customer.phone?.toLowerCase() || '';
-
-              return (
-                fullName.includes(filterValue) ||
-                businessName.includes(filterValue) ||
-                phone.includes(filterValue)
-              );
-            });
-          }}
-          renderOption={(props, customer) => (
-            <li {...props} key={customer.id}>
-              <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-                <Box sx={{ fontWeight: 600 }}>
-                  {customer.businessName
-                    ? `${customer.businessName}`
-                    : `${customer.firstName} ${customer.lastName}`}
-                </Box>
-                {customer.businessName && (
-                  <Box sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
-                    {customer.firstName} {customer.lastName}
-                  </Box>
-                )}
-                {customer.phone && (
-                  <Box sx={{ fontSize: '0.875rem', color: 'primary.main' }}>
-                    {customer.phone}
-                  </Box>
-                )}
+          renderOptionContent={(customer) => (
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+              <Box sx={{ fontWeight: 600 }}>
+                {customer.businessName
+                  ? customer.businessName
+                  : `${customer.firstName} ${customer.lastName}`}
               </Box>
-            </li>
+              {customer.businessName && (
+                <Box sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+                  {customer.firstName} {customer.lastName}
+                </Box>
+              )}
+              {customer.phone && (
+                <Box sx={{ fontSize: '0.875rem', color: 'primary.main' }}>
+                  {customer.phone}
+                </Box>
+              )}
+            </Box>
           )}
           loading={loading}
           disabled={disabled}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Customer (search by name or phone)"
-              required
-              InputProps={{
-                ...params.InputProps,
-                endAdornment: (
-                  <>
-                    {loading ? (
-                      <CircularProgress color="inherit" size={20} />
-                    ) : null}
-                    {params.InputProps.endAdornment}
-                  </>
-                ),
-              }}
-            />
-          )}
+          required
+          onAdd={showAddButton ? onAddCustomer : undefined}
+          onEdit={onEditCustomer}
         />
-        {showAddButton && (
-          <Tooltip title="Add New Customer">
-            <IconButton
-              onClick={onAddCustomer}
-              color="primary"
-              sx={{
-                mt: 0.5,
-                border: '1px dashed',
-                borderColor: 'primary.main',
-              }}
-            >
-              <AddIcon />
-            </IconButton>
-          </Tooltip>
-        )}
       </Box>
     </FormControl>
   );

--- a/apps/webApp/src/app/components/appointments/ServiceTypeSelector.tsx
+++ b/apps/webApp/src/app/components/appointments/ServiceTypeSelector.tsx
@@ -1,13 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   Grid,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Divider,
-  ListItemIcon,
-  ListItemText,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -15,16 +8,9 @@ import {
   Button,
   Stack,
   TextField,
-  Box,
-  IconButton,
-  Tooltip,
 } from '@mui/material';
-import {
-  AddCircleOutline as AddIcon,
-  Edit as EditIcon,
-  Delete as DeleteIcon,
-} from '@mui/icons-material';
 import { NumberInput } from '../common';
+import { CrudAutocomplete } from '../common/CrudAutocomplete';
 import { serviceTypeService } from '../../requests/service-type.requests';
 import { useAuth } from '../../hooks/useAuth';
 import { useError } from '../../contexts/ErrorContext';
@@ -51,9 +37,6 @@ export const SERVICE_TYPES: ServiceTypeOption[] = [
   { value: 'OTHER', label: 'Other Service', duration: 60 },
 ];
 
-// Sentinel value used by the inline "Add new service type" menu entry.
-const ADD_NEW = '__ADD_NEW_SERVICE_TYPE__';
-
 interface ServiceTypeSelectorProps {
   serviceType: string;
   duration: number;
@@ -73,7 +56,6 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
   const canManage = isAdmin || isSupervisor;
 
   const [options, setOptions] = useState<ServiceTypeOption[]>(SERVICE_TYPES);
-  const [menuOpen, setMenuOpen] = useState(false);
 
   // Create/edit dialog state. `editingId` null => creating.
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -120,11 +102,10 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
         ]
       : options;
 
+  const selectedOption =
+    displayOptions.find((o) => o.value === serviceType) ?? null;
+
   const handleSelectChange = (newServiceType: string) => {
-    if (newServiceType === ADD_NEW) {
-      openCreate();
-      return;
-    }
     const service = displayOptions.find((s) => s.value === newServiceType);
     onServiceTypeChange(newServiceType);
     if (service) {
@@ -133,7 +114,6 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
   };
 
   const openCreate = () => {
-    setMenuOpen(false);
     setEditingId(null);
     setFormName('');
     setFormDuration(60);
@@ -142,7 +122,6 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
 
   const openEdit = (option: ServiceTypeOption) => {
     if (!option.id) return;
-    setMenuOpen(false);
     setEditingId(option.id);
     setFormName(option.label);
     setFormDuration(option.duration);
@@ -187,7 +166,6 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
 
   const handleDelete = async (option: ServiceTypeOption) => {
     if (!option.id) return;
-    setMenuOpen(false);
     const confirmed = await confirm({
       title: 'Delete Service Type',
       message: `Delete "${option.label}"? Existing appointments keep their record, but this type will no longer be selectable.`,
@@ -215,70 +193,24 @@ export const ServiceTypeSelector: React.FC<ServiceTypeSelectorProps> = ({
     <>
       {/* Service Type */}
       <Grid size={{ xs: 12, sm: 6 }}>
-        <FormControl fullWidth required>
-          <InputLabel>Service Type</InputLabel>
-          <Select
-            value={serviceType}
-            open={menuOpen}
-            onOpen={() => setMenuOpen(true)}
-            onClose={() => setMenuOpen(false)}
-            onChange={(e) => handleSelectChange(e.target.value)}
-            label="Service Type"
-            renderValue={(value) => {
-              const opt = displayOptions.find((o) => o.value === value);
-              return opt ? `${opt.label} (${opt.duration} min)` : '';
-            }}
-          >
-            {displayOptions.map((service) => (
-              <MenuItem key={service.value} value={service.value}>
-                <ListItemText
-                  primary={`${service.label} (${service.duration} min)`}
-                />
-                {canManage && service.id && (
-                  <Box
-                    sx={{ display: 'flex', gap: 0.5, ml: 1 }}
-                    // Prevent selecting the row when tapping the icons.
-                    onClick={(e) => e.stopPropagation()}
-                    onMouseDown={(e) => e.stopPropagation()}
-                  >
-                    <Tooltip title="Edit">
-                      <IconButton
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          openEdit(service);
-                        }}
-                      >
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Delete">
-                      <IconButton
-                        size="small"
-                        color="error"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDelete(service);
-                        }}
-                      >
-                        <DeleteIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  </Box>
-                )}
-              </MenuItem>
-            ))}
-            {canManage && <Divider />}
-            {canManage && (
-              <MenuItem value={ADD_NEW}>
-                <ListItemIcon>
-                  <AddIcon fontSize="small" color="primary" />
-                </ListItemIcon>
-                <ListItemText primary="Add new service type…" />
-              </MenuItem>
-            )}
-          </Select>
-        </FormControl>
+        <CrudAutocomplete<ServiceTypeOption>
+          label="Service Type"
+          entityLabel="service type"
+          required
+          options={displayOptions}
+          value={selectedOption}
+          onChange={(option) => handleSelectChange(option?.value ?? '')}
+          getOptionId={(option) => option.value}
+          getOptionLabel={(option) =>
+            `${option.label} (${option.duration} min)`
+          }
+          // Only types loaded from the API have an id; the hardcoded fallbacks
+          // and a retired type kept for an existing appointment cannot be edited.
+          isOptionManageable={(option) => Boolean(option.id)}
+          onAdd={canManage ? openCreate : undefined}
+          onEdit={canManage ? openEdit : undefined}
+          onDelete={canManage ? handleDelete : undefined}
+        />
       </Grid>
 
       {/* Duration */}

--- a/apps/webApp/src/app/components/common/CrudAutocomplete.tsx
+++ b/apps/webApp/src/app/components/common/CrudAutocomplete.tsx
@@ -1,0 +1,310 @@
+import { ReactNode, SyntheticEvent, useState } from 'react';
+import {
+  Autocomplete,
+  Box,
+  CircularProgress,
+  IconButton,
+  TextField,
+  Tooltip,
+  alpha,
+} from '@mui/material';
+import { AddIcon, EditIcon, DeleteIcon } from '../../icons/standard.icons';
+import { colors } from '../../theme/colors';
+
+export interface CrudAutocompleteProps<T> {
+  /** Field label, e.g. "Brand". */
+  label: string;
+  /**
+   * Singular, lowercase name of the thing being picked, e.g. "brand". Used to
+   * build the tooltips and aria-labels ("Add new brand", "Edit brand").
+   */
+  entityLabel: string;
+
+  options: T[];
+  value: T | null;
+  onChange: (option: T | null) => void;
+  getOptionId: (option: T) => string;
+  getOptionLabel: (option: T) => string;
+  /** Optional richer row content; defaults to the plain option label. */
+  renderOptionContent?: (option: T) => ReactNode;
+  /**
+   * Extra text a row should match while typing, on top of its label — e.g. a
+   * customer's phone number or business name. Return everything searchable.
+   */
+  getOptionSearchText?: (option: T) => string;
+  /**
+   * Per-row gate for the edit/delete buttons. Use when only some options are
+   * editable — e.g. service types that exist in the database, versus hardcoded
+   * fallbacks that have no id. Defaults to every row being manageable.
+   */
+  isOptionManageable?: (option: T) => boolean;
+
+  /** Opens the create dialog. The button is hidden when omitted. */
+  onAdd?: () => void;
+  /** Per-row edit. The row's edit button is hidden when omitted. */
+  onEdit?: (option: T) => void;
+  /** Per-row delete. The row's delete button is hidden when omitted. */
+  onDelete?: (option: T) => void;
+  /** Id of the option currently being deleted — shows a spinner on that row. */
+  pendingDeleteId?: string | null;
+
+  loading?: boolean;
+  disabled?: boolean;
+  error?: boolean;
+  helperText?: string;
+  required?: boolean;
+  size?: 'small' | 'medium';
+  placeholder?: string;
+}
+
+/**
+ * The standard picker for small managed catalogs (tire brands, sizes,
+ * locations) — a list the user both selects from and maintains in place.
+ *
+ * Layout contract:
+ * - **Add** sits inside the input on the right, ahead of the clear/dropdown
+ *   indicators, so it reads as part of the field.
+ * - **Edit / Delete** sit on each row of the dropdown, so they act on the row
+ *   you are pointing at rather than only on the current selection.
+ *
+ * Callers own the data and the dialogs; this component owns the layout and the
+ * event plumbing that keeps row buttons from selecting the row.
+ *
+ * @example
+ * <CrudAutocomplete
+ *   label="Brand"
+ *   entityLabel="brand"
+ *   options={brands}
+ *   value={selectedBrand}
+ *   onChange={(b) => onChange(b?.id ?? '', b?.name ?? '')}
+ *   getOptionId={(b) => b.id}
+ *   getOptionLabel={(b) => b.name}
+ *   onAdd={handleAddNew}
+ *   onEdit={handleEdit}
+ *   onDelete={handleDelete}
+ *   pendingDeleteId={deleteMutation.isPending ? pendingId : null}
+ * />
+ */
+export function CrudAutocomplete<T>({
+  label,
+  entityLabel,
+  options,
+  value,
+  onChange,
+  getOptionId,
+  getOptionLabel,
+  renderOptionContent,
+  getOptionSearchText,
+  isOptionManageable,
+  onAdd,
+  onEdit,
+  onDelete,
+  pendingDeleteId,
+  loading = false,
+  disabled = false,
+  error = false,
+  helperText,
+  required = false,
+  size = 'medium',
+  placeholder,
+}: CrudAutocompleteProps<T>) {
+  const [open, setOpen] = useState(false);
+
+  const hasRowActions = Boolean(onEdit || onDelete);
+
+  // A row button must not also pick the row. Suppressing mousedown keeps focus
+  // on the input (so the listbox doesn't close from under the click), and
+  // stopping the click keeps it from reaching the option's own handler.
+  const swallow = (event: SyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const runRowAction = (event: SyntheticEvent, action: () => void) => {
+    swallow(event);
+    // Close the list first: these actions open a dialog, and leaving the
+    // popper open behind a modal traps focus in a confusing place.
+    setOpen(false);
+    action();
+  };
+
+  return (
+    <Autocomplete
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      options={options}
+      value={value}
+      onChange={(_, newValue) => onChange(newValue)}
+      getOptionLabel={getOptionLabel}
+      isOptionEqualToValue={(option, selected) =>
+        getOptionId(option) === getOptionId(selected)
+      }
+      filterOptions={(opts, { inputValue }) => {
+        const query = inputValue.trim().toLowerCase();
+        if (!query) return opts;
+        return opts.filter((option) => {
+          const haystack = getOptionSearchText
+            ? `${getOptionLabel(option)} ${getOptionSearchText(option)}`
+            : getOptionLabel(option);
+          return haystack.toLowerCase().includes(query);
+        });
+      }}
+      loading={loading}
+      disabled={disabled}
+      size={size}
+      // No dropdown arrow — the list still opens on click/focus of the input.
+      // forcePopupIcon={false} is what actually drops it; popupIcon={null}
+      // leaves an empty indicator button behind.
+      forcePopupIcon={false}
+      openOnFocus
+      renderOption={(props, option) => {
+        // MUI supplies `key` inside props; React 19 warns if it is spread.
+        const { key, ...liProps } = props as typeof props & { key: string };
+        const id = getOptionId(option);
+        const isDeleting = pendingDeleteId === id;
+        const rowManageable = isOptionManageable
+          ? isOptionManageable(option)
+          : true;
+
+        return (
+          <Box
+            component="li"
+            key={key}
+            {...liProps}
+            sx={{ display: 'flex', alignItems: 'center', gap: 1, pr: 1 }}
+          >
+            <Box
+              sx={{
+                flexGrow: 1,
+                minWidth: 0,
+                overflow: 'hidden',
+                // Custom content lays itself out (customer rows are multi-line);
+                // only the plain label gets single-line truncation.
+                ...(renderOptionContent
+                  ? {}
+                  : { textOverflow: 'ellipsis', whiteSpace: 'nowrap' }),
+              }}
+            >
+              {renderOptionContent
+                ? renderOptionContent(option)
+                : getOptionLabel(option)}
+            </Box>
+
+            {hasRowActions && rowManageable && (
+              <Box sx={{ display: 'flex', flexShrink: 0, gap: 0.25 }}>
+                {onEdit && (
+                  <Tooltip title={`Edit ${entityLabel}`}>
+                    <IconButton
+                      size="small"
+                      // Excluded from the tab order so keyboard users still
+                      // move through options normally.
+                      tabIndex={-1}
+                      aria-label={`Edit ${getOptionLabel(option)}`}
+                      onMouseDown={swallow}
+                      onClick={(event) =>
+                        runRowAction(event, () => onEdit(option))
+                      }
+                      sx={{ p: 0.5 }}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+                {onDelete && (
+                  <Tooltip title={`Delete ${entityLabel}`}>
+                    {/* span keeps the tooltip working while disabled */}
+                    <span>
+                      <IconButton
+                        size="small"
+                        tabIndex={-1}
+                        aria-label={`Delete ${getOptionLabel(option)}`}
+                        disabled={isDeleting}
+                        onMouseDown={swallow}
+                        onClick={(event) =>
+                          runRowAction(event, () => onDelete(option))
+                        }
+                        sx={{ p: 0.5, color: colors.semantic.error }}
+                      >
+                        {isDeleting ? (
+                          <CircularProgress size={16} />
+                        ) : (
+                          <DeleteIcon fontSize="small" />
+                        )}
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                )}
+              </Box>
+            )}
+          </Box>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={placeholder}
+          required={required}
+          error={error}
+          helperText={helperText}
+          sx={{
+            // MUI absolutely positions the clear indicator against the right
+            // edge of the input, which would float it past the Add button no
+            // matter the DOM order. Putting it back in flow makes the row read
+            // [clear] [add]; the reserved right padding goes with it.
+            '& .MuiAutocomplete-endAdornment': {
+              position: 'static',
+              transform: 'none',
+            },
+            '& .MuiAutocomplete-inputRoot': {
+              paddingRight: '9px !important',
+            },
+            // MUI pulls the clear indicator 2px right to tuck it under the
+            // arrow we removed; that would overlap the Add button.
+            '& .MuiAutocomplete-clearIndicator': {
+              marginRight: 0,
+            },
+          }}
+          slotProps={{
+            input: {
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading && <CircularProgress color="inherit" size={20} />}
+                  {/* Clear (X) sits ahead of Add, which anchors the right edge. */}
+                  {params.InputProps.endAdornment}
+                  {onAdd && !disabled && (
+                    <Tooltip title={`Add new ${entityLabel}`}>
+                      <IconButton
+                        size="small"
+                        aria-label={`Add new ${entityLabel}`}
+                        onClick={onAdd}
+                        sx={{
+                          p: 0.5,
+                          mr: 0.5,
+                          borderRadius: '50%',
+                          border: `2px solid ${colors.primary.main}`,
+                          color: colors.primary.main,
+                          '&:hover': {
+                            borderColor: colors.primary.dark,
+                            color: colors.primary.dark,
+                            bgcolor: alpha(colors.primary.main, 0.08),
+                          },
+                        }}
+                      >
+                        <AddIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </>
+              ),
+            },
+          }}
+        />
+      )}
+    />
+  );
+}
+
+export default CrudAutocomplete;

--- a/apps/webApp/src/app/components/common/index.ts
+++ b/apps/webApp/src/app/components/common/index.ts
@@ -7,3 +7,5 @@ export type { AnalyticsCardData } from './AnalyticsCards';
 export { default as NumberInput } from './NumberInput';
 export type { NumberInputProps } from './NumberInput';
 export { PhoneInput } from './PhoneInput';
+export { CrudAutocomplete } from './CrudAutocomplete';
+export type { CrudAutocompleteProps } from './CrudAutocomplete';

--- a/apps/webApp/src/app/components/inventory/BrandSelect.tsx
+++ b/apps/webApp/src/app/components/inventory/BrandSelect.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import {
-  IconButton,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -9,13 +8,17 @@ import {
   Button,
   Alert,
   Box,
-  Tooltip,
   CircularProgress,
-  Autocomplete,
 } from '@mui/material';
-import { AddIcon, EditIcon, DeleteIcon } from '../../icons/standard.icons';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { TireBrandService, TireBrand, CreateTireBrandDto, UpdateTireBrandDto } from '../../requests/tire-brand.requests';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CrudAutocomplete } from '../common/CrudAutocomplete';
+import { useCatalogSelect } from '../../hooks/useCatalogSelect';
+import {
+  TireBrandService,
+  TireBrand,
+  CreateTireBrandDto,
+  UpdateTireBrandDto,
+} from '../../requests/tire-brand.requests';
 
 interface BrandSelectProps {
   value?: string;
@@ -29,7 +32,7 @@ interface BrandDialogProps {
   open: boolean;
   onClose: () => void;
   brand?: TireBrand | null;
-  onSuccess: () => void;
+  onSuccess: (saved: TireBrand) => void;
 }
 
 function BrandDialog({ open, onClose, brand, onSuccess }: BrandDialogProps) {
@@ -39,7 +42,9 @@ function BrandDialog({ open, onClose, brand, onSuccess }: BrandDialogProps) {
     name: '',
     imageUrl: '',
   });
-  const [errors, setErrors] = useState<{ name?: string; imageUrl?: string }>({});
+  const [errors, setErrors] = useState<{ name?: string; imageUrl?: string }>(
+    {}
+  );
 
   useEffect(() => {
     if (open) {
@@ -59,59 +64,36 @@ function BrandDialog({ open, onClose, brand, onSuccess }: BrandDialogProps) {
   }, [brand, open]);
 
   const createMutation = useMutation({
-    mutationFn: async (data: CreateTireBrandDto) => {
-      // Ensure we have a valid token before making the request
-      await ensureValidToken();
-      return TireBrandService.create(data);
-    },
-    onSuccess: () => {
+    mutationFn: (data: CreateTireBrandDto) => TireBrandService.create(data),
+    onSuccess: (saved) => {
       queryClient.invalidateQueries({ queryKey: ['tire-brands'] });
-      onSuccess();
+      onSuccess(saved);
       onClose();
     },
     onError: (error: any) => {
       if (process.env.NODE_ENV !== 'production') {
-        console.error('Create brand failed:', error?.response?.data?.message || error.message);
+        console.error(
+          'Create brand failed:',
+          error?.response?.data?.message || error.message
+        );
       }
     },
   });
 
-  // Function to ensure we have a valid auth token
-  const ensureValidToken = async () => {
-    let token = localStorage.getItem('authToken');
-
-    if (!token && window.Clerk?.session) {
-      try {
-        token = await window.Clerk.session.getToken();
-        if (token) {
-          localStorage.setItem('authToken', token);
-        }
-      } catch (error) {
-        throw new Error('Authentication required');
-      }
-    }
-
-    if (!token) {
-      throw new Error('No authentication token available');
-    }
-
-    return token;
-  };
-
   const updateMutation = useMutation({
-    mutationFn: async (data: UpdateTireBrandDto) => {
-      // Ensure we have a valid token before making the request
-      await ensureValidToken();
-      return TireBrandService.update(brand!.id, data);
-    },
-    onSuccess: () => {
+    mutationFn: (data: UpdateTireBrandDto) =>
+      TireBrandService.update(brand!.id, data),
+    onSuccess: (saved) => {
       queryClient.invalidateQueries({ queryKey: ['tire-brands'] });
-      onSuccess();
+      onSuccess(saved);
       onClose();
     },
     onError: (error: any) => {
       if (process.env.NODE_ENV !== 'production') {
-        console.error('Update brand failed:', error?.response?.data?.message || error.message);
+        console.error(
+          'Update brand failed:',
+          error?.response?.data?.message || error.message
+        );
       }
     },
   });
@@ -163,17 +145,14 @@ function BrandDialog({ open, onClose, brand, onSuccess }: BrandDialogProps) {
             fullWidth
             value={formData.name}
             onChange={(e) => {
-              setFormData(prev => ({ ...prev, name: e.target.value }));
-              if (errors.name) setErrors(prev => ({ ...prev, name: undefined }));
+              setFormData((prev) => ({ ...prev, name: e.target.value }));
+              if (errors.name)
+                setErrors((prev) => ({ ...prev, name: undefined }));
             }}
             error={!!errors.name}
-            helperText={errors.name || (isEditMode ? "Brand name cannot be changed" : undefined)}
+            helperText={errors.name}
             margin="normal"
             required
-            disabled={isEditMode}
-            InputProps={{
-              readOnly: isEditMode,
-            }}
           />
 
           <TextField
@@ -181,8 +160,9 @@ function BrandDialog({ open, onClose, brand, onSuccess }: BrandDialogProps) {
             fullWidth
             value={formData.imageUrl}
             onChange={(e) => {
-              setFormData(prev => ({ ...prev, imageUrl: e.target.value }));
-              if (errors.imageUrl) setErrors(prev => ({ ...prev, imageUrl: undefined }));
+              setFormData((prev) => ({ ...prev, imageUrl: e.target.value }));
+              if (errors.imageUrl)
+                setErrors((prev) => ({ ...prev, imageUrl: undefined }));
             }}
             error={!!errors.imageUrl}
             helperText={errors.imageUrl}
@@ -208,174 +188,79 @@ function BrandDialog({ open, onClose, brand, onSuccess }: BrandDialogProps) {
   );
 }
 
-export function BrandSelect({ value, onChange, error, helperText, disabled }: BrandSelectProps) {
-  const queryClient = useQueryClient();
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingBrand, setEditingBrand] = useState<TireBrand | null>(null);
-  const [, setIsAuthenticated] = useState(true);
-
-  // Check if we have a token which indicates authentication capability
-  const hasAuthToken = !!localStorage.getItem('authToken') || !!window.Clerk?.session;
-
-  // Try to load full brand objects for authenticated users with CRUD, fallback to simple names
-  const { data: brands = [], isLoading } = useQuery({
+export function BrandSelect({
+  value,
+  onChange,
+  error,
+  helperText,
+  disabled,
+}: BrandSelectProps) {
+  const {
+    items: brands,
+    isLoading,
+    canManage,
+    canDelete,
+    dialogOpen,
+    editingItem,
+    openAdd,
+    openEdit,
+    closeDialog,
+    requestDelete,
+    pendingDeleteId,
+  } = useCatalogSelect<TireBrand>({
     queryKey: ['tire-brands'],
-    queryFn: async () => {
-      try {
-        // Try authenticated endpoint first for full CRUD functionality
-        return await TireBrandService.getAll();
-      } catch (error: any) {
-        // If auth fails (401), fallback to public endpoint and create mock brand objects
-        if (error?.response?.status === 401) {
-          setIsAuthenticated(false);
-          const brandNames = await TireBrandService.getBrands();
-          return brandNames.map(name => ({
-            id: name, // Use name as ID for fallback
-            name,
-            imageUrl: undefined,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          }));
-        }
-        throw error;
-      }
+    entityLabel: 'brand',
+    fetchAll: () => TireBrandService.getAll(),
+    fetchNames: () => TireBrandService.getBrands(),
+    toFallbackItem: (name) =>
+      ({
+        id: name,
+        name,
+        imageUrl: undefined,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as TireBrand),
+    remove: (id) => TireBrandService.delete(id),
+    getId: (brand) => brand.id,
+    getLabel: (brand) => brand.name,
+    onDeleted: (brand) => {
+      // The field holds the brand *name*; clear it when that brand is gone.
+      if (brand.name === value) onChange('', '');
     },
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => TireBrandService.delete(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tire-brands'] });
-      // If the deleted brand was selected, clear the selection
-      if (value && brands.find(b => b.id === value && !brands.find(b2 => b2.id === value))) {
-        onChange('', '');
-      }
-    },
-  });
-
-  const handleAddNew = () => {
-    setEditingBrand(null);
-    setDialogOpen(true);
-  };
-
-  const handleEdit = (brand: TireBrand) => {
-    setEditingBrand(brand);
-    setDialogOpen(true);
-  };
-
-  const handleDelete = async (brand: TireBrand) => {
-    if (window.confirm(`Are you sure you want to delete "${brand.name}"? This action cannot be undone.`)) {
-      deleteMutation.mutate(brand.id);
-    }
-  };
-
-  const handleChange = (brandId: string) => {
-    const brand = brands.find(b => b.id === brandId);
-    onChange(brandId, brand?.name || '');
-  };
-
-  const selectedBrand = brands.find(b => b.name === value);
+  const selectedBrand = brands.find((b) => b.name === value) ?? null;
 
   return (
     <>
-      <Box sx={{ position: 'relative' }}>
-        <Autocomplete
-          options={brands}
-          getOptionLabel={(option) => option.name}
-          value={selectedBrand || null}
-          onChange={(event, newValue) => {
-            if (newValue) {
-              handleChange(newValue.id);
-            } else {
-              onChange('', '');
-            }
-          }}
-          loading={isLoading}
-          disabled={disabled}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Brand"
-              error={error}
-              helperText={helperText}
-              InputProps={{
-                ...params.InputProps,
-                endAdornment: (
-                  <>
-                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
-                    {params.InputProps.endAdornment}
-                  </>
-                ),
-              }}
-            />
-          )}
-          filterOptions={(options, { inputValue }) => {
-            return options.filter((option) =>
-              option.name.toLowerCase().includes(inputValue.toLowerCase())
-            );
-          }}
-        />
-        {hasAuthToken && (
-          <Box sx={{
-            position: 'absolute',
-            right: 8,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            display: 'flex',
-            alignItems: 'center',
-            zIndex: 1
-          }}>
-            <Tooltip title="Add new brand">
-              <IconButton
-                size="small"
-                onClick={handleAddNew}
-                disabled={disabled}
-                sx={{ p: 0.5 }}
-              >
-                <AddIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            {selectedBrand && (
-              <>
-                <Tooltip title="Edit brand">
-                  <IconButton
-                    size="small"
-                    onClick={() => handleEdit(selectedBrand)}
-                    disabled={disabled}
-                    sx={{ p: 0.5 }}
-                  >
-                    <EditIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="Delete brand">
-                  <IconButton
-                    size="small"
-                    onClick={() => handleDelete(selectedBrand)}
-                    disabled={disabled || deleteMutation.isPending}
-                    sx={{ p: 0.5 }}
-                  >
-                    {deleteMutation.isPending ? (
-                      <CircularProgress size={16} />
-                    ) : (
-                      <DeleteIcon fontSize="small" />
-                    )}
-                  </IconButton>
-                </Tooltip>
-              </>
-            )}
-          </Box>
-        )}
-      </Box>
+      <CrudAutocomplete<TireBrand>
+        label="Brand"
+        entityLabel="brand"
+        options={brands}
+        value={selectedBrand}
+        onChange={(brand) => onChange(brand?.id ?? '', brand?.name ?? '')}
+        getOptionId={(brand) => brand.id}
+        getOptionLabel={(brand) => brand.name}
+        loading={isLoading}
+        disabled={disabled}
+        error={error}
+        helperText={helperText}
+        onAdd={canManage ? openAdd : undefined}
+        onEdit={canManage ? openEdit : undefined}
+        onDelete={canDelete ? requestDelete : undefined}
+        pendingDeleteId={pendingDeleteId}
+      />
 
-      {hasAuthToken && (
+      {canManage && (
         <BrandDialog
           open={dialogOpen}
-          onClose={() => setDialogOpen(false)}
-          brand={editingBrand}
-          onSuccess={() => {
-            // If we just added a new brand, auto-select it
-            if (!editingBrand) {
-              queryClient.invalidateQueries({ queryKey: ['tire-brands'] });
+          onClose={closeDialog}
+          brand={editingItem}
+          onSuccess={(saved) => {
+            // Select what was just created, and follow a rename through to the
+            // field — it stores the name, so a rename would otherwise blank it.
+            if (!editingItem || editingItem.name === value) {
+              onChange(saved.id, saved.name);
             }
           }}
         />

--- a/apps/webApp/src/app/components/inventory/LocationSelect.tsx
+++ b/apps/webApp/src/app/components/inventory/LocationSelect.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import {
-  IconButton,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -9,13 +8,17 @@ import {
   Button,
   Alert,
   Box,
-  Tooltip,
   CircularProgress,
-  Autocomplete,
 } from '@mui/material';
-import { AddIcon, DeleteIcon } from '../../icons/standard.icons';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { LocationService, Location, CreateLocationDto } from '../../requests/location.requests';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CrudAutocomplete } from '../common/CrudAutocomplete';
+import { useCatalogSelect } from '../../hooks/useCatalogSelect';
+import {
+  LocationService,
+  Location,
+  CreateLocationDto,
+  UpdateLocationDto,
+} from '../../requests/location.requests';
 
 interface LocationSelectProps {
   value?: string;
@@ -28,11 +31,18 @@ interface LocationSelectProps {
 interface LocationDialogProps {
   open: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  location?: Location | null;
+  onSuccess: (saved: Location) => void;
 }
 
-function LocationDialog({ open, onClose, onSuccess }: LocationDialogProps) {
+function LocationDialog({
+  open,
+  onClose,
+  location,
+  onSuccess,
+}: LocationDialogProps) {
   const queryClient = useQueryClient();
+  const isEditMode = !!location;
   const [formData, setFormData] = useState({
     name: '',
   });
@@ -41,17 +51,27 @@ function LocationDialog({ open, onClose, onSuccess }: LocationDialogProps) {
   useEffect(() => {
     if (open) {
       setFormData({
-        name: '',
+        name: location?.name ?? '',
       });
       setErrors({});
     }
-  }, [open]);
+  }, [open, location]);
 
   const createMutation = useMutation({
     mutationFn: (data: CreateLocationDto) => LocationService.create(data),
-    onSuccess: () => {
+    onSuccess: (saved) => {
       queryClient.invalidateQueries({ queryKey: ['locations'] });
-      onSuccess();
+      onSuccess(saved);
+      onClose();
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: UpdateLocationDto) =>
+      LocationService.update(location!.id, data),
+    onSuccess: (saved) => {
+      queryClient.invalidateQueries({ queryKey: ['locations'] });
+      onSuccess(saved);
       onClose();
     },
   });
@@ -72,15 +92,21 @@ function LocationDialog({ open, onClose, onSuccess }: LocationDialogProps) {
       name: formData.name.trim(),
     };
 
-    createMutation.mutate(data);
+    if (isEditMode) {
+      updateMutation.mutate(data);
+    } else {
+      createMutation.mutate(data);
+    }
   };
 
-  const isLoading = createMutation.isPending;
-  const error = createMutation.error;
+  const isLoading = createMutation.isPending || updateMutation.isPending;
+  const error = createMutation.error || updateMutation.error;
 
   return (
     <Dialog open={open} disableEscapeKeyDown maxWidth="sm" fullWidth>
-      <DialogTitle>Add New Location</DialogTitle>
+      <DialogTitle>
+        {isEditMode ? 'Edit Location' : 'Add New Location'}
+      </DialogTitle>
       <DialogContent>
         <Box sx={{ pt: 1 }}>
           {error && (
@@ -94,8 +120,9 @@ function LocationDialog({ open, onClose, onSuccess }: LocationDialogProps) {
             fullWidth
             value={formData.name}
             onChange={(e) => {
-              setFormData(prev => ({ ...prev, name: e.target.value }));
-              if (errors.name) setErrors(prev => ({ ...prev, name: undefined }));
+              setFormData((prev) => ({ ...prev, name: e.target.value }));
+              if (errors.name)
+                setErrors((prev) => ({ ...prev, name: undefined }));
             }}
             error={!!errors.name}
             helperText={errors.name}
@@ -115,159 +142,87 @@ function LocationDialog({ open, onClose, onSuccess }: LocationDialogProps) {
           disabled={isLoading}
           startIcon={isLoading ? <CircularProgress size={16} /> : null}
         >
-          Add Location
+          {isEditMode ? 'Update' : 'Add'} Location
         </Button>
       </DialogActions>
     </Dialog>
   );
 }
 
-export function LocationSelect({ value, onChange, error, helperText, disabled }: LocationSelectProps) {
-  const queryClient = useQueryClient();
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [, setIsAuthenticated] = useState(true);
-
-  // Check if we have a token which indicates authentication capability
-  const hasAuthToken = !!localStorage.getItem('authToken') || !!window.Clerk?.session;
-
-  // Try to load full location objects for authenticated users with CRUD, fallback to simple names
-  const { data: locations = [], isLoading } = useQuery({
+export function LocationSelect({
+  value,
+  onChange,
+  error,
+  helperText,
+  disabled,
+}: LocationSelectProps) {
+  const {
+    items: locations,
+    isLoading,
+    canManage,
+    canDelete,
+    dialogOpen,
+    editingItem,
+    openAdd,
+    openEdit,
+    closeDialog,
+    requestDelete,
+    pendingDeleteId,
+  } = useCatalogSelect<Location>({
     queryKey: ['locations'],
-    queryFn: async () => {
-      try {
-        // Try authenticated endpoint first for full CRUD functionality
-        return await LocationService.getAll();
-      } catch (error: any) {
-        // If auth fails (401), fallback to public endpoint and create mock location objects
-        if (error?.response?.status === 401) {
-          setIsAuthenticated(false);
-          const locationNames = await LocationService.getLocations();
-          return locationNames.map(name => ({
-            id: name, // Use name as ID for fallback
-            name,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          }));
-        }
-        throw error;
-      }
+    entityLabel: 'location',
+    fetchAll: () => LocationService.getAll(),
+    fetchNames: () => LocationService.getLocations(),
+    toFallbackItem: (name) =>
+      ({
+        id: name,
+        name,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Location),
+    remove: (id) => LocationService.delete(id),
+    getId: (location) => location.id,
+    getLabel: (location) => location.name,
+    onDeleted: (location) => {
+      if (location.name === value) onChange('', '');
     },
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => LocationService.delete(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['locations'] });
-      // If the deleted location was selected, clear the selection
-      if (value && locations.find(l => l.id === value && !locations.find(l2 => l2.id === value))) {
-        onChange('', '');
-      }
-    },
-  });
-
-  const handleAddNew = () => {
-    setDialogOpen(true);
-  };
-
-  const handleDelete = async (location: Location) => {
-    if (window.confirm(`Are you sure you want to delete "${location.name}"? This action cannot be undone.`)) {
-      deleteMutation.mutate(location.id);
-    }
-  };
-
-  const handleChange = (locationId: string) => {
-    const location = locations.find(l => l.id === locationId);
-    onChange(locationId, location?.name || '');
-  };
-
-  const selectedLocation = locations.find(l => l.name === value);
+  const selectedLocation = locations.find((l) => l.name === value) ?? null;
 
   return (
     <>
-      <Box sx={{ position: 'relative' }}>
-        <Autocomplete
-          options={locations}
-          getOptionLabel={(option) => option.name}
-          value={selectedLocation || null}
-          onChange={(event, newValue) => {
-            if (newValue) {
-              handleChange(newValue.id);
-            } else {
-              onChange('', '');
-            }
-          }}
-          loading={isLoading}
-          disabled={disabled}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Location"
-              error={error}
-              helperText={helperText}
-              InputProps={{
-                ...params.InputProps,
-                endAdornment: (
-                  <>
-                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
-                    {params.InputProps.endAdornment}
-                  </>
-                ),
-              }}
-            />
-          )}
-          filterOptions={(options, { inputValue }) => {
-            return options.filter((option) =>
-              option.name.toLowerCase().includes(inputValue.toLowerCase())
-            );
-          }}
-        />
-        {hasAuthToken && (
-          <Box sx={{
-            position: 'absolute',
-            right: 8,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            display: 'flex',
-            alignItems: 'center',
-            zIndex: 1
-          }}>
-            <Tooltip title="Add new location">
-              <IconButton
-                size="small"
-                onClick={handleAddNew}
-                disabled={disabled}
-                sx={{ p: 0.5 }}
-              >
-                <AddIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            {selectedLocation && (
-              <Tooltip title="Delete location">
-                <IconButton
-                  size="small"
-                  onClick={() => handleDelete(selectedLocation)}
-                  disabled={disabled || deleteMutation.isPending}
-                  sx={{ p: 0.5 }}
-                >
-                  {deleteMutation.isPending ? (
-                    <CircularProgress size={16} />
-                  ) : (
-                    <DeleteIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </Tooltip>
-            )}
-          </Box>
-        )}
-      </Box>
+      <CrudAutocomplete<Location>
+        label="Location"
+        entityLabel="location"
+        options={locations}
+        value={selectedLocation}
+        onChange={(location) =>
+          onChange(location?.id ?? '', location?.name ?? '')
+        }
+        getOptionId={(location) => location.id}
+        getOptionLabel={(location) => location.name}
+        loading={isLoading}
+        disabled={disabled}
+        error={error}
+        helperText={helperText}
+        onAdd={canManage ? openAdd : undefined}
+        onEdit={canManage ? openEdit : undefined}
+        onDelete={canDelete ? requestDelete : undefined}
+        pendingDeleteId={pendingDeleteId}
+      />
 
-      {hasAuthToken && (
+      {canManage && (
         <LocationDialog
           open={dialogOpen}
-          onClose={() => setDialogOpen(false)}
-          onSuccess={() => {
-            // Auto-select the newly added location if possible
-            queryClient.invalidateQueries({ queryKey: ['locations'] });
+          onClose={closeDialog}
+          location={editingItem}
+          onSuccess={(saved) => {
+            // Select what was just created, and follow a rename through to the
+            // field — it stores the name, so a rename would otherwise blank it.
+            if (!editingItem || editingItem.name === value) {
+              onChange(saved.id, saved.name);
+            }
           }}
         />
       )}

--- a/apps/webApp/src/app/components/inventory/SizeSelect.tsx
+++ b/apps/webApp/src/app/components/inventory/SizeSelect.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import {
-  IconButton,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -9,13 +8,17 @@ import {
   Button,
   Alert,
   Box,
-  Tooltip,
   CircularProgress,
-  Autocomplete,
 } from '@mui/material';
-import { AddIcon, DeleteIcon } from '../../icons/standard.icons';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { TireSizeService, TireSize, CreateTireSizeDto, UpdateTireSizeDto } from '../../requests/tire-size.requests';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CrudAutocomplete } from '../common/CrudAutocomplete';
+import { useCatalogSelect } from '../../hooks/useCatalogSelect';
+import {
+  TireSizeService,
+  TireSize,
+  CreateTireSizeDto,
+  UpdateTireSizeDto,
+} from '../../requests/tire-size.requests';
 
 interface SizeSelectProps {
   value?: string;
@@ -29,7 +32,7 @@ interface SizeDialogProps {
   open: boolean;
   onClose: () => void;
   size?: TireSize | null;
-  onSuccess: () => void;
+  onSuccess: (saved: TireSize) => void;
 }
 
 function SizeDialog({ open, onClose, size, onSuccess }: SizeDialogProps) {
@@ -55,18 +58,19 @@ function SizeDialog({ open, onClose, size, onSuccess }: SizeDialogProps) {
 
   const createMutation = useMutation({
     mutationFn: (data: CreateTireSizeDto) => TireSizeService.create(data),
-    onSuccess: () => {
+    onSuccess: (saved) => {
       queryClient.invalidateQueries({ queryKey: ['tire-sizes'] });
-      onSuccess();
+      onSuccess(saved);
       onClose();
     },
   });
 
   const updateMutation = useMutation({
-    mutationFn: (data: UpdateTireSizeDto) => TireSizeService.update(size!.id, data),
-    onSuccess: () => {
+    mutationFn: (data: UpdateTireSizeDto) =>
+      TireSizeService.update(size!.id, data),
+    onSuccess: (saved) => {
       queryClient.invalidateQueries({ queryKey: ['tire-sizes'] });
-      onSuccess();
+      onSuccess(saved);
       onClose();
     },
   });
@@ -113,18 +117,15 @@ function SizeDialog({ open, onClose, size, onSuccess }: SizeDialogProps) {
             fullWidth
             value={formData.size}
             onChange={(e) => {
-              setFormData(prev => ({ ...prev, size: e.target.value }));
-              if (errors.size) setErrors(prev => ({ ...prev, size: undefined }));
+              setFormData((prev) => ({ ...prev, size: e.target.value }));
+              if (errors.size)
+                setErrors((prev) => ({ ...prev, size: undefined }));
             }}
             error={!!errors.size}
-            helperText={errors.size || (isEditMode ? "Tire size cannot be changed" : undefined)}
+            helperText={errors.size}
             margin="normal"
-            placeholder={isEditMode ? undefined : "e.g., 225/65R17, 265/70R16"}
+            placeholder="e.g., 225/65R17, 265/70R16"
             required
-            disabled={isEditMode}
-            InputProps={{
-              readOnly: isEditMode,
-            }}
           />
         </Box>
       </DialogContent>
@@ -145,156 +146,77 @@ function SizeDialog({ open, onClose, size, onSuccess }: SizeDialogProps) {
   );
 }
 
-export function SizeSelect({ value, onChange, error, helperText, disabled }: SizeSelectProps) {
-  const queryClient = useQueryClient();
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingSize, setEditingSize] = useState<TireSize | null>(null);
-  const [, setIsAuthenticated] = useState(true);
-
-  // Check if we have a token which indicates authentication capability
-  const hasAuthToken = !!localStorage.getItem('authToken') || !!window.Clerk?.session;
-
-  // Try to load full size objects for authenticated users with CRUD, fallback to simple names
-  const { data: sizes = [], isLoading } = useQuery({
+export function SizeSelect({
+  value,
+  onChange,
+  error,
+  helperText,
+  disabled,
+}: SizeSelectProps) {
+  const {
+    items: sizes,
+    isLoading,
+    canManage,
+    canDelete,
+    dialogOpen,
+    editingItem,
+    openAdd,
+    openEdit,
+    closeDialog,
+    requestDelete,
+    pendingDeleteId,
+  } = useCatalogSelect<TireSize>({
     queryKey: ['tire-sizes'],
-    queryFn: async () => {
-      try {
-        // Try authenticated endpoint first for full CRUD functionality
-        return await TireSizeService.getAll();
-      } catch (error: any) {
-        // If auth fails (401), fallback to public endpoint and create mock size objects
-        if (error?.response?.status === 401) {
-          setIsAuthenticated(false);
-          const sizeNames = await TireSizeService.getSizes();
-          return sizeNames.map(size => ({
-            id: size, // Use size as ID for fallback
-            size,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          }));
-        }
-        throw error;
-      }
+    entityLabel: 'size',
+    fetchAll: () => TireSizeService.getAll(),
+    fetchNames: () => TireSizeService.getSizes(),
+    toFallbackItem: (size) =>
+      ({
+        id: size,
+        size,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as TireSize),
+    remove: (id) => TireSizeService.delete(id),
+    getId: (size) => size.id,
+    getLabel: (size) => size.size,
+    onDeleted: (size) => {
+      if (size.size === value) onChange('', '');
     },
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => TireSizeService.delete(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tire-sizes'] });
-      // If the deleted size was selected, clear the selection
-      if (value && sizes.find(s => s.id === value && !sizes.find(s2 => s2.id === value))) {
-        onChange('', '');
-      }
-    },
-  });
-
-  const handleAddNew = () => {
-    setEditingSize(null);
-    setDialogOpen(true);
-  };
-
-  const handleDelete = async (size: TireSize) => {
-    if (window.confirm(`Are you sure you want to delete size "${size.size}"? This action cannot be undone.`)) {
-      deleteMutation.mutate(size.id);
-    }
-  };
-
-  const handleChange = (sizeId: string) => {
-    const size = sizes.find(s => s.id === sizeId);
-    onChange(sizeId, size?.size || '');
-  };
-
-  const selectedSize = sizes.find(s => s.size === value);
+  const selectedSize = sizes.find((s) => s.size === value) ?? null;
 
   return (
     <>
-      <Box sx={{ position: 'relative' }}>
-        <Autocomplete
-          options={sizes}
-          getOptionLabel={(option) => option.size}
-          value={selectedSize || null}
-          onChange={(event, newValue) => {
-            if (newValue) {
-              handleChange(newValue.id);
-            } else {
-              onChange('', '');
-            }
-          }}
-          loading={isLoading}
-          disabled={disabled}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Size"
-              error={error}
-              helperText={helperText}
-              InputProps={{
-                ...params.InputProps,
-                endAdornment: (
-                  <>
-                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
-                    {params.InputProps.endAdornment}
-                  </>
-                ),
-              }}
-            />
-          )}
-          filterOptions={(options, { inputValue }) => {
-            return options.filter((option) =>
-              option.size.toLowerCase().includes(inputValue.toLowerCase())
-            );
-          }}
-        />
-        {hasAuthToken && (
-          <Box sx={{
-            position: 'absolute',
-            right: 8,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            display: 'flex',
-            alignItems: 'center',
-            zIndex: 1
-          }}>
-            <Tooltip title="Add new size">
-              <IconButton
-                size="small"
-                onClick={handleAddNew}
-                disabled={disabled}
-                sx={{ p: 0.5 }}
-              >
-                <AddIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            {selectedSize && (
-              <Tooltip title="Delete size">
-                <IconButton
-                  size="small"
-                  onClick={() => handleDelete(selectedSize)}
-                  disabled={disabled || deleteMutation.isPending}
-                  sx={{ p: 0.5 }}
-                >
-                  {deleteMutation.isPending ? (
-                    <CircularProgress size={16} />
-                  ) : (
-                    <DeleteIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </Tooltip>
-            )}
-          </Box>
-        )}
-      </Box>
+      <CrudAutocomplete<TireSize>
+        label="Size"
+        entityLabel="size"
+        options={sizes}
+        value={selectedSize}
+        onChange={(size) => onChange(size?.id ?? '', size?.size ?? '')}
+        getOptionId={(size) => size.id}
+        getOptionLabel={(size) => size.size}
+        loading={isLoading}
+        disabled={disabled}
+        error={error}
+        helperText={helperText}
+        onAdd={canManage ? openAdd : undefined}
+        onEdit={canManage ? openEdit : undefined}
+        onDelete={canDelete ? requestDelete : undefined}
+        pendingDeleteId={pendingDeleteId}
+      />
 
-      {hasAuthToken && (
+      {canManage && (
         <SizeDialog
           open={dialogOpen}
-          onClose={() => setDialogOpen(false)}
-          size={editingSize}
-          onSuccess={() => {
-            // If we just added a new size, auto-select it
-            if (!editingSize) {
-              queryClient.invalidateQueries({ queryKey: ['tire-sizes'] });
+          onClose={closeDialog}
+          size={editingItem}
+          onSuccess={(saved) => {
+            // Select what was just created, and follow a rename through to the
+            // field — it stores the size, so a rename would otherwise blank it.
+            if (!editingItem || editingItem.size === value) {
+              onChange(saved.id, saved.size);
             }
           }}
         />

--- a/apps/webApp/src/app/components/inventory/TireDialog.tsx
+++ b/apps/webApp/src/app/components/inventory/TireDialog.tsx
@@ -227,8 +227,12 @@ export function TireDialog({
   const handleBrandChange = (brandId: string, brandName: string) => {
     handleChange('brand', brandName);
 
-    // Find the brand object to get its image URL
-    const brands = queryClient.getQueryData(['tire-brands']) as any[];
+    // Find the brand object to get its image URL. useCatalogSelect caches
+    // { items, isFallback } under this key.
+    const cached = queryClient.getQueryData(['tire-brands']) as
+      | { items?: any[] }
+      | undefined;
+    const brands = cached?.items;
     if (brands) {
       const selectedBrand = brands.find((b) => b.id === brandId);
       if (selectedBrand?.imageUrl) {

--- a/apps/webApp/src/app/components/services/ServiceSelect.tsx
+++ b/apps/webApp/src/app/components/services/ServiceSelect.tsx
@@ -1,37 +1,24 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  IconButton,
-  Tooltip,
-  CircularProgress,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  Typography,
-  Autocomplete,
-  TextField,
-} from '@mui/material';
-import {
-  Add as AddIcon,
-  Edit as EditIcon,
-  Delete as DeleteIcon,
-  Warning as WarningIcon,
-} from '@mui/icons-material';
+import { Box, Typography } from '@mui/material';
 import { ServiceDto } from '@gt-automotive/data';
 import { serviceService } from '../../requests/service.requests';
 import ServiceDialog from './ServiceDialog';
 import { useError } from '../../contexts/ErrorContext';
+import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
+import { CrudAutocomplete } from '../common/CrudAutocomplete';
 
 interface ServiceSelectProps {
   services: ServiceDto[];
+  /** Selected service id. */
   value?: string;
   onChange: (serviceId: string, serviceName: string, unitPrice: number) => void;
   onServicesChange: () => void;
   disabled?: boolean;
   size?: 'small' | 'medium';
 }
+
+const priceOf = (service: ServiceDto) =>
+  parseFloat(service.unitPrice.toString()) || 0;
 
 export const ServiceSelect: React.FC<ServiceSelectProps> = ({
   services,
@@ -42,164 +29,120 @@ export const ServiceSelect: React.FC<ServiceSelectProps> = ({
   size = 'medium',
 }) => {
   const { showError } = useError();
+  const { confirmDelete } = useConfirmationHelpers();
   const [serviceDialogOpen, setServiceDialogOpen] = useState(false);
   const [editingService, setEditingService] = useState<ServiceDto | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [serviceToDelete, setServiceToDelete] = useState<ServiceDto | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
-  const selectedService = services.find(s => s.id === value);
-
-  const handleServiceSelect = (serviceId: string) => {
-    const service = services.find(s => s.id === serviceId);
-    if (service) {
-      onChange(service.id, service.name, parseFloat(service.unitPrice.toString()));
-    }
-  };
+  const selectedService = services.find((s) => s.id === value) || null;
 
   const handleAddNew = () => {
     setEditingService(null);
     setServiceDialogOpen(true);
   };
 
-  const handleEdit = () => {
-    if (selectedService) {
-      setEditingService(selectedService);
-      setServiceDialogOpen(true);
-    }
+  const handleEdit = (service: ServiceDto) => {
+    setEditingService(service);
+    setServiceDialogOpen(true);
   };
 
-  const handleDeleteClick = () => {
-    if (selectedService) {
-      setServiceToDelete(selectedService);
-      setDeleteDialogOpen(true);
-    }
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!serviceToDelete) return;
+  const handleDelete = async (service: ServiceDto) => {
+    const confirmed = await confirmDelete(`the service "${service.name}"`);
+    if (!confirmed) return;
 
     try {
-      setDeleting(true);
-      await serviceService.delete(serviceToDelete.id);
-      // Clear selection if deleted service was selected
-      onChange('', '', 0);
-      await onServicesChange();
-      setDeleteDialogOpen(false);
-      setServiceToDelete(null);
-    } catch (error) {
-      showError('Failed to delete service');
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const handleCancelDelete = () => {
-    setDeleteDialogOpen(false);
-    setServiceToDelete(null);
-  };
-
-  const handleServiceSave = async (serviceData: { name: string; description?: string; unitPrice: number }) => {
-    try {
-      if (editingService) {
-        // Update existing service
-        await serviceService.update(editingService.id, serviceData);
-      } else {
-        // Create new service
-        await serviceService.create(serviceData);
+      setPendingDeleteId(service.id);
+      await serviceService.delete(service.id);
+      // Only drop the line's selection if it was this service.
+      if (service.id === value) {
+        onChange('', '', 0);
       }
       await onServicesChange();
+    } catch (error: any) {
+      showError({
+        title: 'Could not delete service',
+        message:
+          error?.response?.data?.message ||
+          'Something went wrong deleting this service. Please try again.',
+      });
+    } finally {
+      setPendingDeleteId(null);
+    }
+  };
+
+  const handleServiceSave = async (serviceData: {
+    name: string;
+    description?: string;
+    unitPrice: number;
+  }) => {
+    try {
+      if (editingService) {
+        const updated = await serviceService.update(
+          editingService.id,
+          serviceData
+        );
+        await onServicesChange();
+        // Keep the line in step with a rename or a price change.
+        if (editingService.id === value) {
+          onChange(updated.id, updated.name, priceOf(updated));
+        }
+      } else {
+        const created = await serviceService.create(serviceData);
+        await onServicesChange();
+        onChange(created.id, created.name, priceOf(created));
+      }
       setServiceDialogOpen(false);
       setEditingService(null);
-    } catch (error) {
-      showError(editingService ? 'Failed to update service' : 'Failed to create service');
-      console.error('Service save error:', error);
+    } catch (error: any) {
+      showError({
+        title: editingService
+          ? 'Could not update service'
+          : 'Could not create service',
+        message:
+          error?.response?.data?.message ||
+          'Something went wrong saving this service. Please try again.',
+      });
     }
   };
 
   return (
     <>
-      <Box sx={{ position: 'relative' }}>
-        <Autocomplete
-          options={services}
-          value={selectedService || null}
-          onChange={(event, newValue) => {
-            if (newValue) {
-              handleServiceSelect(newValue.id);
-            }
-          }}
-          getOptionLabel={(service) => service.name}
-          renderOption={(props, service) => {
-            const { key, ...otherProps } = props;
-            return (
-              <Box component="li" key={key} {...otherProps}>
-                {service.name}
-              </Box>
-            );
-          }}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Select Service"
-              placeholder="Type to search..."
-              size={size}
-            />
-          )}
-          size={size}
-          fullWidth
-          disabled={disabled}
-        />
-
-        <Box sx={{
-          position: 'absolute',
-          right: 40,
-          top: '50%',
-          transform: 'translateY(-50%)',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 0.5,
-          zIndex: 1,
-        }}>
-          <Tooltip title="Add new service">
-            <IconButton
-              size="small"
-              onClick={handleAddNew}
-              disabled={disabled}
-              sx={{ p: 0.5 }}
-            >
-              <AddIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-          {selectedService && (
-            <>
-              <Tooltip title="Edit service">
-                <IconButton
-                  size="small"
-                  onClick={handleEdit}
-                  disabled={disabled}
-                  sx={{ p: 0.5 }}
-                >
-                  <EditIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="Delete service">
-                <IconButton
-                  size="small"
-                  onClick={handleDeleteClick}
-                  disabled={disabled || deleting}
-                  sx={{ p: 0.5 }}
-                >
-                  {deleting ? (
-                    <CircularProgress size={16} />
-                  ) : (
-                    <DeleteIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </Tooltip>
-            </>
-          )}
-        </Box>
-      </Box>
+      <CrudAutocomplete<ServiceDto>
+        label="Select Service"
+        entityLabel="service"
+        placeholder="Type to search..."
+        options={services}
+        value={selectedService}
+        onChange={(service) =>
+          service
+            ? onChange(service.id, service.name, priceOf(service))
+            : onChange('', '', 0)
+        }
+        getOptionId={(service) => service.id}
+        getOptionLabel={(service) => service.name}
+        getOptionSearchText={(service) => service.description || ''}
+        renderOptionContent={(service) => (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'baseline',
+              justifyContent: 'space-between',
+              gap: 1,
+            }}
+          >
+            <span>{service.name}</span>
+            <Typography variant="caption" color="text.secondary">
+              ${priceOf(service).toFixed(2)}
+            </Typography>
+          </Box>
+        )}
+        size={size}
+        disabled={disabled}
+        onAdd={handleAddNew}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        pendingDeleteId={pendingDeleteId}
+      />
 
       <ServiceDialog
         open={serviceDialogOpen}
@@ -210,41 +153,6 @@ export const ServiceSelect: React.FC<ServiceSelectProps> = ({
         onSave={handleServiceSave}
         service={editingService}
       />
-
-      {/* Delete Confirmation Dialog */}
-      <Dialog
-        open={deleteDialogOpen}
-        onClose={handleCancelDelete}
-        maxWidth="xs"
-        fullWidth
-      >
-        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <WarningIcon color="error" />
-          Delete Service
-        </DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to delete <strong>"{serviceToDelete?.name}"</strong>?
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-            This action cannot be undone.
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCancelDelete} disabled={deleting}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleConfirmDelete}
-            color="error"
-            variant="contained"
-            disabled={deleting}
-            startIcon={deleting ? <CircularProgress size={16} /> : <DeleteIcon />}
-          >
-            {deleting ? 'Deleting...' : 'Delete'}
-          </Button>
-        </DialogActions>
-      </Dialog>
     </>
   );
 };

--- a/apps/webApp/src/app/hooks/useCatalogSelect.spec.tsx
+++ b/apps/webApp/src/app/hooks/useCatalogSelect.spec.tsx
@@ -1,0 +1,152 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useCatalogSelect } from './useCatalogSelect';
+
+const mockShowError = jest.fn();
+const mockConfirmDelete = jest.fn();
+const mockAuthState = {
+  isAdmin: true,
+  isForeman: false,
+  isSupervisor: false,
+  isStaff: false,
+};
+
+jest.mock('./useAuth', () => ({ useAuth: () => mockAuthState }));
+jest.mock('../contexts/ErrorContext', () => ({
+  useError: () => ({ showError: mockShowError }),
+}));
+jest.mock('../contexts/ConfirmationContext', () => ({
+  useConfirmationHelpers: () => ({ confirmDelete: mockConfirmDelete }),
+}));
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+const setup = (fetchAll: () => Promise<Item[]>, remove = jest.fn()) =>
+  renderHook(
+    () =>
+      useCatalogSelect<Item>({
+        queryKey: ['catalog-test'],
+        entityLabel: 'location',
+        fetchAll,
+        fetchNames: async () => ['Wherehouse'],
+        toFallbackItem: (name) => ({ id: name, name }),
+        remove,
+        getId: (item) => item.id,
+        getLabel: (item) => item.name,
+      }),
+    { wrapper }
+  );
+
+const unauthorized = () =>
+  Object.assign(new Error('Unauthorized'), { response: { status: 401 } });
+
+describe('useCatalogSelect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(mockAuthState, {
+      isAdmin: true,
+      isForeman: false,
+      isSupervisor: false,
+      isStaff: false,
+    });
+  });
+
+  it('allows managing the catalog when the authenticated list loads', async () => {
+    const { result } = setup(async () => [
+      { id: 'cl9q7x2m80003xyz', name: 'Wherehouse' },
+    ]);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.items).toEqual([
+      { id: 'cl9q7x2m80003xyz', name: 'Wherehouse' },
+    ]);
+    expect(result.current.canManage).toBe(true);
+    expect(result.current.canDelete).toBe(true);
+  });
+
+  it('disables management when the list falls back to names-only', async () => {
+    // The fallback rebuilds records from names, so their "id" is really a name.
+    // Letting those through produced PUT/DELETE /tires/locations/Wherehouse.
+    const { result } = setup(async () => {
+      throw unauthorized();
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.items).toEqual([
+      { id: 'Wherehouse', name: 'Wherehouse' },
+    ]);
+    expect(result.current.canManage).toBe(false);
+    expect(result.current.canDelete).toBe(false);
+  });
+
+  it('hides delete from STAFF, matching the API role guard', async () => {
+    Object.assign(mockAuthState, { isAdmin: false, isStaff: true });
+    const { result } = setup(async () => [{ id: 'id-1', name: 'Wherehouse' }]);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.canManage).toBe(true);
+    expect(result.current.canDelete).toBe(false);
+  });
+
+  it('deletes with the real id and skips the call when unconfirmed', async () => {
+    const remove = jest.fn().mockResolvedValue(undefined);
+    const { result } = setup(
+      async () => [{ id: 'cl9q7x2m80003xyz', name: 'Wherehouse' }],
+      remove
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockConfirmDelete.mockResolvedValueOnce(false);
+    await act(async () => {
+      await result.current.requestDelete(result.current.items[0]);
+    });
+    expect(remove).not.toHaveBeenCalled();
+
+    mockConfirmDelete.mockResolvedValueOnce(true);
+    await act(async () => {
+      await result.current.requestDelete(result.current.items[0]);
+    });
+    await waitFor(() =>
+      expect(remove).toHaveBeenCalledWith('cl9q7x2m80003xyz')
+    );
+  });
+
+  it('surfaces the API message when a delete is rejected', async () => {
+    const remove = jest.fn().mockRejectedValue({
+      response: {
+        data: {
+          message:
+            'Cannot delete location - it is being used by existing tires',
+        },
+      },
+    });
+    const { result } = setup(
+      async () => [{ id: 'id-1', name: 'Wherehouse' }],
+      remove
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    mockConfirmDelete.mockResolvedValueOnce(true);
+    await act(async () => {
+      await result.current.requestDelete(result.current.items[0]);
+    });
+
+    await waitFor(() =>
+      expect(mockShowError).toHaveBeenCalledWith({
+        title: 'Could not delete location',
+        message: 'Cannot delete location - it is being used by existing tires',
+      })
+    );
+  });
+});

--- a/apps/webApp/src/app/hooks/useCatalogSelect.ts
+++ b/apps/webApp/src/app/hooks/useCatalogSelect.ts
@@ -1,0 +1,144 @@
+import { useCallback, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from './useAuth';
+import { useConfirmationHelpers } from '../contexts/ConfirmationContext';
+import { useError } from '../contexts/ErrorContext';
+
+interface UseCatalogSelectOptions<T> {
+  /** React Query cache key, e.g. ['tire-brands']. */
+  queryKey: string[];
+  /** Authenticated fetch returning full records (needed for edit/delete). */
+  fetchAll: () => Promise<T[]>;
+  /** Public fetch returning names only, used when the user can't see the full list. */
+  fetchNames: () => Promise<string[]>;
+  /** Builds a read-only stand-in record from a name for the public fallback. */
+  toFallbackItem: (name: string) => T;
+  remove: (id: string) => Promise<unknown>;
+  getId: (item: T) => string;
+  getLabel: (item: T) => string;
+  /** Singular, lowercase, e.g. "brand" — used in confirm/error copy. */
+  entityLabel: string;
+  /** Called after a successful delete so the caller can clear a stale selection. */
+  onDeleted?: (item: T) => void;
+}
+
+/**
+ * Shared wiring for the small managed catalogs behind CrudAutocomplete (tire
+ * brands, sizes, locations). Owns the list query, the delete flow and the
+ * add/edit dialog state so each *Select component is just markup.
+ *
+ * Permissions mirror the API guards on server/src/tires/tires.controller.ts:
+ * create/update allow ADMIN, FOREMAN, SUPERVISOR and STAFF; delete excludes
+ * STAFF. Gating here keeps STAFF from clicking a button that can only 403.
+ */
+export function useCatalogSelect<T>({
+  queryKey,
+  fetchAll,
+  fetchNames,
+  toFallbackItem,
+  remove,
+  getId,
+  getLabel,
+  entityLabel,
+  onDeleted,
+}: UseCatalogSelectOptions<T>) {
+  const queryClient = useQueryClient();
+  const { confirmDelete } = useConfirmationHelpers();
+  const { showError } = useError();
+  const { isAdmin, isForeman, isSupervisor, isStaff } = useAuth();
+
+  const hasManageRole = isAdmin || isForeman || isSupervisor || isStaff;
+  const hasDeleteRole = isAdmin || isForeman || isSupervisor;
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<T | null>(null);
+  const [deletingItem, setDeletingItem] = useState<T | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<{ items: T[]; isFallback: boolean }> => {
+      try {
+        return { items: await fetchAll(), isFallback: false };
+      } catch (error: any) {
+        // Callers without list access still need to *read* the names to fill
+        // the field, so fall back to the public names-only endpoint.
+        if (
+          error?.response?.status === 401 ||
+          error?.response?.status === 403
+        ) {
+          const names = await fetchNames();
+          return { items: names.map(toFallbackItem), isFallback: true };
+        }
+        throw error;
+      }
+    },
+  });
+
+  const items = data?.items ?? [];
+  // Fallback records are reconstructed from names and have no real id, so they
+  // must never reach an update/delete URL — that produced
+  // `PUT /api/tires/locations/Wherehouse` and a "not found" from the API.
+  // If we couldn't read the real list, we can't manage it either.
+  const isFallback = data?.isFallback ?? false;
+
+  const deleteMutation = useMutation({
+    mutationFn: (item: T) => remove(getId(item)),
+    onSettled: () => setDeletingItem(null),
+    onSuccess: (_data, item) => {
+      queryClient.invalidateQueries({ queryKey });
+      onDeleted?.(item);
+    },
+    onError: (error: any) => {
+      // The API returns 409 when the row is still referenced by tires. That is
+      // the common case and deserves a plain explanation, not a stack trace.
+      const apiMessage = error?.response?.data?.message;
+      showError({
+        title: `Could not delete ${entityLabel}`,
+        message:
+          apiMessage ||
+          `Something went wrong deleting this ${entityLabel}. Please try again.`,
+      });
+    },
+  });
+
+  const openAdd = useCallback(() => {
+    setEditingItem(null);
+    setDialogOpen(true);
+  }, []);
+
+  const openEdit = useCallback((item: T) => {
+    setEditingItem(item);
+    setDialogOpen(true);
+  }, []);
+
+  const closeDialog = useCallback(() => {
+    setDialogOpen(false);
+    setEditingItem(null);
+  }, []);
+
+  const requestDelete = useCallback(
+    async (item: T) => {
+      const confirmed = await confirmDelete(
+        `the ${entityLabel} "${getLabel(item)}"`
+      );
+      if (!confirmed) return;
+      setDeletingItem(item);
+      deleteMutation.mutate(item);
+    },
+    [confirmDelete, deleteMutation, entityLabel, getLabel]
+  );
+
+  return {
+    items,
+    isLoading,
+    canManage: hasManageRole && !isFallback,
+    canDelete: hasDeleteRole && !isFallback,
+    dialogOpen,
+    editingItem,
+    openAdd,
+    openEdit,
+    closeDialog,
+    requestDelete,
+    pendingDeleteId: deletingItem ? getId(deletingItem) : null,
+  };
+}

--- a/apps/webApp/src/app/pages/admin/DaySummary.tsx
+++ b/apps/webApp/src/app/pages/admin/DaySummary.tsx
@@ -54,13 +54,14 @@ import { paymentService } from '../../requests/payment.requests';
 import { invoiceService } from '../../requests/invoice.requests';
 import { PaymentResponseDto } from '@gt-automotive/data';
 import { PaymentDialog } from '../../components/appointments/PaymentDialog';
+import {
+  buildPaymentLineItems,
+  isCashMethod,
+  type PaymentLineItem,
+} from '../../utils/paymentStatsUtils';
 
 // @ts-ignore
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-
-// All cash variants (CASH, CASH_NO_TAX, cash-with-tax, etc.) are physical cash —
-// treat them as one for the day summary breakdown.
-const isCashMethod = (method: string) => method.toUpperCase().includes('CASH');
 
 /** Collapse every cash-like method into a single 'CASH' bucket. */
 const combineCashMethods = (
@@ -75,6 +76,107 @@ const combineCashMethods = (
   if (cash > 0) result['CASH'] = cash;
   return result;
 };
+
+// The DB enum is CHECK; older records and some UI used CHEQUE. Map both so a
+// cheque payment never renders with a blank label.
+const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  CASH: '💵 Cash',
+  E_TRANSFER: '📱 E-Transfer',
+  CREDIT_CARD: '💳 Credit',
+  DEBIT_CARD: '💳 Debit',
+  CHECK: '📝 Cheque',
+  CHEQUE: '📝 Cheque',
+  FINANCING: '🏦 Financing',
+  BANK_DEPOSIT: '🏦 Bank Deposit',
+};
+
+const methodLabel = (method: string) =>
+  PAYMENT_METHOD_LABELS[method] || method.replace(/_/g, ' ');
+
+/**
+ * A payment method's total with the individual payments that make it up.
+ *
+ * The line items come from the same two sources the totals do — money recorded
+ * on the appointment and invoice payments collected today — so they add up to
+ * the method total shown above them.
+ */
+function MethodBreakdownList({
+  byMethod,
+  itemsByMethod,
+}: {
+  byMethod: Record<string, number>;
+  itemsByMethod: Record<string, PaymentLineItem[]>;
+}) {
+  return (
+    <Stack spacing={1.5}>
+      {Object.entries(byMethod).map(([method, amount]) => {
+        const items = itemsByMethod[method] || [];
+        return (
+          <Box key={method}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'baseline',
+                justifyContent: 'space-between',
+                gap: 1,
+              }}
+            >
+              <Typography variant="body2" color="text.secondary">
+                {methodLabel(method)}
+              </Typography>
+              <Typography variant="h6" fontWeight="bold">
+                ${amount.toFixed(2)}
+              </Typography>
+            </Box>
+
+            {items.length > 0 && (
+              <Stack
+                spacing={0.25}
+                sx={{ mt: 0.5, pl: 1.5, borderLeft: 2, borderColor: 'divider' }}
+              >
+                {items.map((item) => (
+                  <Box
+                    key={item.key}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'baseline',
+                      justifyContent: 'space-between',
+                      gap: 1,
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {item.invoiceNumber ? (
+                        <>
+                          {item.invoiceNumber}
+                          {item.customerName && ` · ${item.customerName}`}
+                        </>
+                      ) : (
+                        // Appointment money with no invoice raised — the
+                        // customer is the only thing to identify it by.
+                        <em>{item.customerName || 'No invoice'}</em>
+                      )}
+                    </Typography>
+                    <Typography variant="caption" fontWeight="medium">
+                      ${item.amount.toFixed(2)}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+            )}
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}
 
 export function DaySummary() {
   const { getToken } = useAuth(); // Still needed for EOD email endpoint
@@ -185,6 +287,17 @@ export function DaySummary() {
       (apt) => apt.appointmentType === 'MOBILE_SERVICE'
     );
   }, [sortedPayments]);
+
+  // Individual payments behind each method total, split by location.
+  const lineItemsByLocation = useMemo(
+    () =>
+      buildPaymentLineItems(
+        atGaragePayments as any,
+        mobileServicePayments as any,
+        invoiceDay?.payments || []
+      ),
+    [atGaragePayments, mobileServicePayments, invoiceDay]
+  );
 
   // Calculate statistics
   const stats = useMemo(() => {
@@ -1045,7 +1158,7 @@ export function DaySummary() {
                   Total payments collected
                 </Typography>
 
-                {/* Payment Method Breakdown */}
+                {/* Payment methods, each with the payments behind it */}
                 {Object.keys(stats.atGaragePaymentsByMethod).length > 0 && (
                   <Box
                     sx={{ mt: 2, pt: 2, borderTop: 1, borderColor: 'divider' }}
@@ -1059,29 +1172,10 @@ export function DaySummary() {
                     >
                       Payment Methods:
                     </Typography>
-                    <Grid container spacing={2}>
-                      {Object.entries(stats.atGaragePaymentsByMethod).map(
-                        ([method, amount]) => (
-                          <Grid size={{ xs: 6, sm: 4 }} key={method}>
-                            <Box>
-                              <Typography
-                                variant="body2"
-                                color="text.secondary"
-                              >
-                                {method === 'CASH' && '💵 Cash'}
-                                {method === 'E_TRANSFER' && '📱 E-Transfer'}
-                                {method === 'CREDIT_CARD' && '💳 Credit'}
-                                {method === 'DEBIT_CARD' && '💳 Debit'}
-                                {method === 'CHEQUE' && '📝 Cheque'}
-                              </Typography>
-                              <Typography variant="h6" fontWeight="bold">
-                                ${amount.toFixed(2)}
-                              </Typography>
-                            </Box>
-                          </Grid>
-                        )
-                      )}
-                    </Grid>
+                    <MethodBreakdownList
+                      byMethod={stats.atGaragePaymentsByMethod}
+                      itemsByMethod={lineItemsByLocation.atGarage}
+                    />
                   </Box>
                 )}
               </Paper>
@@ -1152,7 +1246,7 @@ export function DaySummary() {
                   Total payments collected
                 </Typography>
 
-                {/* Payment Method Breakdown */}
+                {/* Payment methods, each with the payments behind it */}
                 {Object.keys(stats.mobileServicePaymentsByMethod).length >
                   0 && (
                   <Box
@@ -1167,29 +1261,10 @@ export function DaySummary() {
                     >
                       Payment Methods:
                     </Typography>
-                    <Grid container spacing={2}>
-                      {Object.entries(stats.mobileServicePaymentsByMethod).map(
-                        ([method, amount]) => (
-                          <Grid size={{ xs: 6, sm: 4 }} key={method}>
-                            <Box>
-                              <Typography
-                                variant="body2"
-                                color="text.secondary"
-                              >
-                                {method === 'CASH' && '💵 Cash'}
-                                {method === 'E_TRANSFER' && '📱 E-Transfer'}
-                                {method === 'CREDIT_CARD' && '💳 Credit'}
-                                {method === 'DEBIT_CARD' && '💳 Debit'}
-                                {method === 'CHEQUE' && '📝 Cheque'}
-                              </Typography>
-                              <Typography variant="h6" fontWeight="bold">
-                                ${amount.toFixed(2)}
-                              </Typography>
-                            </Box>
-                          </Grid>
-                        )
-                      )}
-                    </Grid>
+                    <MethodBreakdownList
+                      byMethod={stats.mobileServicePaymentsByMethod}
+                      itemsByMethod={lineItemsByLocation.mobileService}
+                    />
                   </Box>
                 )}
               </Paper>

--- a/apps/webApp/src/app/requests/catalog-api-client.ts
+++ b/apps/webApp/src/app/requests/catalog-api-client.ts
@@ -1,0 +1,61 @@
+import axios from 'axios';
+
+// @ts-ignore
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+/**
+ * Axios client shared by the tire catalog request modules (brands, sizes,
+ * locations).
+ *
+ * The token handling deliberately matches tire.requests.ts: ask Clerk for a
+ * token on every request and treat localStorage only as a last resort. Clerk
+ * hands back a cached token and refreshes it when it is close to expiring.
+ *
+ * The catalog modules used to do the opposite — trust localStorage first and
+ * only call Clerk when nothing was stored. Clerk session tokens are short
+ * lived (60s), so a stored token was routinely expired, the request 401'd, and
+ * the list silently degraded to the names-only public endpoint. Those
+ * name-shaped records then flowed into edit/delete as if they were ids.
+ */
+export const catalogApiClient = axios.create({
+  baseURL: `${API_URL}/api`,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+catalogApiClient.interceptors.request.use(
+  async (config) => {
+    try {
+      if (window.Clerk?.session) {
+        const token = await window.Clerk.session.getToken({});
+        if (token) {
+          localStorage.setItem('authToken', token);
+          config.headers.Authorization = `Bearer ${token}`;
+          return config;
+        }
+      }
+
+      const stored = localStorage.getItem('authToken');
+      if (stored) {
+        config.headers.Authorization = `Bearer ${stored}`;
+      }
+    } catch (error) {
+      console.error('Failed to get auth token:', error);
+    }
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+catalogApiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      // Drop the stale copy; the next request pulls a fresh one from Clerk.
+      localStorage.removeItem('authToken');
+    }
+    return Promise.reject(error);
+  }
+);

--- a/apps/webApp/src/app/requests/location.requests.ts
+++ b/apps/webApp/src/app/requests/location.requests.ts
@@ -1,58 +1,5 @@
-import axios, { AxiosResponse } from 'axios';
-
-
-// @ts-ignore
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-
-// Create axios instance with common configuration
-const apiClient = axios.create({
-  baseURL: `${API_URL}/api`,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-// Add token interceptor for authentication
-apiClient.interceptors.request.use(
-  async (config) => {
-    let token = localStorage.getItem('authToken');
-
-    // If no token in localStorage, try to get it from Clerk
-    if (!token) {
-      try {
-        // Check if Clerk is available
-        if (window.Clerk && window.Clerk.session) {
-          token = await window.Clerk.session.getToken();
-          if (token) {
-            localStorage.setItem('authToken', token);
-          }
-        }
-      } catch (error) {
-        // Silently handle token retrieval errors
-      }
-    }
-
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-// Response interceptor for error handling
-apiClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      // Handle unauthorized - clear token but don't redirect automatically
-      localStorage.removeItem('authToken');
-    }
-    return Promise.reject(error);
-  }
-);
+import { AxiosResponse } from 'axios';
+import { catalogApiClient as apiClient } from './catalog-api-client';
 
 export interface Location {
   id: string;
@@ -73,27 +20,38 @@ export class LocationService {
   private static readonly BASE_URL = '/tires/locations';
 
   static async getAll(): Promise<Location[]> {
-    const response: AxiosResponse<Location[]> = await apiClient.get(`${this.BASE_URL}/all`);
+    const response: AxiosResponse<Location[]> = await apiClient.get(
+      `${this.BASE_URL}/all`
+    );
     return response.data;
   }
 
   static async getLocations(): Promise<string[]> {
-    const response: AxiosResponse<string[]> = await apiClient.get(`${this.BASE_URL}`);
+    const response: AxiosResponse<string[]> = await apiClient.get(
+      `${this.BASE_URL}`
+    );
     return response.data;
   }
 
   static async create(data: CreateLocationDto): Promise<Location> {
-    const response: AxiosResponse<Location> = await apiClient.post(this.BASE_URL, data);
+    const response: AxiosResponse<Location> = await apiClient.post(
+      this.BASE_URL,
+      data
+    );
     return response.data;
   }
 
   static async update(id: string, data: UpdateLocationDto): Promise<Location> {
-    const response: AxiosResponse<Location> = await apiClient.put(`${this.BASE_URL}/${id}`, data);
+    const response: AxiosResponse<Location> = await apiClient.put(
+      `${this.BASE_URL}/${id}`,
+      data
+    );
     return response.data;
   }
 
   static async delete(id: string): Promise<{ success: boolean }> {
-    const response: AxiosResponse<{ success: boolean }> = await apiClient.delete(`${this.BASE_URL}/${id}`);
+    const response: AxiosResponse<{ success: boolean }> =
+      await apiClient.delete(`${this.BASE_URL}/${id}`);
     return response.data;
   }
 }

--- a/apps/webApp/src/app/requests/tire-brand.requests.ts
+++ b/apps/webApp/src/app/requests/tire-brand.requests.ts
@@ -1,58 +1,5 @@
-import axios, { AxiosResponse } from 'axios';
-
-
-// @ts-ignore
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-
-// Create axios instance with common configuration
-const apiClient = axios.create({
-  baseURL: `${API_URL}/api`,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-// Add token interceptor for authentication
-apiClient.interceptors.request.use(
-  async (config) => {
-    let token = localStorage.getItem('authToken');
-
-    // If no token in localStorage, try to get it from Clerk
-    if (!token) {
-      try {
-        // Check if Clerk is available
-        if (window.Clerk && window.Clerk.session) {
-          token = await window.Clerk.session.getToken();
-          if (token) {
-            localStorage.setItem('authToken', token);
-          }
-        }
-      } catch (error) {
-        // Silently handle token retrieval errors
-      }
-    }
-
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-// Response interceptor for error handling
-apiClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      // Handle unauthorized - clear token but don't redirect automatically
-      localStorage.removeItem('authToken');
-    }
-    return Promise.reject(error);
-  }
-);
+import { AxiosResponse } from 'axios';
+import { catalogApiClient as apiClient } from './catalog-api-client';
 
 export interface TireBrand {
   id: string;
@@ -76,27 +23,41 @@ export class TireBrandService {
   private static readonly BASE_URL = '/tires/brands';
 
   static async getAll(): Promise<TireBrand[]> {
-    const response: AxiosResponse<TireBrand[]> = await apiClient.get(`${this.BASE_URL}/all`);
+    const response: AxiosResponse<TireBrand[]> = await apiClient.get(
+      `${this.BASE_URL}/all`
+    );
     return response.data;
   }
 
   static async getBrands(): Promise<string[]> {
-    const response: AxiosResponse<string[]> = await apiClient.get(`${this.BASE_URL}`);
+    const response: AxiosResponse<string[]> = await apiClient.get(
+      `${this.BASE_URL}`
+    );
     return response.data;
   }
 
   static async create(data: CreateTireBrandDto): Promise<TireBrand> {
-    const response: AxiosResponse<TireBrand> = await apiClient.post(this.BASE_URL, data);
+    const response: AxiosResponse<TireBrand> = await apiClient.post(
+      this.BASE_URL,
+      data
+    );
     return response.data;
   }
 
-  static async update(id: string, data: UpdateTireBrandDto): Promise<TireBrand> {
-    const response: AxiosResponse<TireBrand> = await apiClient.put(`${this.BASE_URL}/${id}`, data);
+  static async update(
+    id: string,
+    data: UpdateTireBrandDto
+  ): Promise<TireBrand> {
+    const response: AxiosResponse<TireBrand> = await apiClient.put(
+      `${this.BASE_URL}/${id}`,
+      data
+    );
     return response.data;
   }
 
   static async delete(id: string): Promise<{ success: boolean }> {
-    const response: AxiosResponse<{ success: boolean }> = await apiClient.delete(`${this.BASE_URL}/${id}`);
+    const response: AxiosResponse<{ success: boolean }> =
+      await apiClient.delete(`${this.BASE_URL}/${id}`);
     return response.data;
   }
 }

--- a/apps/webApp/src/app/requests/tire-size.requests.ts
+++ b/apps/webApp/src/app/requests/tire-size.requests.ts
@@ -1,58 +1,5 @@
-import axios, { AxiosResponse } from 'axios';
-
-
-// @ts-ignore
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-
-// Create axios instance with common configuration
-const apiClient = axios.create({
-  baseURL: `${API_URL}/api`,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
-// Add token interceptor for authentication
-apiClient.interceptors.request.use(
-  async (config) => {
-    let token = localStorage.getItem('authToken');
-
-    // If no token in localStorage, try to get it from Clerk
-    if (!token) {
-      try {
-        // Check if Clerk is available
-        if (window.Clerk && window.Clerk.session) {
-          token = await window.Clerk.session.getToken();
-          if (token) {
-            localStorage.setItem('authToken', token);
-          }
-        }
-      } catch (error) {
-        // Silently handle token retrieval errors
-      }
-    }
-
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
-// Response interceptor for error handling
-apiClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      // Handle unauthorized - clear token but don't redirect automatically
-      localStorage.removeItem('authToken');
-    }
-    return Promise.reject(error);
-  }
-);
+import { AxiosResponse } from 'axios';
+import { catalogApiClient as apiClient } from './catalog-api-client';
 
 export interface TireSize {
   id: string;
@@ -73,27 +20,38 @@ export class TireSizeService {
   private static readonly BASE_URL = '/tires/sizes';
 
   static async getAll(): Promise<TireSize[]> {
-    const response: AxiosResponse<TireSize[]> = await apiClient.get(`${this.BASE_URL}/all`);
+    const response: AxiosResponse<TireSize[]> = await apiClient.get(
+      `${this.BASE_URL}/all`
+    );
     return response.data;
   }
 
   static async getSizes(): Promise<string[]> {
-    const response: AxiosResponse<string[]> = await apiClient.get(`${this.BASE_URL}`);
+    const response: AxiosResponse<string[]> = await apiClient.get(
+      `${this.BASE_URL}`
+    );
     return response.data;
   }
 
   static async create(data: CreateTireSizeDto): Promise<TireSize> {
-    const response: AxiosResponse<TireSize> = await apiClient.post(this.BASE_URL, data);
+    const response: AxiosResponse<TireSize> = await apiClient.post(
+      this.BASE_URL,
+      data
+    );
     return response.data;
   }
 
   static async update(id: string, data: UpdateTireSizeDto): Promise<TireSize> {
-    const response: AxiosResponse<TireSize> = await apiClient.put(`${this.BASE_URL}/${id}`, data);
+    const response: AxiosResponse<TireSize> = await apiClient.put(
+      `${this.BASE_URL}/${id}`,
+      data
+    );
     return response.data;
   }
 
   static async delete(id: string): Promise<{ success: boolean }> {
-    const response: AxiosResponse<{ success: boolean }> = await apiClient.delete(`${this.BASE_URL}/${id}`);
+    const response: AxiosResponse<{ success: boolean }> =
+      await apiClient.delete(`${this.BASE_URL}/${id}`);
     return response.data;
   }
 }

--- a/apps/webApp/src/app/utils/paymentStatsUtils.spec.ts
+++ b/apps/webApp/src/app/utils/paymentStatsUtils.spec.ts
@@ -2,6 +2,8 @@ import {
   parsePaymentBreakdown,
   calculatePaymentsByMethod,
   calculatePaymentStats,
+  buildPaymentLineItems,
+  isCashMethod,
 } from './paymentStatsUtils';
 
 // Minimal appointment factory matching the internal Appointment shape used by the util.
@@ -187,5 +189,162 @@ describe('paymentStatsUtils', () => {
       expect(stats.totalExpected).toBe(40);
       expect(stats.totalOwed).toBe(0); // no expectedAmount -> expected treated as 0
     });
+  });
+});
+
+describe('buildPaymentLineItems', () => {
+  const combineCashMethods = (map: Record<string, number>) => {
+    const result: Record<string, number> = {};
+    let cash = 0;
+    for (const [method, amount] of Object.entries(map)) {
+      if (isCashMethod(method)) cash += amount;
+      else result[method] = amount;
+    }
+    if (cash > 0) result['CASH'] = cash;
+    return result;
+  };
+
+  const shopApts = [
+    makeApt({
+      id: 'a1',
+      appointmentType: 'AT_GARAGE',
+      paymentAmount: 150,
+      paymentBreakdown: [
+        { method: 'CASH', amount: 100 },
+        { method: 'E_TRANSFER', amount: 50 },
+      ],
+      customer: { firstName: 'Ann', lastName: 'Lee' },
+      invoice: { id: 'i1', invoiceNumber: 'INV-001', status: 'PAID' },
+    }),
+    // No breakdown, no invoice — falls back to CASH and the customer name.
+    makeApt({
+      id: 'a2',
+      appointmentType: 'AT_GARAGE',
+      paymentAmount: 40,
+      customer: { businessName: 'Ray Haulage' },
+    }),
+  ];
+  const mobileApts = [
+    makeApt({
+      id: 'a3',
+      appointmentType: 'MOBILE_SERVICE',
+      paymentAmount: 200,
+      paymentBreakdown: [{ method: 'CASH_NO_TAX', amount: 200 }],
+      customer: { firstName: 'Cid', lastName: 'Vos' },
+    }),
+  ];
+  const invoicePayments = [
+    {
+      id: 'p1',
+      amount: 75,
+      paymentMethod: 'CREDIT_CARD',
+      invoiceNumber: 'INV-010',
+      customerName: 'Dee Fox',
+      appointmentType: 'AT_GARAGE',
+    },
+    {
+      id: 'p2',
+      amount: 25,
+      paymentMethod: 'CASH',
+      invoiceNumber: 'INV-011',
+      customerName: 'Eli Gray',
+      appointmentType: 'MOBILE_SERVICE',
+    },
+    // No linked appointment — the API counts these as shop.
+    {
+      id: 'p3',
+      amount: 10,
+      paymentMethod: 'CASH',
+      invoiceNumber: 'INV-012',
+      customerName: 'Fay Hill',
+      appointmentType: null,
+    },
+  ];
+
+  it('groups shop payments by method with invoice number and amount', () => {
+    const { atGarage } = buildPaymentLineItems(
+      shopApts,
+      mobileApts,
+      invoicePayments
+    );
+
+    expect(Object.keys(atGarage).sort()).toEqual([
+      'CASH',
+      'CREDIT_CARD',
+      'E_TRANSFER',
+    ]);
+    expect(atGarage['CREDIT_CARD']).toEqual([
+      {
+        key: 'inv-p1',
+        invoiceNumber: 'INV-010',
+        customerName: 'Dee Fox',
+        amount: 75,
+      },
+    ]);
+    // Sorted largest first.
+    expect(atGarage['CASH'].map((i) => i.amount)).toEqual([100, 40, 10]);
+  });
+
+  it('falls back to the customer name when there is no invoice', () => {
+    const { atGarage } = buildPaymentLineItems(shopApts, [], []);
+    const noInvoice = atGarage['CASH'].find((i) => i.key === 'apt-a2');
+    expect(noInvoice).toEqual({
+      key: 'apt-a2',
+      invoiceNumber: null,
+      customerName: 'Ray Haulage',
+      amount: 40,
+    });
+  });
+
+  it('buckets cash variants together, matching the displayed totals', () => {
+    const { mobileService } = buildPaymentLineItems(
+      [],
+      mobileApts,
+      invoicePayments
+    );
+    // CASH_NO_TAX (200) and CASH (25) report under one CASH heading.
+    expect(mobileService['CASH'].map((i) => i.amount)).toEqual([200, 25]);
+  });
+
+  it('line items reconcile to the method totals shown above them', () => {
+    const { atGarage, mobileService } = buildPaymentLineItems(
+      shopApts,
+      mobileApts,
+      invoicePayments
+    );
+
+    // Rebuild the totals exactly as DaySummary does: appointment money by
+    // method, plus the API's per-location invoice totals, then cash-combined.
+    const shopTotals = calculatePaymentsByMethod(shopApts);
+    shopTotals['CREDIT_CARD'] = (shopTotals['CREDIT_CARD'] || 0) + 75;
+    shopTotals['CASH'] = (shopTotals['CASH'] || 0) + 10;
+
+    const mobileTotals = calculatePaymentsByMethod(mobileApts);
+    mobileTotals['CASH'] = (mobileTotals['CASH'] || 0) + 25;
+
+    const sumOf = (items: { amount: number }[]) =>
+      items.reduce((s, i) => s + i.amount, 0);
+
+    Object.entries(combineCashMethods(shopTotals)).forEach(([m, total]) => {
+      expect(sumOf(atGarage[m] || [])).toBeCloseTo(total, 2);
+    });
+    Object.entries(combineCashMethods(mobileTotals)).forEach(([m, total]) => {
+      expect(sumOf(mobileService[m] || [])).toBeCloseTo(total, 2);
+    });
+  });
+
+  it('ignores zero-amount entries', () => {
+    const { atGarage } = buildPaymentLineItems(
+      [
+        makeApt({
+          id: 'z1',
+          paymentAmount: 0,
+          paymentBreakdown: [{ method: 'CASH', amount: 0 }],
+        }),
+      ],
+      [],
+      []
+    );
+    expect(atGarage).toEqual({});
   });
 });

--- a/apps/webApp/src/app/utils/paymentStatsUtils.ts
+++ b/apps/webApp/src/app/utils/paymentStatsUtils.ts
@@ -6,6 +6,11 @@ import { PaymentEntryDto as PaymentEntry } from '@gt-automotive/data';
 
 interface Appointment {
   id: string;
+  customer?: {
+    firstName?: string;
+    lastName?: string;
+    businessName?: string;
+  };
   duration: number;
   status: string;
   serviceType: string;
@@ -56,13 +61,15 @@ export const calculatePaymentsByMethod = (
       // Manual payment with breakdown (multiple payment methods)
       breakdown.forEach((payment: PaymentEntry) => {
         const method = payment.method || 'CASH';
-        paymentsByMethod[method] = (paymentsByMethod[method] || 0) + (payment.amount || 0);
+        paymentsByMethod[method] =
+          (paymentsByMethod[method] || 0) + (payment.amount || 0);
       });
     } else if (apt.paymentAmount) {
       // Check if appointment has an invoice (Square payment creates invoice automatically)
       const invoice = apt.invoice || null;
       const method = invoice?.paymentMethod || 'CASH'; // Use invoice payment method or default to CASH
-      paymentsByMethod[method] = (paymentsByMethod[method] || 0) + apt.paymentAmount;
+      paymentsByMethod[method] =
+        (paymentsByMethod[method] || 0) + apt.paymentAmount;
     }
   });
 
@@ -77,7 +84,10 @@ export const calculatePaymentStats = (
   paymentsProcessed: Appointment[]
 ) => {
   // Scheduled appointments stats
-  const totalDuration = scheduledAppointments.reduce((sum, apt) => sum + apt.duration, 0);
+  const totalDuration = scheduledAppointments.reduce(
+    (sum, apt) => sum + apt.duration,
+    0
+  );
   const statusCounts = scheduledAppointments.reduce((acc, apt) => {
     acc[apt.status] = (acc[apt.status] || 0) + 1;
     return acc;
@@ -92,7 +102,10 @@ export const calculatePaymentStats = (
   );
 
   // Payment statistics - based on payments PROCESSED today
-  const totalPayments = paymentsProcessed.reduce((sum, apt) => sum + (apt.paymentAmount || 0), 0);
+  const totalPayments = paymentsProcessed.reduce(
+    (sum, apt) => sum + (apt.paymentAmount || 0),
+    0
+  );
   const totalExpected = paymentsProcessed.reduce(
     (sum, apt) => sum + (apt.expectedAmount || apt.paymentAmount || 0),
     0
@@ -125,7 +138,9 @@ export const calculatePaymentStats = (
     (sum, apt) => sum + (apt.paymentAmount || 0),
     0
   );
-  const mobileServicePaymentsByMethod = calculatePaymentsByMethod(mobileServicePayments);
+  const mobileServicePaymentsByMethod = calculatePaymentsByMethod(
+    mobileServicePayments
+  );
 
   return {
     // Scheduled appointments info
@@ -151,4 +166,129 @@ export const calculatePaymentStats = (
     completedMobileService: mobileServicePayments.length,
     mobileServicePaymentsByMethod,
   };
+};
+
+// --- Day Summary line items -------------------------------------------------
+
+/**
+ * All cash variants (CASH, CASH_NO_TAX, …) are physical cash — the Day Summary
+ * reports them as one bucket.
+ */
+export const isCashMethod = (method: string) =>
+  method.toUpperCase().includes('CASH');
+
+/** The bucket key a raw payment method is reported under. */
+export const methodBucket = (method: string) =>
+  isCashMethod(method) ? 'CASH' : method;
+
+/** One payment making up a method total, shown beneath it for reconciling. */
+export interface PaymentLineItem {
+  key: string;
+  invoiceNumber: string | null;
+  customerName: string;
+  amount: number;
+}
+
+/** An invoice payment as returned by GET /api/invoices/day-summary. */
+export interface InvoiceDayPayment {
+  id: string;
+  amount: number | string;
+  paymentMethod?: string;
+  invoiceNumber?: string | null;
+  customerName?: string;
+  appointmentType?: string | null;
+}
+
+export interface PaymentLineItemsByLocation {
+  atGarage: Record<string, PaymentLineItem[]>;
+  mobileService: Record<string, PaymentLineItem[]>;
+}
+
+const customerNameOf = (apt: Appointment) =>
+  apt.customer?.businessName ||
+  [apt.customer?.firstName, apt.customer?.lastName].filter(Boolean).join(' ') ||
+  '';
+
+/**
+ * Break each payment-method total down into the individual payments behind it,
+ * split by location.
+ *
+ * Draws on the same two sources the totals do — money recorded against the
+ * appointment, and invoice payments collected today — and buckets methods
+ * identically, so every list sums to the method total displayed above it.
+ * Appointment money raised without an invoice has no invoice number, so those
+ * rows fall back to the customer name.
+ */
+export const buildPaymentLineItems = (
+  atGarageAppointments: Appointment[],
+  mobileServiceAppointments: Appointment[],
+  invoicePayments: InvoiceDayPayment[] = []
+): PaymentLineItemsByLocation => {
+  const atGarage: Record<string, PaymentLineItem[]> = {};
+  const mobileService: Record<string, PaymentLineItem[]> = {};
+
+  const push = (
+    bucket: Record<string, PaymentLineItem[]>,
+    method: string,
+    item: PaymentLineItem
+  ) => {
+    if (!item.amount) return;
+    const key = methodBucket(method);
+    (bucket[key] = bucket[key] || []).push(item);
+  };
+
+  const addAppointments = (
+    appointments: Appointment[],
+    bucket: Record<string, PaymentLineItem[]>
+  ) => {
+    appointments.forEach((apt) => {
+      const breakdown = parsePaymentBreakdown(apt.paymentBreakdown);
+      const invoiceNumber = apt.invoice?.invoiceNumber || null;
+      const customerName = customerNameOf(apt);
+
+      if (breakdown && Array.isArray(breakdown)) {
+        breakdown.forEach((entry, index) => {
+          push(bucket, entry.method || 'CASH', {
+            key: `apt-${apt.id}-${index}`,
+            invoiceNumber,
+            customerName,
+            amount: entry.amount || 0,
+          });
+        });
+      } else if (apt.paymentAmount) {
+        push(bucket, apt.invoice?.paymentMethod || 'CASH', {
+          key: `apt-${apt.id}`,
+          invoiceNumber,
+          customerName,
+          amount: apt.paymentAmount,
+        });
+      }
+    });
+  };
+
+  addAppointments(atGarageAppointments, atGarage);
+  addAppointments(mobileServiceAppointments, mobileService);
+
+  // Invoice payments already carry their location from the API. Anything that
+  // is not explicitly mobile counts as shop, matching how the API buckets its
+  // atGarage/mobileService totals.
+  invoicePayments.forEach((payment) => {
+    const bucket =
+      payment.appointmentType === 'MOBILE_SERVICE' ? mobileService : atGarage;
+    push(bucket, payment.paymentMethod || 'CASH', {
+      key: `inv-${payment.id}`,
+      invoiceNumber: payment.invoiceNumber || null,
+      customerName: payment.customerName || '',
+      amount: Number(payment.amount) || 0,
+    });
+  });
+
+  // Largest first — the entries worth checking sit at the top.
+  [atGarage, mobileService].forEach((bucket) =>
+    Object.values(bucket).forEach((items) =>
+      items.sort((a, b) => b.amount - a.amount)
+    )
+  );
+
+  return { atGarage, mobileService };
 };


### PR DESCRIPTION
Four related pieces of front-end work, one commit each — reviewable in order.

## 1. `CrudAutocomplete` — a standard for managed catalogs

Brand, size, location and service pickers each hand-rolled the same "autocomplete with add/edit/delete" markup, and had drifted apart: brand had an edit button, size and location didn't, even though their dialogs and `PUT` endpoints already supported renaming.

The bigger problem was *where* the icons were. They acted only on the **currently selected** option, so deleting a brand meant first selecting it — which also wrote it into the form you were filling in.

`CrudAutocomplete` puts **edit/delete on each dropdown row** and **add inside the input**. Row buttons suppress `mousedown` and stop click propagation so they act without selecting the row or leaving the popper open behind the dialog they launch. `useCatalogSelect` holds the shared query/delete/dialog wiring.

### Bugs fixed here

**Bad ids were reaching the API.** The catalog request modules trusted a token cached in `localStorage` and only asked Clerk when nothing was stored. Clerk session tokens last **60 seconds**, so the stored copy was routinely expired, `/tires/locations/all` 401'd, and the list silently degraded to the public names-only endpoint — whose records use the *name* as the id. Edit and delete then issued:

```
PUT    /api/tires/locations/Wherehouse
DELETE /api/tires/locations/Wherehouse
```

and the API correctly answered *"Location not found"* (the real row is `cl9q7x2m80003xyz`). Two fixes, since either alone leaves a hole: a shared `catalog-api-client` that asks Clerk on every request (matching the existing `tire.requests.ts` pattern), and `useCatalogSelect` disabling management entirely when the list came from the fallback, so a name can never be sent as an id.

This fallback predates the PR — moving delete onto every row just made it easy to hit.

Also in this commit:
- Brand and size names were **hard-disabled** in edit mode (*"Brand name cannot be changed"*), leaving the size dialog with nothing editable at all. The API supports renaming both.
- `window.confirm` → `ConfirmationContext`, per the project rule against browser dialogs.
- Delete errors were swallowed; the API's 409 *"it is being used by existing tires"* now surfaces.
- Delete was offered to STAFF, whom the API's role guard rejects. Now hidden for them.
- `TireDialog` reads the `tire-brands` cache directly for the brand logo and needed updating for the new cache shape — it's typed `as any[]`, so this would have thrown at runtime rather than failing the build.

## 2. Appointments — inline customer edit, searchable service type

Customer rows get an edit button wired to the existing `CustomerDialog` (it already accepted a `customerId`). No delete: customers own invoices, vehicles and appointments, so that belongs on the customer management page. Search still matches name, business name and phone.

Service type was a plain `Select` with no filtering. Now searchable with per-row edit/delete — gated so only API-backed types are manageable, since the hardcoded fallbacks and a retired type kept selectable for an existing appointment have no id and would have failed on edit.

## 3. Invoices — service picker on the standard

The fourth and last hand-rolled copy, 253 → 152 lines. Rows now show the unit price, and typing searches the description too.

Four bugs surfaced: clearing the field did nothing (leaving a stale `serviceId` on the line); deleting *any* service wiped the line's selection; editing left the line on the old name and price; API errors were flattened to `"Failed to delete service"`.

`ServiceSelect` is shared, so **the quotation form gets the same treatment and fixes**. Props unchanged, so neither caller needed editing.

## 4. Day Summary — invoice detail per payment method

The At Shop and Mobile Service cards showed each method as a single figure. Each method now lists the payments behind it — invoice number, customer, amount.

No backend change needed: `GET /api/invoices/day-summary` already returns a `payments[]` array with `invoiceNumber`, `amount`, `paymentMethod`, `customerName` and `appointmentType`. The page was fetching it and using only the totals.

**The care is in making the rows add up.** Each method total is the sum of two sources — money on the appointment (`paymentBreakdown`) and invoice payments collected that day. Listing only invoice payments would leave rows that don't sum to the total above them, which reads as missing money. `buildPaymentLineItems` draws on both and buckets methods identically (all cash variants under one `CASH` heading); a test rebuilds the totals the way the page does and asserts every method's rows sum to its displayed total.

Appointment money with no invoice raised has no number, so those rows fall back to the customer name in italics.

Also fixes a display bug: the DB enum is `CHECK` but every label map tested for `CHEQUE`, so cheque payments rendered with a **blank** label.

## Verification

- **131 tests pass** (9 suites). New: 5 for `useCatalogSelect` (fallback ⇒ management disabled; delete sends the real cuid; STAFF gating; 409 surfacing) and 5 for `buildPaymentLineItems` (including the reconciliation assertion).
- **12 browser checks** against the real `CrudAutocomplete` in headless Chrome: row buttons fire without selecting the row (programmatic *and* real mouse events, since only real `mousedown` exercises the focus/popper path), dropdown closes before the dialog opens, delete spinner is row-scoped, keyboard arrow+enter still selects with buttons at `tabIndex={-1}`, clear sits left of add, no dropdown arrow.
- `yarn typecheck:web` clean; 0 ESLint errors on changed files.

⚠️ **A CI break I caught mid-work:** the `useCatalogSelect` spec was originally vitest-style. This app runs **Jest** (`nx test webApp` → `jest`), so it would have failed CI with *"Vitest cannot be imported in a CommonJS module"*. It passed when run standalone under vitest, which is exactly how it slipped through. Converted, including the `mock`-prefix rule for hoisted `jest.mock` factories.

## Worth a manual pass

The numbers are verified against synthetic data, not a real trading day. Worth opening a day with mixed shop/mobile and cash/e-transfer activity and confirming the rows sum to the headline — especially a day with both an appointment payment and a separate invoice payment for the same customer.

The token-refresh fix rests on reasoning from the backend logs plus the Clerk 60s expiry; I couldn't exercise a real Clerk login headlessly, so that's the piece to confirm by using the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
