### PR TITLE
feat(vehicles): scan VIN from QR codes, not just barcodes (GA-50)

### DIFF
--- a/apps/webApp/src/app/components/vehicles/VinScanDialog.tsx
+++ b/apps/webApp/src/app/components/vehicles/VinScanDialog.tsx
@@ -41,12 +41,14 @@ interface VinScanDialogProps {
 type ScanStatus = 'starting' | 'scanning' | 'result' | 'error';
 
 // VIN barcodes are almost always Code 39; newer vehicles occasionally use Code
-// 128 or Data Matrix. Restricting the format set makes decoding faster and less
-// prone to false positives.
+// 128 or Data Matrix, and some recent models print a QR code on the door-jamb
+// label instead of a linear barcode. Restricting the format set makes decoding
+// faster and less prone to false positives.
 const VIN_FORMATS = [
   BarcodeFormat.CODE_39,
   BarcodeFormat.CODE_128,
   BarcodeFormat.DATA_MATRIX,
+  BarcodeFormat.QR_CODE,
 ];
 
 export default function VinScanDialog({
@@ -384,8 +386,8 @@ export default function VinScanDialog({
               color="text.secondary"
               sx={{ mt: 1.5, textAlign: 'center' }}
             >
-              Point the camera at the VIN barcode — usually on the driver&apos;s
-              door jamb or the bottom of the windshield.
+              Point the camera at the VIN barcode or QR code — usually on the
+              driver&apos;s door jamb or the bottom of the windshield.
             </Typography>
           </Box>
         )}

--- a/apps/webApp/src/app/utils/vin.util.spec.ts
+++ b/apps/webApp/src/app/utils/vin.util.spec.ts
@@ -87,5 +87,53 @@ describe('vin.util', () => {
     it('returns null when no 17-character VIN is present', () => {
       expect(extractVinFromScan('SHORT123')).toBeNull();
     });
+
+    // QR labels on newer vehicles carry several fields rather than a bare VIN.
+    describe('QR payloads', () => {
+      it('extracts the VIN from a delimited key/value payload', () => {
+        const result = extractVinFromScan(
+          'VIN:1HGCM82633A004352;MODEL:ACCORD;YEAR:2003'
+        );
+        expect(result).toEqual({
+          vin: '1HGCM82633A004352',
+          checkDigitValid: true,
+        });
+      });
+
+      it('extracts the VIN from a multi-line payload', () => {
+        const result = extractVinFromScan(
+          'MFR=HONDA\nVIN=1HGCM82633A004352\nPLANT=MARYSVILLE'
+        );
+        expect(result?.vin).toBe('1HGCM82633A004352');
+      });
+
+      it('extracts the VIN embedded in a URL', () => {
+        const result = extractVinFromScan(
+          'https://vehicle.example.com/lookup/1HGCM82633A004352?src=qr'
+        );
+        expect(result?.vin).toBe('1HGCM82633A004352');
+      });
+
+      it('never fabricates a VIN by joining two adjacent fields', () => {
+        // Descriptive fields only. Concatenating the payload before scanning
+        // would produce a >17-character run and yield a bogus "VIN".
+        expect(
+          extractVinFromScan('MODEL:F150XLT;COLOR:BLUE;TRIM:LARIAT4X4')
+        ).toBeNull();
+      });
+
+      it('prefers a standalone VIN field over a lucky window in a longer field', () => {
+        // A run of 1s is longer than a VIN and every window inside it happens
+        // to satisfy the check digit — the real VIN field must still win, even
+        // though its own check digit does not validate.
+        const result = extractVinFromScan(
+          '1111111111111111111;1HGCM82653A004352'
+        );
+        expect(result).toEqual({
+          vin: '1HGCM82653A004352',
+          checkDigitValid: false,
+        });
+      });
+    });
   });
 });

--- a/apps/webApp/src/app/utils/vin.util.ts
+++ b/apps/webApp/src/app/utils/vin.util.ts
@@ -87,35 +87,69 @@ export const isValidVinCheckDigit = (vin: string): boolean => {
 };
 
 export interface VinScanCandidate {
-  /** The 17-character VIN extracted from the scanned barcode payload. */
+  /** The 17-character VIN extracted from the scanned barcode/QR payload. */
   vin: string;
   /** Whether the ISO 3779 check digit validated (confidence signal). */
   checkDigitValid: boolean;
 }
 
+// Confidence tiers for an extracted candidate, best first.
+//
+// A field that is *exactly* a VIN outranks one carved out of a longer run of
+// characters: the check digit validates by chance for roughly 1 in 11 random
+// 17-character windows, so a long descriptor field (common in QR payloads)
+// offers enough windows that a bogus one will regularly pass.
+const SCORE_FIELD_CHECK_DIGIT = 4;
+const SCORE_FIELD = 3;
+const SCORE_WINDOW_CHECK_DIGIT = 2;
+const SCORE_WINDOW = 1;
+
 /**
- * Extract a VIN from a raw barcode payload.
+ * Extract a VIN from a raw barcode or QR payload.
  *
  * Door-jamb / windshield Code 39 barcodes sometimes wrap the VIN with delimiter
- * characters (e.g. a leading "I" or a trailing "*"), so the payload can be
- * longer than 17 chars. We scan every 17-character window and prefer the one
- * whose check digit validates; otherwise we fall back to the first structurally
- * valid window. Returns null when no 17-character VIN can be found.
+ * characters (e.g. a leading "I" or a trailing "*"). QR labels go further and
+ * carry several fields — "VIN:xxx;MODEL:yyy", or a URL with the VIN in the path
+ * — so the VIN is one field among many.
+ *
+ * We split the payload on every character that can never appear in a VIN, which
+ * both trims those delimiters and keeps fields apart, then look for a VIN inside
+ * each field. Splitting matters: concatenating the whole payload first lets a
+ * 17-character "VIN" be fabricated from the tail of one field and the head of
+ * the next. Candidates are ranked by `SCORE_*` above. Returns null when no
+ * 17-character VIN can be found.
  */
 export const extractVinFromScan = (raw: string): VinScanCandidate | null => {
-  const cleaned = raw.toUpperCase().replace(/[^A-HJ-NPR-Z0-9]/g, '');
-  if (cleaned.length < 17) return null;
+  const fields = raw
+    .toUpperCase()
+    .split(/[^A-HJ-NPR-Z0-9]+/)
+    .filter((field) => field.length >= 17);
 
-  let firstValid: VinScanCandidate | null = null;
-  for (let start = 0; start + 17 <= cleaned.length; start++) {
-    const candidate = cleaned.slice(start, start + 17);
-    if (!VIN_PATTERN.test(candidate)) continue;
-    if (isValidVinCheckDigit(candidate)) {
-      return { vin: candidate, checkDigitValid: true };
-    }
-    if (!firstValid) {
-      firstValid = { vin: candidate, checkDigitValid: false };
+  let best: VinScanCandidate | null = null;
+  let bestScore = 0;
+
+  for (const field of fields) {
+    const isWholeField = field.length === 17;
+    for (let start = 0; start + 17 <= field.length; start++) {
+      const candidate = field.slice(start, start + 17);
+      if (!VIN_PATTERN.test(candidate)) continue;
+      const checkDigitValid = isValidVinCheckDigit(candidate);
+      const score = isWholeField
+        ? checkDigitValid
+          ? SCORE_FIELD_CHECK_DIGIT
+          : SCORE_FIELD
+        : checkDigitValid
+        ? SCORE_WINDOW_CHECK_DIGIT
+        : SCORE_WINDOW;
+
+      if (score > bestScore) {
+        best = { vin: candidate, checkDigitValid };
+        bestScore = score;
+        // Nothing can beat a standalone field with a valid check digit.
+        if (score === SCORE_FIELD_CHECK_DIGIT) return best;
+      }
     }
   }
-  return firstValid;
+
+  return best;
 };


### PR DESCRIPTION
Closes [GA-50](https://gt-automotives.atlassian.net/browse/GA-50).

Some recent vehicles print a **QR code** on the door-jamb label instead of a linear barcode, so those VINs couldn't be scanned at all — the scanner's format list was Code 39 / Code 128 / Data Matrix only.

## The decoder change

`VinScanDialog` now includes `BarcodeFormat.QR_CODE` in its `POSSIBLE_FORMATS` hint, and the on-screen hint reads "barcode or QR code".

## The payload parser

This is the half that actually mattered. `extractVinFromScan` stripped every non-VIN character from the **whole** payload, then slid a 17-character window over the result. That's fine for a Code 39 barcode that is essentially a bare VIN, but QR labels carry several fields — `VIN:xxx;MODEL:yyy`, or a URL with the VIN in the path — and joining them fabricates VINs. Checked against the old algorithm:

| payload | old result |
|---|---|
| `MODEL:F150XLT;COLOR:BLUE;TRIM:LARIAT4X4` | `MDELF150XLTCLRBLU` — invented; no VIN present |
| `https://vehicle.example.com/lookup/<vin>` | `HTTPSVEHCLEEXAMPL` when the VIN's check digit doesn't validate |

It now splits the payload on characters that can never appear in a VIN. That trims the Code 39 wrapping delimiters exactly as before, while keeping QR fields apart, and candidates are ranked: a field that *is* a VIN outranks one carved out of a longer run, because the check digit passes by chance for roughly 1 in 11 random 17-character windows and a long descriptor field offers plenty of windows to get lucky in.

## Verification

- 138/138 webApp tests pass. 5 new QR cases (key/value, multi-line, URL-embedded, no-fabrication, lucky-window-loses); all 5 pre-existing `extractVinFromScan` tests unchanged and green.
- Lint 0 errors; `tsc --noEmit` clean.

## Not done

- **Device testing.** Decoding a real QR label needs a camera and a vehicle, so the iPhone Safari / Android Chrome acceptance criteria and the "preview still responsive on older phones" check are unmet.
- **`PDF_417` left out.** It was an open question on the ticket; scoped this PR to QR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)