### PR TITLE
fix(quotations): editing a quote 500s, and a failed save wipes its items

### DIFF
--- a/server/src/quotations/quotations.service.spec.ts
+++ b/server/src/quotations/quotations.service.spec.ts
@@ -305,3 +305,117 @@ describe('QuotationsService', () => {
     });
   });
 });
+
+describe('QuotationsService — item payload sanitising', () => {
+  let service: QuotationsService;
+  let quotationRepository: any;
+
+  beforeEach(() => {
+    quotationRepository = {
+      create: jest.fn(async (data: any) => ({ id: 'quote-1', ...data })),
+      findOne: jest.fn(async () => ({
+        id: 'q1',
+        gstRate: 0.05,
+        pstRate: 0.07,
+        items: [],
+      })),
+      update: jest.fn(async (id: string, data: any) => ({ id, ...data })),
+      deleteItems: jest.fn(),
+      createItems: jest.fn(),
+    };
+    service = new QuotationsService(
+      quotationRepository as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+  });
+
+  // Exactly what the edit form sends back: GET /quotations/:id includes each
+  // item's `tire` relation, so a saved item round-trips carrying `tire`, `id`
+  // and `serviceId`. Prisma rejected those with "Unknown argument `tire`".
+  const roundTrippedItem = {
+    id: 'item-1',
+    tireId: null,
+    tireName: null,
+    tire: null,
+    serviceId: 'svc-9',
+    itemType: 'SERVICE',
+    description: 'Breakes replacement',
+    quantity: 1,
+    unitPrice: 100,
+    total: 100,
+    createdAt: '2026-07-27T00:00:00.000Z',
+    updatedAt: '2026-07-27T00:00:00.000Z',
+  };
+
+  it('strips non-column fields before recreating items on update', async () => {
+    await service.update('q1', {
+      items: [
+        roundTrippedItem,
+        {
+          itemType: 'OTHER',
+          description: 'dasdads',
+          quantity: 1,
+          unitPrice: 220,
+        },
+      ],
+    } as any);
+
+    const written = quotationRepository.createItems.mock.calls[0][0];
+    written.forEach((item: any) => {
+      expect(item).not.toHaveProperty('tire');
+      expect(item).not.toHaveProperty('serviceId');
+      expect(item).not.toHaveProperty('id');
+      expect(item).not.toHaveProperty('createdAt');
+      expect(item).not.toHaveProperty('updatedAt');
+    });
+    expect(Object.keys(written[0]).sort()).toEqual([
+      'description',
+      'itemType',
+      'quantity',
+      'quotationId',
+      'tireId',
+      'tireName',
+      'total',
+      'unitPrice',
+    ]);
+    expect(written[0].quotationId).toBe('q1');
+  });
+
+  it('strips non-column fields on create too', async () => {
+    await service.create(
+      { customerName: 'Bob', items: [roundTrippedItem] } as any,
+      'u1'
+    );
+
+    const item = quotationRepository.create.mock.calls[0][0].items.create[0];
+    expect(item).not.toHaveProperty('tire');
+    expect(item).not.toHaveProperty('serviceId');
+    expect(item.description).toBe('Breakes replacement');
+  });
+
+  it('normalises an empty tireId to null so the FK is not violated', async () => {
+    await service.update('q1', {
+      items: [{ ...roundTrippedItem, tireId: '', tireName: '' }],
+    } as any);
+
+    const written = quotationRepository.createItems.mock.calls[0][0];
+    expect(written[0].tireId).toBeNull();
+    expect(written[0].tireName).toBeNull();
+  });
+
+  it('still recalculates totals from the sanitised items', async () => {
+    await service.update('q1', {
+      items: [
+        { ...roundTrippedItem, quantity: 2, unitPrice: 170 },
+        { itemType: 'OTHER', description: 'x', quantity: 1, unitPrice: 100 },
+      ],
+    } as any);
+
+    const written = quotationRepository.createItems.mock.calls[0][0];
+    expect(written[0].total).toBe(340);
+    expect(written[1].total).toBe(100);
+    expect(quotationRepository.update.mock.calls[0][1].subtotal).toBe(440);
+  });
+});

--- a/server/src/quotations/quotations.service.spec.ts
+++ b/server/src/quotations/quotations.service.spec.ts
@@ -25,6 +25,13 @@ describe('QuotationsService', () => {
       delete: jest.fn(),
       deleteItems: jest.fn(),
       createItems: jest.fn(),
+      replaceItemsAndUpdate: jest.fn(
+        async (id: string, items: any, data: any) => ({
+          id,
+          ...data,
+          items,
+        })
+      ),
       search: jest.fn(),
       convertToInvoice: jest.fn(),
     };
@@ -124,13 +131,17 @@ describe('QuotationsService', () => {
         items: [{ quantity: 3, unitPrice: 100, itemType: 'TIRE' }],
       } as any);
 
-      expect(quotationRepository.deleteItems).toHaveBeenCalledWith('q1');
-      expect(quotationRepository.createItems).toHaveBeenCalled();
-      const itemsArg = quotationRepository.createItems.mock.calls[0][0];
+      // Items and totals are swapped in one transactional call so a failure
+      // can't leave the quote with its items deleted.
+      expect(quotationRepository.replaceItemsAndUpdate).toHaveBeenCalledTimes(
+        1
+      );
+      const [idArg, itemsArg, updateArg] =
+        quotationRepository.replaceItemsAndUpdate.mock.calls[0];
+      expect(idArg).toBe('q1');
       expect(itemsArg[0].total).toBe(300);
       expect(itemsArg[0].quotationId).toBe('q1');
 
-      const updateArg = quotationRepository.update.mock.calls[0][1];
       expect(updateArg.subtotal).toBe(300);
       expect(updateArg.taxAmount).toBeCloseTo(36); // 300*0.12
       expect(updateArg.total).toBeCloseTo(336);
@@ -145,7 +156,8 @@ describe('QuotationsService', () => {
       await service.update('q1', {
         items: [{ quantity: 1, unitPrice: 200 }],
       } as any);
-      const updateArg = quotationRepository.update.mock.calls[0][1];
+      const updateArg =
+        quotationRepository.replaceItemsAndUpdate.mock.calls[0][2];
       expect(updateArg.gstAmount).toBeCloseTo(20);
       expect(updateArg.pstAmount).toBeCloseTo(10);
       expect(updateArg.total).toBeCloseTo(230);
@@ -322,6 +334,13 @@ describe('QuotationsService — item payload sanitising', () => {
       update: jest.fn(async (id: string, data: any) => ({ id, ...data })),
       deleteItems: jest.fn(),
       createItems: jest.fn(),
+      replaceItemsAndUpdate: jest.fn(
+        async (id: string, items: any, data: any) => ({
+          id,
+          ...data,
+          items,
+        })
+      ),
     };
     service = new QuotationsService(
       quotationRepository as any,
@@ -362,7 +381,7 @@ describe('QuotationsService — item payload sanitising', () => {
       ],
     } as any);
 
-    const written = quotationRepository.createItems.mock.calls[0][0];
+    const written = quotationRepository.replaceItemsAndUpdate.mock.calls[0][1];
     written.forEach((item: any) => {
       expect(item).not.toHaveProperty('tire');
       expect(item).not.toHaveProperty('serviceId');
@@ -400,7 +419,7 @@ describe('QuotationsService — item payload sanitising', () => {
       items: [{ ...roundTrippedItem, tireId: '', tireName: '' }],
     } as any);
 
-    const written = quotationRepository.createItems.mock.calls[0][0];
+    const written = quotationRepository.replaceItemsAndUpdate.mock.calls[0][1];
     expect(written[0].tireId).toBeNull();
     expect(written[0].tireName).toBeNull();
   });
@@ -413,9 +432,60 @@ describe('QuotationsService — item payload sanitising', () => {
       ],
     } as any);
 
-    const written = quotationRepository.createItems.mock.calls[0][0];
+    const written = quotationRepository.replaceItemsAndUpdate.mock.calls[0][1];
     expect(written[0].total).toBe(340);
     expect(written[1].total).toBe(100);
-    expect(quotationRepository.update.mock.calls[0][1].subtotal).toBe(440);
+    expect(
+      quotationRepository.replaceItemsAndUpdate.mock.calls[0][2].subtotal
+    ).toBe(440);
+  });
+});
+
+describe('QuotationsService — item replacement is atomic', () => {
+  let service: QuotationsService;
+  let quotationRepository: any;
+
+  beforeEach(() => {
+    quotationRepository = {
+      findOne: jest.fn(async () => ({
+        id: 'q1',
+        gstRate: 0.05,
+        pstRate: 0.07,
+        items: [],
+      })),
+      update: jest.fn(),
+      deleteItems: jest.fn(),
+      createItems: jest.fn(),
+      replaceItemsAndUpdate: jest.fn(async () => ({ id: 'q1' })),
+    };
+    service = new QuotationsService(
+      quotationRepository as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+  });
+
+  // A failing save previously deleted the items and then threw before
+  // recreating them, leaving a live quote with zero items and stale totals.
+  // Everything must now go through the single transactional call.
+  it('never deletes items outside the transaction', async () => {
+    await service.update('q1', {
+      items: [
+        { itemType: 'OTHER', description: 'x', quantity: 1, unitPrice: 10 },
+      ],
+    } as any);
+
+    expect(quotationRepository.deleteItems).not.toHaveBeenCalled();
+    expect(quotationRepository.createItems).not.toHaveBeenCalled();
+    expect(quotationRepository.replaceItemsAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves items untouched when the payload has none', async () => {
+    await service.update('q1', { notes: 'just a note' } as any);
+
+    expect(quotationRepository.deleteItems).not.toHaveBeenCalled();
+    expect(quotationRepository.replaceItemsAndUpdate).not.toHaveBeenCalled();
+    expect(quotationRepository.update).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/src/quotations/quotations.service.ts
+++ b/server/src/quotations/quotations.service.ts
@@ -166,9 +166,6 @@ export class QuotationsService {
 
     // If items are being updated, recalculate totals
     if (items) {
-      // Delete existing items
-      await this.quotationRepository.deleteItems(id);
-
       // Calculate new totals
       let subtotal = 0;
       const processedItems = items.map((item) => {
@@ -186,21 +183,23 @@ export class QuotationsService {
       const taxAmount = gstAmount + pstAmount;
       const total = subtotal + taxAmount;
 
-      // Create new items
-      await this.quotationRepository.createItems(processedItems);
-
-      // Update quotation with new totals
-      return this.quotationRepository.update(id, {
-        ...quoteData,
-        subtotal,
-        gstRate,
-        gstAmount,
-        pstRate,
-        pstAmount,
-        taxRate,
-        taxAmount,
-        total,
-      });
+      // Replace the items and write the new totals in one transaction, so a
+      // failure can't leave the quotation with its items deleted.
+      return this.quotationRepository.replaceItemsAndUpdate(
+        id,
+        processedItems,
+        {
+          ...quoteData,
+          subtotal,
+          gstRate,
+          gstAmount,
+          pstRate,
+          pstAmount,
+          taxRate,
+          taxAmount,
+          total,
+        }
+      );
     }
 
     // If no items update, just update the quotation data

--- a/server/src/quotations/quotations.service.ts
+++ b/server/src/quotations/quotations.service.ts
@@ -17,6 +17,27 @@ type QuotationWithItems = Quotation & {
   })[];
 };
 
+/**
+ * Reduce an incoming item to the columns QuotationItem actually has.
+ *
+ * GET /quotations/:id returns each item with its `tire` relation loaded, and
+ * the edit form sends those items straight back — so the payload arrives
+ * carrying `tire` (plus `id` and `serviceId`, which are not writable columns
+ * either). Spreading the DTO into Prisma made createMany fail with
+ * "Unknown argument `tire`", so saving an edit to any quotation that already
+ * had items returned a 500.
+ */
+const toQuotationItemData = (item: any, total: number) => ({
+  // An empty string would be treated as a real id and break the FK.
+  tireId: item.tireId || null,
+  tireName: item.tireName || null,
+  itemType: item.itemType,
+  description: item.description,
+  quantity: item.quantity,
+  unitPrice: item.unitPrice,
+  total,
+});
+
 @Injectable()
 export class QuotationsService {
   constructor(
@@ -53,10 +74,7 @@ export class QuotationsService {
       const processedItems = items.map((item) => {
         const total = Number(item.quantity) * item.unitPrice;
         subtotal += total;
-        return {
-          ...item,
-          total,
-        };
+        return toQuotationItemData(item, total);
       });
       console.log('Service: Processed items count:', processedItems.length);
 
@@ -156,11 +174,7 @@ export class QuotationsService {
       const processedItems = items.map((item) => {
         const total = Number(item.quantity) * item.unitPrice;
         subtotal += total;
-        return {
-          ...item,
-          quotationId: id,
-          total,
-        };
+        return { ...toQuotationItemData(item, total), quotationId: id };
       });
 
       // Calculate taxes

--- a/server/src/quotations/repositories/quotation.repository.ts
+++ b/server/src/quotations/repositories/quotation.repository.ts
@@ -89,9 +89,45 @@ export class QuotationRepository {
     });
   }
 
-  async createItems(items: Prisma.QuotationItemCreateManyInput[]): Promise<void> {
+  async createItems(
+    items: Prisma.QuotationItemCreateManyInput[]
+  ): Promise<void> {
     await this.prisma.quotationItem.createMany({
       data: items,
+    });
+  }
+
+  /**
+   * Swap a quotation's items and update the quotation itself, atomically.
+   *
+   * Editing a quote replaces its whole item set. Doing that as separate
+   * delete/create calls means a failure in the create leaves the quotation
+   * with no items at all — a Prisma validation error wiped the line items off
+   * a real quote exactly this way, leaving stale totals and nothing to show.
+   * Running all three statements in one transaction means a failed save now
+   * changes nothing.
+   */
+  async replaceItemsAndUpdate(
+    id: string,
+    items: Prisma.QuotationItemCreateManyInput[],
+    data: Prisma.QuotationUpdateInput
+  ): Promise<Quotation> {
+    return this.prisma.$transaction(async (tx) => {
+      await tx.quotationItem.deleteMany({ where: { quotationId: id } });
+      if (items.length > 0) {
+        await tx.quotationItem.createMany({ data: items });
+      }
+      return tx.quotation.update({
+        where: { id },
+        data,
+        include: {
+          items: {
+            include: {
+              tire: true,
+            },
+          },
+        },
+      });
     });
   }
 
@@ -157,7 +193,10 @@ export class QuotationRepository {
     });
   }
 
-  async convertToInvoice(quotationId: string, invoiceId: string): Promise<Quotation> {
+  async convertToInvoice(
+    quotationId: string,
+    invoiceId: string
+  ): Promise<Quotation> {
     return this.prisma.quotation.update({
       where: { id: quotationId },
       data: {


### PR DESCRIPTION
Two linked defects in the quotation edit path. The first makes every edit fail; the second turns that failure into **data loss**.

## 1. Editing a quote returned a 500

```
PrismaClientValidationError:
Invalid `prisma.quotationItem.createMany()` invocation:
  { tireId: null, tireName: null, itemType: "PART", description: "Breaks",
    quantity: 1, unitPrice: 170, tire: null, quotationId: "cmrz99...", total: 170 }
Unknown argument `tire`. Did you mean `tireId`?
  at QuotationRepository.createItems (quotation.repository.ts:86)
  at QuotationsService.update (quotations.service.ts:136)
```

`GET /quotations/:id` loads each item with its `tire` relation included. The edit form sends those items straight back, so the payload arrives carrying `tire` — plus `id`, `serviceId`, `createdAt` and `updatedAt`, none of which are writable columns on `QuotationItem`. Both the create and update paths spread the incoming item into Prisma, so those keys reached `createMany`.

**Creating** a quote worked because the form builds items fresh with no relation attached — only **editing** round-trips a saved item. Visible in the failure above: the two loaded items carry `tire: null`, the newly added third one doesn't.

**Fix:** reduce each item to the columns `QuotationItem` actually has, on both paths, and normalise an empty `tireId` to `null` so a blank string can't be taken for a real id and violate the FK.

`InvoicesService` already strips `tire` on its update path; quotations never got the same treatment. This uses a **whitelist** rather than that blacklist, so a future relation or generated column can't leak through the same way.

## 2. A failed save deleted the quote's items

`update()` replaced the item set as two separate calls — `deleteItems()` then `createItems()`. When the error above fired, **the delete had already committed**. The quote was left with zero items and stale totals, and the edit form then had nothing to populate.

This is not hypothetical. On the reported quote:

```
cmrz99yng0006y0y5n6vwe6oa | Q16630698-0EMH | 0 items | subtotal 270 | total 302.40
```

Zero items, but a subtotal of 270 — which is exactly the two original lines (170 + 100) that the log shows being deleted. The totals were never rewritten because the failure happened before that step.

**Fix:** `replaceItemsAndUpdate()` runs the delete, the insert and the totals update inside one `prisma.$transaction`, so a failed save changes nothing at all. Fix 1 stops the specific error that triggered this, but any future failure between the two statements would have destroyed items the same way.

## Tests

25 pass in the suite (6 new, 2 pre-existing updated for the transactional call):

- non-column fields stripped before items are recreated on update, asserting the written keys are exactly the 7 columns plus `quotationId`
- the same on the create path
- empty `tireId`/`tireName` become `null`
- totals still recalculated correctly from the sanitised items
- `deleteItems`/`createItems` are never called outside the transaction
- a payload with no items leaves items untouched

`yarn typecheck:server` clean.

## Note on recovery

This fixes the cause, but it does not restore lines already lost. Quote `Q16630698-0EMH` currently has 0 items; from the log its originals were `PART "Breaks" 1 × $170` and `SERVICE "Breakes replacement" 1 × $100`. They can be re-entered by hand, or I can restore them directly — say the word.

Any other quote edited while the 500 was live should be checked for the same symptom: a non-zero subtotal with no line items.

## Not verified here

Diagnosed from the backend log and the database, and pinned with unit tests, but I could not drive an authenticated edit through the UI from my environment. Worth re-saving a quote that has items to confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
