### PR TITLE
feat(reports): invoice sales report with date range, status filter and totals (GA-49)

### DIFF
--- a/apps/webApp/src/app/pages/admin/Reports.tsx
+++ b/apps/webApp/src/app/pages/admin/Reports.tsx
@@ -22,11 +22,7 @@ import {
   FormControl,
   InputLabel,
 } from '@mui/material';
-import {
-  Receipt,
-  AttachMoney,
-  Assessment,
-} from '@mui/icons-material';
+import { Receipt, AttachMoney, Assessment } from '@mui/icons-material';
 import axios from 'axios';
 import { useAuth } from '@clerk/clerk-react';
 
@@ -73,12 +69,15 @@ export function Reports() {
       if (startDate) params.startDate = startDate;
       if (endDate) params.endDate = endDate;
 
-      const response = await axios.get(`${baseURL}/api/reports/purchase-report`, {
-        params,
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await axios.get(
+        `${baseURL}/api/reports/purchase-report`,
+        {
+          params,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
 
       setReportData(response.data);
       setTaxReportData(null); // Clear tax report data
@@ -133,12 +132,15 @@ export function Reports() {
       if (startDate) params.startDate = startDate;
       if (endDate) params.endDate = endDate;
 
-      const response = await axios.get(`${baseURL}/api/reports/gst-paid-report`, {
-        params,
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await axios.get(
+        `${baseURL}/api/reports/gst-paid-report`,
+        {
+          params,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
 
       setGstPaidReportData(response.data);
       setReportData(null);
@@ -167,7 +169,14 @@ export function Reports() {
         <Grid container spacing={2} sx={{ mb: 3 }}>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
             <Card sx={{ height: '100%' }}>
-              <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+              <CardContent
+                sx={{
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'space-between',
+                }}
+              >
                 <Typography color="text.secondary" gutterBottom variant="body2">
                   Total Purchase Invoices
                 </Typography>
@@ -187,7 +196,14 @@ export function Reports() {
         <Grid container spacing={2} sx={{ mb: 3 }}>
           <Grid size={{ xs: 12, sm: 6, md: 4 }}>
             <Card sx={{ height: '100%' }}>
-              <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+              <CardContent
+                sx={{
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'space-between',
+                }}
+              >
                 <Typography color="text.secondary" gutterBottom variant="body2">
                   Total Expense Invoices
                 </Typography>
@@ -211,16 +227,18 @@ export function Reports() {
     if (!reportData) return null;
 
     // Show only Purchase or Expense categories based on report type
-    const categories = reportType === 'purchase'
-      ? reportData.purchasesByCategory
-      : reportData.expensesByCategory;
+    const categories =
+      reportType === 'purchase'
+        ? reportData.purchasesByCategory
+        : reportData.expensesByCategory;
 
     if (!categories?.length) return null;
 
     return (
       <Paper sx={{ p: 2, mb: 3 }}>
         <Typography variant="h6" gutterBottom>
-          {reportType === 'purchase' ? 'Purchase' : 'Expense'} Breakdown by Category
+          {reportType === 'purchase' ? 'Purchase' : 'Expense'} Breakdown by
+          Category
         </Typography>
         <TableContainer>
           <Table size="small">
@@ -235,7 +253,10 @@ export function Reports() {
               {categories.map((cat: any) => (
                 <TableRow key={cat.category}>
                   <TableCell>
-                    <Chip label={cat.category.replace(/_/g, ' ')} size="small" />
+                    <Chip
+                      label={cat.category.replace(/_/g, ' ')}
+                      size="small"
+                    />
                   </TableCell>
                   <TableCell align="right">{cat.count}</TableCell>
                   <TableCell align="right" sx={{ fontWeight: 'bold' }}>
@@ -270,15 +291,17 @@ export function Reports() {
               </TableRow>
             </TableHead>
             <TableBody>
-              {reportData.topVendorsBySpending.map((vendor: any, index: number) => (
-                <TableRow key={index}>
-                  <TableCell>{vendor.vendorName || 'Unknown'}</TableCell>
-                  <TableCell align="right">{vendor.count}</TableCell>
-                  <TableCell align="right" sx={{ fontWeight: 'bold' }}>
-                    {formatCurrency(vendor.totalAmount)}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {reportData.topVendorsBySpending.map(
+                (vendor: any, index: number) => (
+                  <TableRow key={index}>
+                    <TableCell>{vendor.vendorName || 'Unknown'}</TableCell>
+                    <TableCell align="right">{vendor.count}</TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 'bold' }}>
+                      {formatCurrency(vendor.totalAmount)}
+                    </TableCell>
+                  </TableRow>
+                )
+              )}
             </TableBody>
           </Table>
         </TableContainer>
@@ -294,7 +317,8 @@ export function Reports() {
     return (
       <Paper sx={{ p: 2 }}>
         <Typography variant="h6" gutterBottom>
-          Monthly Trends - {reportType === 'purchase' ? 'Purchases' : 'Expenses'}
+          Monthly Trends -{' '}
+          {reportType === 'purchase' ? 'Purchases' : 'Expenses'}
         </Typography>
         <TableContainer>
           <Table size="small">
@@ -310,10 +334,16 @@ export function Reports() {
                 <TableRow key={trend.month}>
                   <TableCell>{trend.month}</TableCell>
                   <TableCell align="right">
-                    {reportType === 'purchase' ? trend.purchaseCount : trend.expenseCount}
+                    {reportType === 'purchase'
+                      ? trend.purchaseCount
+                      : trend.expenseCount}
                   </TableCell>
                   <TableCell align="right" sx={{ fontWeight: 'bold' }}>
-                    {formatCurrency(reportType === 'purchase' ? trend.purchaseTotal : trend.expenseTotal)}
+                    {formatCurrency(
+                      reportType === 'purchase'
+                        ? trend.purchaseTotal
+                        : trend.expenseTotal
+                    )}
                   </TableCell>
                 </TableRow>
               ))}
@@ -346,7 +376,9 @@ export function Reports() {
               <Select
                 value={reportType}
                 label="Report Type"
-                onChange={(e) => handleReportTypeChange(e.target.value as ReportType)}
+                onChange={(e) =>
+                  handleReportTypeChange(e.target.value as ReportType)
+                }
               >
                 <MenuItem value="purchase">
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -403,7 +435,13 @@ export function Reports() {
               fullWidth
               variant="contained"
               size="large"
-              startIcon={loading ? <CircularProgress size={20} color="inherit" /> : <Assessment />}
+              startIcon={
+                loading ? (
+                  <CircularProgress size={20} color="inherit" />
+                ) : (
+                  <Assessment />
+                )
+              }
               onClick={handleGenerateReport}
               disabled={loading}
               sx={{ height: 56 }}
@@ -429,109 +467,169 @@ export function Reports() {
         )}
 
         {/* Purchase & Expense Report Results */}
-        {!loading && (reportType === 'purchase' || reportType === 'expense') && reportData && (
-          <>
-            {renderSummaryCards()}
-            {renderCategoryBreakdown()}
-            {renderVendorAnalysis()}
-            {renderMonthlyTrends()}
-          </>
-        )}
+        {!loading &&
+          (reportType === 'purchase' || reportType === 'expense') &&
+          reportData && (
+            <>
+              {renderSummaryCards()}
+              {renderCategoryBreakdown()}
+              {renderVendorAnalysis()}
+              {renderMonthlyTrends()}
+            </>
+          )}
 
         {/* Tax Collection Report Results */}
         {!loading && reportType === 'tax-collection' && taxReportData && (
-            <>
-              {/* Tax Summary Cards */}
-              <Grid container spacing={2} sx={{ mb: 3 }}>
-                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ height: '100%' }}>
-                    <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                      <Typography color="text.secondary" gutterBottom variant="body2">
-                        Paid Invoices
-                      </Typography>
-                      <Typography variant="h5" fontWeight="bold">
-                        {taxReportData.totalInvoices || 0}
-                      </Typography>
-                    </CardContent>
-                  </Card>
-                </Grid>
-
-                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ height: '100%' }}>
-                    <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                      <Typography color="text.secondary" gutterBottom variant="body2">
-                        GST Collected
-                      </Typography>
-                      <Typography variant="h6" fontWeight="bold" color="success.main">
-                        {formatCurrency(taxReportData.totalGstCollected || 0)}
-                      </Typography>
-                    </CardContent>
-                  </Card>
-                </Grid>
-
-                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ height: '100%' }}>
-                    <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                      <Typography color="text.secondary" gutterBottom variant="body2">
-                        PST Collected
-                      </Typography>
-                      <Typography variant="h6" fontWeight="bold" color="success.main">
-                        {formatCurrency(taxReportData.totalPstCollected || 0)}
-                      </Typography>
-                    </CardContent>
-                  </Card>
-                </Grid>
-
-                <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                  <Card sx={{ height: '100%' }}>
-                    <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                      <Typography color="text.secondary" gutterBottom variant="body2">
-                        Total Tax Collected
-                      </Typography>
-                      <Typography variant="h6" fontWeight="bold" color="primary">
-                        {formatCurrency(taxReportData.totalTaxCollected || 0)}
-                      </Typography>
-                    </CardContent>
-                  </Card>
-                </Grid>
+          <>
+            {/* Tax Summary Cards */}
+            <Grid container spacing={2} sx={{ mb: 3 }}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
+                      Paid Invoices
+                    </Typography>
+                    <Typography variant="h5" fontWeight="bold">
+                      {taxReportData.totalInvoices || 0}
+                    </Typography>
+                  </CardContent>
+                </Card>
               </Grid>
 
-              {/* Monthly Breakdown */}
-              {taxReportData.monthlyBreakdown?.length > 0 && (
-                <Paper sx={{ p: 2 }}>
-                  <Typography variant="h6" gutterBottom>
-                    Monthly Tax Collection
-                  </Typography>
-                  <TableContainer>
-                    <Table size="small">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell>Month</TableCell>
-                          <TableCell align="right">Invoices</TableCell>
-                          <TableCell align="right">GST Collected</TableCell>
-                          <TableCell align="right">PST Collected</TableCell>
-                          <TableCell align="right">Total Tax</TableCell>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
+                      GST Collected
+                    </Typography>
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="success.main"
+                    >
+                      {formatCurrency(taxReportData.totalGstCollected || 0)}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
+                      PST Collected
+                    </Typography>
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="success.main"
+                    >
+                      {formatCurrency(taxReportData.totalPstCollected || 0)}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                <Card sx={{ height: '100%' }}>
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
+                      Total Tax Collected
+                    </Typography>
+                    <Typography variant="h6" fontWeight="bold" color="primary">
+                      {formatCurrency(taxReportData.totalTaxCollected || 0)}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
+
+            {/* Monthly Breakdown */}
+            {taxReportData.monthlyBreakdown?.length > 0 && (
+              <Paper sx={{ p: 2 }}>
+                <Typography variant="h6" gutterBottom>
+                  Monthly Tax Collection
+                </Typography>
+                <TableContainer>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Month</TableCell>
+                        <TableCell align="right">Invoices</TableCell>
+                        <TableCell align="right">GST Collected</TableCell>
+                        <TableCell align="right">PST Collected</TableCell>
+                        <TableCell align="right">Total Tax</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {taxReportData.monthlyBreakdown.map((month: any) => (
+                        <TableRow key={month.month}>
+                          <TableCell>{month.month}</TableCell>
+                          <TableCell align="right">
+                            {month.invoiceCount}
+                          </TableCell>
+                          <TableCell align="right">
+                            {formatCurrency(month.gstCollected)}
+                          </TableCell>
+                          <TableCell align="right">
+                            {formatCurrency(month.pstCollected)}
+                          </TableCell>
+                          <TableCell align="right" sx={{ fontWeight: 'bold' }}>
+                            {formatCurrency(month.totalTaxCollected)}
+                          </TableCell>
                         </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {taxReportData.monthlyBreakdown.map((month: any) => (
-                          <TableRow key={month.month}>
-                            <TableCell>{month.month}</TableCell>
-                            <TableCell align="right">{month.invoiceCount}</TableCell>
-                            <TableCell align="right">{formatCurrency(month.gstCollected)}</TableCell>
-                            <TableCell align="right">{formatCurrency(month.pstCollected)}</TableCell>
-                            <TableCell align="right" sx={{ fontWeight: 'bold' }}>
-                              {formatCurrency(month.totalTaxCollected)}
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                </Paper>
-              )}
-            </>
-          )}
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            )}
+          </>
+        )}
 
         {/* GST Paid on Purchase & Expense Report Results */}
         {!loading && reportType === 'gst-paid' && gstPaidReportData && (
@@ -540,15 +638,27 @@ export function Reports() {
             <Grid container spacing={2} sx={{ mb: 3 }}>
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card sx={{ height: '100%' }}>
-                  <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary" gutterBottom variant="body2">
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
                       Total Paid Invoices
                     </Typography>
                     <Typography variant="h5" fontWeight="bold">
                       {gstPaidReportData.totalInvoices || 0}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {gstPaidReportData.totalPurchaseInvoices || 0} Purchase, {gstPaidReportData.totalExpenseInvoices || 0} Expense
+                      {gstPaidReportData.totalPurchaseInvoices || 0} Purchase,{' '}
+                      {gstPaidReportData.totalExpenseInvoices || 0} Expense
                     </Typography>
                   </CardContent>
                 </Card>
@@ -556,15 +666,31 @@ export function Reports() {
 
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card sx={{ height: '100%' }}>
-                  <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary" gutterBottom variant="body2">
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
                       GST Paid
                     </Typography>
-                    <Typography variant="h6" fontWeight="bold" color="error.main">
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="error.main"
+                    >
                       {formatCurrency(gstPaidReportData.totalGstPaid || 0)}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      Purchase: {formatCurrency(gstPaidReportData.purchaseGstPaid || 0)}
+                      Purchase:{' '}
+                      {formatCurrency(gstPaidReportData.purchaseGstPaid || 0)}
                     </Typography>
                   </CardContent>
                 </Card>
@@ -572,15 +698,31 @@ export function Reports() {
 
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card sx={{ height: '100%' }}>
-                  <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary" gutterBottom variant="body2">
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
                       PST Paid
                     </Typography>
-                    <Typography variant="h6" fontWeight="bold" color="error.main">
+                    <Typography
+                      variant="h6"
+                      fontWeight="bold"
+                      color="error.main"
+                    >
                       {formatCurrency(gstPaidReportData.totalPstPaid || 0)}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      Purchase: {formatCurrency(gstPaidReportData.purchasePstPaid || 0)}
+                      Purchase:{' '}
+                      {formatCurrency(gstPaidReportData.purchasePstPaid || 0)}
                     </Typography>
                   </CardContent>
                 </Card>
@@ -588,8 +730,19 @@ export function Reports() {
 
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <Card sx={{ height: '100%' }}>
-                  <CardContent sx={{ height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
-                    <Typography color="text.secondary" gutterBottom variant="body2">
+                  <CardContent
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Typography
+                      color="text.secondary"
+                      gutterBottom
+                      variant="body2"
+                    >
                       Total Tax Paid
                     </Typography>
                     <Typography variant="h6" fontWeight="bold" color="primary">
@@ -625,10 +778,18 @@ export function Reports() {
                       {gstPaidReportData.monthlyBreakdown.map((month: any) => (
                         <TableRow key={month.month}>
                           <TableCell>{month.month}</TableCell>
-                          <TableCell align="right">{month.purchaseCount}</TableCell>
-                          <TableCell align="right">{month.expenseCount}</TableCell>
-                          <TableCell align="right">{formatCurrency(month.totalGstPaid)}</TableCell>
-                          <TableCell align="right">{formatCurrency(month.totalPstPaid)}</TableCell>
+                          <TableCell align="right">
+                            {month.purchaseCount}
+                          </TableCell>
+                          <TableCell align="right">
+                            {month.expenseCount}
+                          </TableCell>
+                          <TableCell align="right">
+                            {formatCurrency(month.totalGstPaid)}
+                          </TableCell>
+                          <TableCell align="right">
+                            {formatCurrency(month.totalPstPaid)}
+                          </TableCell>
                           <TableCell align="right" sx={{ fontWeight: 'bold' }}>
                             {formatCurrency(month.totalTaxPaid)}
                           </TableCell>
@@ -643,57 +804,65 @@ export function Reports() {
         )}
 
         {/* Empty State - No Report Generated */}
-        {!loading && !reportData && !taxReportData && !gstPaidReportData && !error && (
-          <Box
-            sx={{
-              textAlign: 'center',
-              py: 8,
-              color: 'text.secondary',
-            }}
-          >
-            {reportType === 'purchase' ? (
-              <>
-                <Receipt sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
-                <Typography variant="h6" gutterBottom fontWeight="500">
-                  No Purchase Invoice Report Generated
-                </Typography>
-                <Typography variant="body2">
-                  Select a date range and click "Generate Report" to view purchase invoice analysis
-                </Typography>
-              </>
-            ) : reportType === 'expense' ? (
-              <>
-                <Receipt sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
-                <Typography variant="h6" gutterBottom fontWeight="500">
-                  No Expense Invoice Report Generated
-                </Typography>
-                <Typography variant="body2">
-                  Select a date range and click "Generate Report" to view expense invoice analysis
-                </Typography>
-              </>
-            ) : reportType === 'tax-collection' ? (
-              <>
-                <AttachMoney sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
-                <Typography variant="h6" gutterBottom fontWeight="500">
-                  No Tax Collection Report Generated
-                </Typography>
-                <Typography variant="body2">
-                  Select a date range and click "Generate Report" to view GST/PST tax collection from paid invoices
-                </Typography>
-              </>
-            ) : (
-              <>
-                <AttachMoney sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
-                <Typography variant="h6" gutterBottom fontWeight="500">
-                  No GST Paid Report Generated
-                </Typography>
-                <Typography variant="body2">
-                  Select a date range and click "Generate Report" to view GST/PST paid on purchase and expense invoices
-                </Typography>
-              </>
-            )}
-          </Box>
-        )}
+        {!loading &&
+          !reportData &&
+          !taxReportData &&
+          !gstPaidReportData &&
+          !error && (
+            <Box
+              sx={{
+                textAlign: 'center',
+                py: 8,
+                color: 'text.secondary',
+              }}
+            >
+              {reportType === 'purchase' ? (
+                <>
+                  <Receipt sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
+                  <Typography variant="h6" gutterBottom fontWeight="500">
+                    No Purchase Invoice Report Generated
+                  </Typography>
+                  <Typography variant="body2">
+                    Select a date range and click "Generate Report" to view
+                    purchase invoice analysis
+                  </Typography>
+                </>
+              ) : reportType === 'expense' ? (
+                <>
+                  <Receipt sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
+                  <Typography variant="h6" gutterBottom fontWeight="500">
+                    No Expense Invoice Report Generated
+                  </Typography>
+                  <Typography variant="body2">
+                    Select a date range and click "Generate Report" to view
+                    expense invoice analysis
+                  </Typography>
+                </>
+              ) : reportType === 'tax-collection' ? (
+                <>
+                  <AttachMoney sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
+                  <Typography variant="h6" gutterBottom fontWeight="500">
+                    No Tax Collection Report Generated
+                  </Typography>
+                  <Typography variant="body2">
+                    Select a date range and click "Generate Report" to view
+                    GST/PST tax collection from paid invoices
+                  </Typography>
+                </>
+              ) : (
+                <>
+                  <AttachMoney sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
+                  <Typography variant="h6" gutterBottom fontWeight="500">
+                    No GST Paid Report Generated
+                  </Typography>
+                  <Typography variant="body2">
+                    Select a date range and click "Generate Report" to view
+                    GST/PST paid on purchase and expense invoices
+                  </Typography>
+                </>
+              )}
+            </Box>
+          )}
       </Paper>
     </Box>
   );

--- a/apps/webApp/src/app/pages/admin/Reports.tsx
+++ b/apps/webApp/src/app/pages/admin/Reports.tsx
@@ -22,28 +22,50 @@ import {
   FormControl,
   InputLabel,
 } from '@mui/material';
-import { Receipt, AttachMoney, Assessment } from '@mui/icons-material';
+import { Receipt, AttachMoney, Assessment, ListAlt } from '@mui/icons-material';
 import axios from 'axios';
 import { useAuth } from '@clerk/clerk-react';
+import { InvoiceStatus } from '@gt-automotive/data';
+import { formatDisplayDate } from '../../utils/dateUtils';
+import { useAuth as useAppAuth } from '../../hooks/useAuth';
 
-type ReportType = 'purchase' | 'expense' | 'tax-collection' | 'gst-paid';
+type ReportType =
+  | 'purchase'
+  | 'expense'
+  | 'tax-collection'
+  | 'gst-paid'
+  | 'sales';
+
+// Sentinel for "don't filter by status" — MUI Select can't hold undefined.
+const ALL_STATUSES = 'ALL';
 
 export function Reports() {
   const [reportType, setReportType] = useState<ReportType>('purchase');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [salesStatus, setSalesStatus] = useState<string>(ALL_STATUSES);
   const [reportData, setReportData] = useState<any>(null);
   const [taxReportData, setTaxReportData] = useState<any>(null);
   const [gstPaidReportData, setGstPaidReportData] = useState<any>(null);
+  const [salesReportData, setSalesReportData] = useState<any>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { getToken } = useAuth();
+  const { role } = useAppAuth();
+  // This page is also routed for supervisors and foremen, but the sales report
+  // endpoint is admin/accountant-only — don't offer a report they'd get a 403 on.
+  const canRunSalesReport = role === 'admin' || role === 'accountant';
 
-  const handleReportTypeChange = (newType: ReportType) => {
-    setReportType(newType);
+  const clearReports = () => {
     setReportData(null);
     setTaxReportData(null);
     setGstPaidReportData(null);
+    setSalesReportData(null);
+  };
+
+  const handleReportTypeChange = (newType: ReportType) => {
+    setReportType(newType);
+    clearReports();
     setError(null);
   };
 
@@ -54,6 +76,8 @@ export function Reports() {
       await loadTaxReport();
     } else if (reportType === 'gst-paid') {
       await loadGstPaidReport();
+    } else if (reportType === 'sales') {
+      await loadSalesReport();
     }
   };
 
@@ -145,9 +169,52 @@ export function Reports() {
       setGstPaidReportData(response.data);
       setReportData(null);
       setTaxReportData(null);
+      setSalesReportData(null);
     } catch (err: any) {
       console.error('Error loading GST paid report:', err);
       setError(err.response?.data?.message || 'Failed to load GST paid report');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadSalesReport = async () => {
+    // Unlike the other reports, the sales report is scoped to an explicit range
+    // rather than defaulting to all time — an unbounded invoice list is never
+    // what the user wants here.
+    if (!startDate || !endDate) {
+      setError('Select both a start date and an end date.');
+      return;
+    }
+    if (endDate < startDate) {
+      setError('The end date cannot be before the start date.');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const token = await getToken();
+      const baseURL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+      const params: any = { startDate, endDate };
+      if (salesStatus !== ALL_STATUSES) params.status = salesStatus;
+
+      const response = await axios.get(`${baseURL}/api/reports/sales-report`, {
+        params,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      setSalesReportData(response.data);
+      setReportData(null);
+      setTaxReportData(null);
+      setGstPaidReportData(null);
+    } catch (err: any) {
+      console.error('Error loading sales report:', err);
+      setError(err.response?.data?.message || 'Failed to load sales report');
     } finally {
       setLoading(false);
     }
@@ -158,6 +225,103 @@ export function Reports() {
       style: 'currency',
       currency: 'CAD',
     }).format(amount);
+  };
+
+  // Enum values are SCREAMING_SNAKE_CASE; show them as words.
+  const humanize = (value?: string | null) =>
+    value ? value.replace(/_/g, ' ') : '';
+
+  const renderSalesReport = () => {
+    if (!salesReportData) return null;
+
+    const { rows, totals, invoiceCount } = salesReportData;
+
+    if (!rows?.length) {
+      return (
+        <Box sx={{ textAlign: 'center', py: 8, color: 'text.secondary' }}>
+          <ListAlt sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
+          <Typography variant="h6" gutterBottom fontWeight="500">
+            No invoices found
+          </Typography>
+          <Typography variant="body2">
+            No invoices match{' '}
+            {formatDisplayDate(salesReportData.startDate, 'short')}
+            {' – '}
+            {formatDisplayDate(salesReportData.endDate, 'short')}
+            {salesStatus !== ALL_STATUSES &&
+              ` with status ${humanize(salesStatus)}`}
+            .
+          </Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <Paper sx={{ p: 2 }}>
+        <Typography variant="h6" gutterBottom>
+          Invoices — {formatDisplayDate(salesReportData.startDate, 'short')} to{' '}
+          {formatDisplayDate(salesReportData.endDate, 'short')} ({invoiceCount})
+        </Typography>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Date</TableCell>
+                <TableCell>Description</TableCell>
+                <TableCell align="right">Sub Total</TableCell>
+                <TableCell align="right">GST</TableCell>
+                <TableCell align="right">PST</TableCell>
+                <TableCell align="right">Net Total</TableCell>
+                <TableCell>Mode of Payment</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row: any) => (
+                <TableRow key={row.invoiceId} hover>
+                  <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                    {formatDisplayDate(row.date, 'short')}
+                  </TableCell>
+                  <TableCell>{row.description}</TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(row.subtotal)}
+                  </TableCell>
+                  <TableCell align="right">{formatCurrency(row.gst)}</TableCell>
+                  <TableCell align="right">{formatCurrency(row.pst)}</TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 'bold' }}>
+                    {formatCurrency(row.netTotal)}
+                  </TableCell>
+                  <TableCell>
+                    {row.paymentMethod ? (
+                      <Chip label={humanize(row.paymentMethod)} size="small" />
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        Unpaid
+                      </Typography>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+              <TableRow sx={{ '& td': { borderTop: 2, fontWeight: 'bold' } }}>
+                <TableCell colSpan={2}>Total</TableCell>
+                <TableCell align="right">
+                  {formatCurrency(totals.subtotal)}
+                </TableCell>
+                <TableCell align="right">
+                  {formatCurrency(totals.gst)}
+                </TableCell>
+                <TableCell align="right">
+                  {formatCurrency(totals.pst)}
+                </TableCell>
+                <TableCell align="right">
+                  {formatCurrency(totals.netTotal)}
+                </TableCell>
+                <TableCell />
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+    );
   };
 
   const renderSummaryCards = () => {
@@ -404,9 +568,37 @@ export function Reports() {
                     <span>GST Paid on Purchase & Expense</span>
                   </Box>
                 </MenuItem>
+                {canRunSalesReport && (
+                  <MenuItem value="sales">
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <ListAlt fontSize="small" />
+                      <span>Invoice Sales</span>
+                    </Box>
+                  </MenuItem>
+                )}
               </Select>
             </FormControl>
           </Grid>
+
+          {reportType === 'sales' && (
+            <Grid size={{ xs: 12, md: 3 }}>
+              <FormControl fullWidth>
+                <InputLabel>Status</InputLabel>
+                <Select
+                  value={salesStatus}
+                  label="Status"
+                  onChange={(e) => setSalesStatus(e.target.value)}
+                >
+                  <MenuItem value={ALL_STATUSES}>All Statuses</MenuItem>
+                  {Object.values(InvoiceStatus).map((status) => (
+                    <MenuItem key={status} value={status}>
+                      {humanize(status)}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+          )}
 
           <Grid size={{ xs: 12, sm: 6, md: 3 }}>
             <TextField
@@ -465,6 +657,12 @@ export function Reports() {
             <CircularProgress size={60} />
           </Box>
         )}
+
+        {/* Invoice Sales Report Results */}
+        {!loading &&
+          reportType === 'sales' &&
+          salesReportData &&
+          renderSalesReport()}
 
         {/* Purchase & Expense Report Results */}
         {!loading &&
@@ -808,6 +1006,7 @@ export function Reports() {
           !reportData &&
           !taxReportData &&
           !gstPaidReportData &&
+          !salesReportData &&
           !error && (
             <Box
               sx={{
@@ -816,7 +1015,18 @@ export function Reports() {
                 color: 'text.secondary',
               }}
             >
-              {reportType === 'purchase' ? (
+              {reportType === 'sales' ? (
+                <>
+                  <ListAlt sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
+                  <Typography variant="h6" gutterBottom fontWeight="500">
+                    No Invoice Sales Report Generated
+                  </Typography>
+                  <Typography variant="body2">
+                    Select a date range and status, then click "Generate Report"
+                    to list invoices with sub total, GST, PST and net total
+                  </Typography>
+                </>
+              ) : reportType === 'purchase' ? (
                 <>
                   <Receipt sx={{ fontSize: 80, mb: 2, opacity: 0.2 }} />
                   <Typography variant="h6" gutterBottom fontWeight="500">

--- a/libs/data/src/index.ts
+++ b/libs/data/src/index.ts
@@ -25,6 +25,7 @@ export * from './lib/payout-rule.dto';
 export * from './lib/purchase-expense-invoice.dto';
 export * from './lib/square-payment.dto';
 export * from './lib/square-terminal.dto';
+export * from './lib/sales-report.dto';
 export * from './lib/tax-report.dto';
 export * from './lib/tire-sale.dto';
 export * from './lib/repair-order.dto';

--- a/libs/data/src/lib/sales-report.dto.ts
+++ b/libs/data/src/lib/sales-report.dto.ts
@@ -1,0 +1,53 @@
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { InvoiceStatus, PaymentMethod } from './prisma-enums';
+
+/**
+ * Sales report: customer invoices in a date range, one row per invoice, with
+ * per-column totals. Run by admins and accountants.
+ */
+export class SalesReportFilterDto {
+  /** Business calendar date (YYYY-MM-DD), inclusive. */
+  @IsDateString()
+  startDate!: string;
+
+  /** Business calendar date (YYYY-MM-DD), inclusive of the whole day. */
+  @IsDateString()
+  endDate!: string;
+
+  /** Omit to include every status. */
+  @IsEnum(InvoiceStatus)
+  @IsOptional()
+  status?: InvoiceStatus;
+}
+
+export class SalesReportRowDto {
+  invoiceId!: string;
+  invoiceNumber!: string;
+  /** Business calendar date in YYYY-MM-DD form — already timezone-resolved. */
+  date!: string;
+  /** Line items summarised, falling back to notes then the customer name. */
+  description!: string;
+  subtotal!: number;
+  gst!: number;
+  pst!: number;
+  netTotal!: number;
+  /** Null when the invoice has not been paid yet. */
+  paymentMethod!: PaymentMethod | null;
+  status!: InvoiceStatus;
+}
+
+/** Column totals across every row in the report. */
+export class SalesReportTotalsDto {
+  subtotal!: number;
+  gst!: number;
+  pst!: number;
+  netTotal!: number;
+}
+
+export class SalesReportResponseDto {
+  startDate!: string;
+  endDate!: string;
+  invoiceCount!: number;
+  rows!: SalesReportRowDto[];
+  totals!: SalesReportTotalsDto;
+}

--- a/server/src/reports/reports.controller.ts
+++ b/server/src/reports/reports.controller.ts
@@ -15,6 +15,10 @@ import {
   TaxReportResponseDto,
   GstPaidReportResponseDto,
 } from '@gt-automotive/data';
+import {
+  SalesReportFilterDto,
+  SalesReportResponseDto,
+} from '@gt-automotive/data';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleGuard } from '../auth/guards/role.guard';
@@ -53,6 +57,14 @@ export class ReportsController {
     @Query(ValidationPipe) filterDto: TaxReportFilterDto
   ): Promise<TaxReportResponseDto> {
     return this.reportsService.getTaxReport(filterDto);
+  }
+
+  @Get('sales-report')
+  @Roles('ADMIN', 'ACCOUNTANT')
+  async getSalesReport(
+    @Query(ValidationPipe) filterDto: SalesReportFilterDto
+  ): Promise<SalesReportResponseDto> {
+    return this.reportsService.getSalesReport(filterDto);
   }
 
   @Get('gst-paid-report')

--- a/server/src/reports/reports.service.spec.ts
+++ b/server/src/reports/reports.service.spec.ts
@@ -1,0 +1,217 @@
+import { BadRequestException } from '@nestjs/common';
+import { ReportsService } from './reports.service';
+
+/**
+ * Unit tests for ReportsService.getSalesReport. Prisma is mocked; the focus is
+ * the business-day range bounds, row mapping and the column totals.
+ */
+describe('ReportsService.getSalesReport', () => {
+  let service: ReportsService;
+  let findMany: jest.Mock;
+
+  const buildInvoice = (overrides: any = {}) => ({
+    id: 'inv-1',
+    invoiceNumber: 'INV-001',
+    invoiceDate: new Date(Date.UTC(2026, 0, 5)),
+    subtotal: 100,
+    gstAmount: 5,
+    pstAmount: 7,
+    total: 112,
+    paymentMethod: 'CASH',
+    status: 'PAID',
+    notes: null,
+    items: [{ description: 'Tire mount balance' }],
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    findMany = jest.fn().mockResolvedValue([]);
+    service = new ReportsService();
+    (service as any).prisma = { invoice: { findMany } };
+  });
+
+  it('bounds the range by business calendar dates, end day inclusive', async () => {
+    await service.getSalesReport({
+      startDate: '2026-01-05',
+      endDate: '2026-01-07',
+    });
+
+    const { where } = findMany.mock.calls[0][0];
+    // invoiceDate is pinned to midnight UTC, so the lower bound is that instant
+    // and the upper bound is the following day, exclusive.
+    expect(where.invoiceDate.gte).toEqual(new Date(Date.UTC(2026, 0, 5)));
+    expect(where.invoiceDate.lt).toEqual(new Date(Date.UTC(2026, 0, 8)));
+    expect(where.status).toBeUndefined();
+  });
+
+  it('covers a single-day range', async () => {
+    await service.getSalesReport({
+      startDate: '2026-01-05',
+      endDate: '2026-01-05',
+    });
+
+    const { where } = findMany.mock.calls[0][0];
+    expect(where.invoiceDate.gte).toEqual(new Date(Date.UTC(2026, 0, 5)));
+    expect(where.invoiceDate.lt).toEqual(new Date(Date.UTC(2026, 0, 6)));
+  });
+
+  it('applies the status filter when one is supplied', async () => {
+    await service.getSalesReport({
+      startDate: '2026-01-05',
+      endDate: '2026-01-07',
+      status: 'PAID',
+    });
+
+    expect(findMany.mock.calls[0][0].where.status).toBe('PAID');
+  });
+
+  it('rejects an end date before the start date', async () => {
+    await expect(
+      service.getSalesReport({
+        startDate: '2026-01-07',
+        endDate: '2026-01-05',
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it('maps an invoice onto a report row', async () => {
+    findMany.mockResolvedValue([buildInvoice()]);
+
+    const report = await service.getSalesReport({
+      startDate: '2026-01-05',
+      endDate: '2026-01-05',
+    });
+
+    expect(report.rows).toEqual([
+      {
+        invoiceId: 'inv-1',
+        invoiceNumber: 'INV-001',
+        date: '2026-01-05',
+        description: 'Tire mount balance',
+        subtotal: 100,
+        gst: 5,
+        pst: 7,
+        netTotal: 112,
+        paymentMethod: 'CASH',
+        status: 'PAID',
+      },
+    ]);
+    expect(report.invoiceCount).toBe(1);
+  });
+
+  it('reports zero tax for legacy invoices with no GST/PST split', async () => {
+    findMany.mockResolvedValue([
+      buildInvoice({ gstAmount: null, pstAmount: null }),
+    ]);
+
+    const report = await service.getSalesReport({
+      startDate: '2026-01-05',
+      endDate: '2026-01-05',
+    });
+
+    expect(report.rows[0].gst).toBe(0);
+    expect(report.rows[0].pst).toBe(0);
+  });
+
+  describe('description', () => {
+    const describeInvoice = async (overrides: any) => {
+      findMany.mockResolvedValue([buildInvoice(overrides)]);
+      const report = await service.getSalesReport({
+        startDate: '2026-01-05',
+        endDate: '2026-01-05',
+      });
+      return report.rows[0].description;
+    };
+
+    it('joins every line item', async () => {
+      expect(
+        await describeInvoice({
+          items: [{ description: 'Winter tire' }, { description: 'Disposal' }],
+        })
+      ).toBe('Winter tire, Disposal');
+    });
+
+    it('falls back to the notes when there are no items', async () => {
+      expect(
+        await describeInvoice({ items: [], notes: 'Roadside callout' })
+      ).toBe('Roadside callout');
+    });
+
+    it('falls back to a placeholder when there is nothing to show', async () => {
+      expect(await describeInvoice({ items: [], notes: '   ' })).toBe(
+        'No description'
+      );
+    });
+  });
+
+  describe('totals', () => {
+    it('sums each money column across the rows', async () => {
+      findMany.mockResolvedValue([
+        buildInvoice({ subtotal: 100, gstAmount: 5, pstAmount: 7, total: 112 }),
+        buildInvoice({
+          id: 'inv-2',
+          subtotal: 50.5,
+          gstAmount: 2.53,
+          pstAmount: 3.54,
+          total: 56.57,
+        }),
+      ]);
+
+      const report = await service.getSalesReport({
+        startDate: '2026-01-05',
+        endDate: '2026-01-05',
+      });
+
+      expect(report.totals).toEqual({
+        subtotal: 150.5,
+        gst: 7.53,
+        pst: 10.54,
+        netTotal: 168.57,
+      });
+    });
+
+    it('rounds away floating-point drift so totals match the rows', async () => {
+      // 0.1 + 0.2 sums to 0.30000000000000004 in binary floating point.
+      findMany.mockResolvedValue([
+        buildInvoice({
+          subtotal: 0.1,
+          gstAmount: 0.1,
+          pstAmount: 0.1,
+          total: 0.1,
+        }),
+        buildInvoice({
+          id: 'inv-2',
+          subtotal: 0.2,
+          gstAmount: 0.2,
+          pstAmount: 0.2,
+          total: 0.2,
+        }),
+      ]);
+
+      const report = await service.getSalesReport({
+        startDate: '2026-01-05',
+        endDate: '2026-01-05',
+      });
+
+      expect(report.totals.subtotal).toBe(0.3);
+      expect(report.totals.netTotal).toBe(0.3);
+    });
+
+    it('returns zeroed totals for an empty range', async () => {
+      const report = await service.getSalesReport({
+        startDate: '2026-01-05',
+        endDate: '2026-01-07',
+      });
+
+      expect(report.rows).toEqual([]);
+      expect(report.invoiceCount).toBe(0);
+      expect(report.totals).toEqual({
+        subtotal: 0,
+        gst: 0,
+        pst: 0,
+        netTotal: 0,
+      });
+    });
+  });
+});

--- a/server/src/reports/reports.service.ts
+++ b/server/src/reports/reports.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaClient, RecurringPeriod } from '@prisma/client';
 import {
   ExpenseReportFilterDto,
@@ -15,6 +15,16 @@ import {
   GstPaidReportResponseDto,
   MonthlyGstPaidBreakdownDto,
 } from '@gt-automotive/data';
+import {
+  SalesReportFilterDto,
+  SalesReportResponseDto,
+  SalesReportRowDto,
+} from '@gt-automotive/data';
+import {
+  extractBusinessDate,
+  shiftBusinessDate,
+  toBusinessCalendarDate,
+} from '../config/timezone.config';
 
 @Injectable()
 export class ReportsService {
@@ -692,6 +702,103 @@ export class ReportsService {
         },
       },
     };
+  }
+
+  /**
+   * Sales report: one row per customer invoice in the range, plus column totals.
+   *
+   * Dates: `invoiceDate` holds a business calendar date pinned to midnight UTC
+   * (see toBusinessCalendarDate), so the range is bounded by the same
+   * representation rather than by businessDayUtcRange() — the latter bounds real
+   * timestamp columns (createdAt/paidAt) and would exclude midnight-UTC dates.
+   * The upper bound is the day *after* endDate, exclusive, which keeps the whole
+   * end day in range for older rows that still carry a real timestamp.
+   */
+  async getSalesReport(
+    filterDto: SalesReportFilterDto
+  ): Promise<SalesReportResponseDto> {
+    const startDate = extractBusinessDate(filterDto.startDate);
+    const endDate = extractBusinessDate(filterDto.endDate);
+
+    if (endDate < startDate) {
+      throw new BadRequestException('endDate cannot be before startDate');
+    }
+
+    const where: any = {
+      invoiceDate: {
+        gte: toBusinessCalendarDate(startDate),
+        lt: toBusinessCalendarDate(shiftBusinessDate(endDate, 1)),
+      },
+    };
+    if (filterDto.status) {
+      where.status = filterDto.status;
+    }
+
+    const invoices = await this.prisma.invoice.findMany({
+      where,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        invoiceDate: true,
+        subtotal: true,
+        gstAmount: true,
+        pstAmount: true,
+        total: true,
+        paymentMethod: true,
+        status: true,
+        notes: true,
+        items: { select: { description: true } },
+      },
+      orderBy: [{ invoiceDate: 'asc' }, { invoiceNumber: 'asc' }],
+    });
+
+    const rows: SalesReportRowDto[] = invoices.map((invoice) => ({
+      invoiceId: invoice.id,
+      invoiceNumber: invoice.invoiceNumber,
+      date: extractBusinessDate(invoice.invoiceDate),
+      description: this.buildSalesRowDescription(invoice.items, invoice.notes),
+      subtotal: Number(invoice.subtotal),
+      // gstAmount/pstAmount are null on invoices created through the legacy
+      // combined-taxRate path; those carry their tax in taxAmount only, so the
+      // tax columns read 0 for them. Matches getTaxReport's existing treatment.
+      gst: Number(invoice.gstAmount || 0),
+      pst: Number(invoice.pstAmount || 0),
+      netTotal: Number(invoice.total),
+      paymentMethod: invoice.paymentMethod,
+      status: invoice.status,
+    }));
+
+    const sum = (pick: (row: SalesReportRowDto) => number) =>
+      this.roundMoney(rows.reduce((acc, row) => acc + pick(row), 0));
+
+    return {
+      startDate,
+      endDate,
+      invoiceCount: rows.length,
+      rows,
+      totals: {
+        subtotal: sum((row) => row.subtotal),
+        gst: sum((row) => row.gst),
+        pst: sum((row) => row.pst),
+        netTotal: sum((row) => row.netTotal),
+      },
+    };
+  }
+
+  private buildSalesRowDescription(
+    items: { description: string }[],
+    notes: string | null
+  ): string {
+    const fromItems = items
+      .map((item) => item.description?.trim())
+      .filter((description): description is string => !!description)
+      .join(', ');
+    return fromItems || notes?.trim() || 'No description';
+  }
+
+  /** Decimal(10,2) columns are exact, but summing them as floats is not. */
+  private roundMoney(amount: number): number {
+    return Math.round((amount + Number.EPSILON) * 100) / 100;
   }
 
   async getTaxReport(

--- a/server/src/reports/reports.service.ts
+++ b/server/src/reports/reports.service.ts
@@ -20,8 +20,12 @@ import {
 export class ReportsService {
   private prisma = new PrismaClient();
 
-  async getExpenseReport(filterDto: ExpenseReportFilterDto): Promise<ExpenseReportResponseDto> {
-    const startDate = filterDto.startDate ? new Date(filterDto.startDate) : undefined;
+  async getExpenseReport(
+    filterDto: ExpenseReportFilterDto
+  ): Promise<ExpenseReportResponseDto> {
+    const startDate = filterDto.startDate
+      ? new Date(filterDto.startDate)
+      : undefined;
     const endDate = filterDto.endDate ? new Date(filterDto.endDate) : undefined;
 
     // Build filter conditions for legacy tables
@@ -31,12 +35,24 @@ export class ReportsService {
     const unifiedWhere: any = {};
 
     if (startDate) {
-      purchaseWhere.invoiceDate = { ...purchaseWhere.invoiceDate, gte: startDate };
-      expenseWhere.invoiceDate = { ...expenseWhere.invoiceDate, gte: startDate };
-      unifiedWhere.invoiceDate = { ...unifiedWhere.invoiceDate, gte: startDate };
+      purchaseWhere.invoiceDate = {
+        ...purchaseWhere.invoiceDate,
+        gte: startDate,
+      };
+      expenseWhere.invoiceDate = {
+        ...expenseWhere.invoiceDate,
+        gte: startDate,
+      };
+      unifiedWhere.invoiceDate = {
+        ...unifiedWhere.invoiceDate,
+        gte: startDate,
+      };
     }
     if (endDate) {
-      purchaseWhere.invoiceDate = { ...purchaseWhere.invoiceDate, lte: endDate };
+      purchaseWhere.invoiceDate = {
+        ...purchaseWhere.invoiceDate,
+        lte: endDate,
+      };
       expenseWhere.invoiceDate = { ...expenseWhere.invoiceDate, lte: endDate };
       unifiedWhere.invoiceDate = { ...unifiedWhere.invoiceDate, lte: endDate };
     }
@@ -69,43 +85,90 @@ export class ReportsService {
     ]);
 
     // Split unified invoices by type
-    const unifiedPurchases = unifiedInvoices.filter(inv => inv.type === 'PURCHASE');
-    const unifiedExpenses = unifiedInvoices.filter(inv => inv.type === 'EXPENSE');
+    const unifiedPurchases = unifiedInvoices.filter(
+      (inv) => inv.type === 'PURCHASE'
+    );
+    const unifiedExpenses = unifiedInvoices.filter(
+      (inv) => inv.type === 'EXPENSE'
+    );
 
     // Combine legacy and unified invoices
     const purchaseInvoices = [...legacyPurchaseInvoices, ...unifiedPurchases];
     const expenseInvoices = [...legacyExpenseInvoices, ...unifiedExpenses];
 
     // Calculate summary statistics
-    const totalPurchaseAmount = purchaseInvoices.reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
-    const totalExpenseAmount = expenseInvoices.reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
+    const totalPurchaseAmount = purchaseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.totalAmount),
+      0
+    );
+    const totalExpenseAmount = expenseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.totalAmount),
+      0
+    );
 
     // For legacy tables, filter by status; unified table doesn't have status
-    const paidLegacyPurchases = legacyPurchaseInvoices.filter(inv => inv.status === 'PAID');
-    const paidLegacyExpenses = legacyExpenseInvoices.filter(inv => inv.status === 'PAID');
+    const paidLegacyPurchases = legacyPurchaseInvoices.filter(
+      (inv) => inv.status === 'PAID'
+    );
+    const paidLegacyExpenses = legacyExpenseInvoices.filter(
+      (inv) => inv.status === 'PAID'
+    );
     // Unified invoices are considered "paid" since there's no status field
     const paidTotal =
-      paidLegacyPurchases.reduce((sum, inv) => sum + Number(inv.totalAmount), 0) +
-      paidLegacyExpenses.reduce((sum, inv) => sum + Number(inv.totalAmount), 0) +
+      paidLegacyPurchases.reduce(
+        (sum, inv) => sum + Number(inv.totalAmount),
+        0
+      ) +
+      paidLegacyExpenses.reduce(
+        (sum, inv) => sum + Number(inv.totalAmount),
+        0
+      ) +
       unifiedInvoices.reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
 
-    const pendingLegacyPurchases = legacyPurchaseInvoices.filter(inv => inv.status === 'PENDING');
-    const pendingLegacyExpenses = legacyExpenseInvoices.filter(inv => inv.status === 'PENDING');
+    const pendingLegacyPurchases = legacyPurchaseInvoices.filter(
+      (inv) => inv.status === 'PENDING'
+    );
+    const pendingLegacyExpenses = legacyExpenseInvoices.filter(
+      (inv) => inv.status === 'PENDING'
+    );
     const pendingTotal =
-      pendingLegacyPurchases.reduce((sum, inv) => sum + Number(inv.totalAmount), 0) +
-      pendingLegacyExpenses.reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
+      pendingLegacyPurchases.reduce(
+        (sum, inv) => sum + Number(inv.totalAmount),
+        0
+      ) +
+      pendingLegacyExpenses.reduce(
+        (sum, inv) => sum + Number(inv.totalAmount),
+        0
+      );
 
-    const overdueLegacyPurchases = legacyPurchaseInvoices.filter(inv => inv.status === 'OVERDUE');
-    const overdueLegacyExpenses = legacyExpenseInvoices.filter(inv => inv.status === 'OVERDUE');
+    const overdueLegacyPurchases = legacyPurchaseInvoices.filter(
+      (inv) => inv.status === 'OVERDUE'
+    );
+    const overdueLegacyExpenses = legacyExpenseInvoices.filter(
+      (inv) => inv.status === 'OVERDUE'
+    );
     const overdueTotal =
-      overdueLegacyPurchases.reduce((sum, inv) => sum + Number(inv.totalAmount), 0) +
-      overdueLegacyExpenses.reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
+      overdueLegacyPurchases.reduce(
+        (sum, inv) => sum + Number(inv.totalAmount),
+        0
+      ) +
+      overdueLegacyExpenses.reduce(
+        (sum, inv) => sum + Number(inv.totalAmount),
+        0
+      );
 
     // Get vendor analysis (includes unified table)
-    const topVendorsBySpending = await this.getTopVendorsBySpending(purchaseWhere, expenseWhere, unifiedWhere);
+    const topVendorsBySpending = await this.getTopVendorsBySpending(
+      purchaseWhere,
+      expenseWhere,
+      unifiedWhere
+    );
 
     // Get monthly trends (includes unified table)
-    const monthlyTrends = this.calculateMonthlyTrends(purchaseInvoices, expenseInvoices);
+    const monthlyTrends = this.calculateMonthlyTrends(
+      purchaseInvoices,
+      expenseInvoices
+    );
 
     return {
       totalPurchases: purchaseInvoices.length,
@@ -124,7 +187,10 @@ export class ReportsService {
     };
   }
 
-  private async getPurchasesByCategory(legacyWhere: any, unifiedWhere: any): Promise<CategorySummaryDto[]> {
+  private async getPurchasesByCategory(
+    legacyWhere: any,
+    unifiedWhere: any
+  ): Promise<CategorySummaryDto[]> {
     // Get legacy purchase invoices grouped by category
     const legacyGroupedData = await this.prisma.purchaseInvoice.groupBy({
       by: ['category'],
@@ -134,12 +200,14 @@ export class ReportsService {
     });
 
     // Get unified purchase invoices grouped by category
-    const unifiedGroupedData = await this.prisma.purchaseExpenseInvoice.groupBy({
-      by: ['category'],
-      where: { ...unifiedWhere, type: 'PURCHASE' },
-      _count: { id: true },
-      _sum: { totalAmount: true },
-    });
+    const unifiedGroupedData = await this.prisma.purchaseExpenseInvoice.groupBy(
+      {
+        by: ['category'],
+        where: { ...unifiedWhere, type: 'PURCHASE' },
+        _count: { id: true },
+        _sum: { totalAmount: true },
+      }
+    );
 
     // Merge categories from both sources
     const categoryMap = new Map<string, CategorySummaryDto>();
@@ -151,15 +219,15 @@ export class ReportsService {
       });
 
       const paidAmount = categoryInvoices
-        .filter(inv => inv.status === 'PAID')
+        .filter((inv) => inv.status === 'PAID')
         .reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
 
       const pendingAmount = categoryInvoices
-        .filter(inv => inv.status === 'PENDING')
+        .filter((inv) => inv.status === 'PENDING')
         .reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
 
       const overdueAmount = categoryInvoices
-        .filter(inv => inv.status === 'OVERDUE')
+        .filter((inv) => inv.status === 'OVERDUE')
         .reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
 
       categoryMap.set(group.category, {
@@ -196,7 +264,10 @@ export class ReportsService {
     return Array.from(categoryMap.values());
   }
 
-  private async getExpensesByCategory(legacyWhere: any, unifiedWhere: any): Promise<CategorySummaryDto[]> {
+  private async getExpensesByCategory(
+    legacyWhere: any,
+    unifiedWhere: any
+  ): Promise<CategorySummaryDto[]> {
     // Get legacy expense invoices grouped by category
     const legacyGroupedData = await this.prisma.expenseInvoice.groupBy({
       by: ['category'],
@@ -206,12 +277,14 @@ export class ReportsService {
     });
 
     // Get unified expense invoices grouped by category
-    const unifiedGroupedData = await this.prisma.purchaseExpenseInvoice.groupBy({
-      by: ['category'],
-      where: { ...unifiedWhere, type: 'EXPENSE' },
-      _count: { id: true },
-      _sum: { totalAmount: true },
-    });
+    const unifiedGroupedData = await this.prisma.purchaseExpenseInvoice.groupBy(
+      {
+        by: ['category'],
+        where: { ...unifiedWhere, type: 'EXPENSE' },
+        _count: { id: true },
+        _sum: { totalAmount: true },
+      }
+    );
 
     // Merge categories from both sources
     const categoryMap = new Map<string, CategorySummaryDto>();
@@ -223,15 +296,15 @@ export class ReportsService {
       });
 
       const paidAmount = categoryInvoices
-        .filter(inv => inv.status === 'PAID')
+        .filter((inv) => inv.status === 'PAID')
         .reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
 
       const pendingAmount = categoryInvoices
-        .filter(inv => inv.status === 'PENDING')
+        .filter((inv) => inv.status === 'PENDING')
         .reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
 
       const overdueAmount = categoryInvoices
-        .filter(inv => inv.status === 'OVERDUE')
+        .filter((inv) => inv.status === 'OVERDUE')
         .reduce((sum, inv) => sum + Number(inv.totalAmount), 0);
 
       categoryMap.set(group.category, {
@@ -271,7 +344,7 @@ export class ReportsService {
   private async getTopVendorsBySpending(
     purchaseWhere: any,
     expenseWhere: any,
-    unifiedWhere: any,
+    unifiedWhere: any
   ): Promise<VendorSummaryDto[]> {
     const vendorMap = new Map<string, VendorSummaryDto>();
 
@@ -360,7 +433,7 @@ export class ReportsService {
 
   private calculateMonthlyTrends(
     purchaseInvoices: any[],
-    expenseInvoices: any[],
+    expenseInvoices: any[]
   ): MonthlyTrendDto[] {
     const monthMap = new Map<string, MonthlyTrendDto>();
 
@@ -403,10 +476,14 @@ export class ReportsService {
     }
 
     // Sort by month (most recent first)
-    return Array.from(monthMap.values()).sort((a, b) => b.month.localeCompare(a.month));
+    return Array.from(monthMap.values()).sort((a, b) =>
+      b.month.localeCompare(a.month)
+    );
   }
 
-  private async getRecurringExpenses(where: any): Promise<RecurringExpenseSummaryDto[]> {
+  private async getRecurringExpenses(
+    where: any
+  ): Promise<RecurringExpenseSummaryDto[]> {
     const recurring = await this.prisma.expenseInvoice.findMany({
       where: {
         ...where,
@@ -415,15 +492,19 @@ export class ReportsService {
       orderBy: { invoiceDate: 'desc' },
     });
 
-    return recurring.map(expense => ({
+    return recurring.map((expense) => ({
       id: expense.id,
       vendorName: expense.vendorName,
       description: expense.description,
       category: expense.category,
       amount: Number(expense.totalAmount),
-      recurringPeriod: (expense.recurringPeriod as RecurringPeriod) || 'MONTHLY',
+      recurringPeriod:
+        (expense.recurringPeriod as RecurringPeriod) || 'MONTHLY',
       lastPaymentDate: expense.paymentDate,
-      nextDueDate: this.calculateNextDueDate(expense.invoiceDate, expense.recurringPeriod || undefined),
+      nextDueDate: this.calculateNextDueDate(
+        expense.invoiceDate,
+        expense.recurringPeriod || undefined
+      ),
       status: expense.status,
     })) as RecurringExpenseSummaryDto[];
   }
@@ -551,15 +632,27 @@ export class ReportsService {
     ]);
 
     // Combine legacy and unified counts/totals
-    const mtdPurchasesCount = mtdLegacyPurchases._count.id + mtdUnifiedPurchases._count.id;
-    const mtdPurchasesTotal = Number(mtdLegacyPurchases._sum.totalAmount || 0) + Number(mtdUnifiedPurchases._sum.totalAmount || 0);
-    const mtdExpensesCount = mtdLegacyExpenses._count.id + mtdUnifiedExpenses._count.id;
-    const mtdExpensesTotal = Number(mtdLegacyExpenses._sum.totalAmount || 0) + Number(mtdUnifiedExpenses._sum.totalAmount || 0);
+    const mtdPurchasesCount =
+      mtdLegacyPurchases._count.id + mtdUnifiedPurchases._count.id;
+    const mtdPurchasesTotal =
+      Number(mtdLegacyPurchases._sum.totalAmount || 0) +
+      Number(mtdUnifiedPurchases._sum.totalAmount || 0);
+    const mtdExpensesCount =
+      mtdLegacyExpenses._count.id + mtdUnifiedExpenses._count.id;
+    const mtdExpensesTotal =
+      Number(mtdLegacyExpenses._sum.totalAmount || 0) +
+      Number(mtdUnifiedExpenses._sum.totalAmount || 0);
 
-    const ytdPurchasesCount = ytdLegacyPurchases._count.id + ytdUnifiedPurchases._count.id;
-    const ytdPurchasesTotal = Number(ytdLegacyPurchases._sum.totalAmount || 0) + Number(ytdUnifiedPurchases._sum.totalAmount || 0);
-    const ytdExpensesCount = ytdLegacyExpenses._count.id + ytdUnifiedExpenses._count.id;
-    const ytdExpensesTotal = Number(ytdLegacyExpenses._sum.totalAmount || 0) + Number(ytdUnifiedExpenses._sum.totalAmount || 0);
+    const ytdPurchasesCount =
+      ytdLegacyPurchases._count.id + ytdUnifiedPurchases._count.id;
+    const ytdPurchasesTotal =
+      Number(ytdLegacyPurchases._sum.totalAmount || 0) +
+      Number(ytdUnifiedPurchases._sum.totalAmount || 0);
+    const ytdExpensesCount =
+      ytdLegacyExpenses._count.id + ytdUnifiedExpenses._count.id;
+    const ytdExpensesTotal =
+      Number(ytdLegacyExpenses._sum.totalAmount || 0) +
+      Number(ytdUnifiedExpenses._sum.totalAmount || 0);
 
     return {
       mtd: {
@@ -601,8 +694,12 @@ export class ReportsService {
     };
   }
 
-  async getTaxReport(filterDto: TaxReportFilterDto): Promise<TaxReportResponseDto> {
-    const startDate = filterDto.startDate ? new Date(filterDto.startDate) : undefined;
+  async getTaxReport(
+    filterDto: TaxReportFilterDto
+  ): Promise<TaxReportResponseDto> {
+    const startDate = filterDto.startDate
+      ? new Date(filterDto.startDate)
+      : undefined;
     const endDate = filterDto.endDate ? new Date(filterDto.endDate) : undefined;
 
     // Build filter conditions - ONLY PAID invoices
@@ -628,8 +725,14 @@ export class ReportsService {
     });
 
     // Calculate total tax collected (from PAID invoices only)
-    const totalGstCollected = invoices.reduce((sum, inv) => sum + Number(inv.gstAmount || 0), 0);
-    const totalPstCollected = invoices.reduce((sum, inv) => sum + Number(inv.pstAmount || 0), 0);
+    const totalGstCollected = invoices.reduce(
+      (sum, inv) => sum + Number(inv.gstAmount || 0),
+      0
+    );
+    const totalPstCollected = invoices.reduce(
+      (sum, inv) => sum + Number(inv.pstAmount || 0),
+      0
+    );
     const totalTaxCollected = totalGstCollected + totalPstCollected;
 
     // Calculate monthly breakdown
@@ -644,7 +747,9 @@ export class ReportsService {
     };
   }
 
-  private calculateMonthlyTaxBreakdown(invoices: any[]): MonthlyTaxBreakdownDto[] {
+  private calculateMonthlyTaxBreakdown(
+    invoices: any[]
+  ): MonthlyTaxBreakdownDto[] {
     const monthMap = new Map<string, MonthlyTaxBreakdownDto>();
 
     for (const invoice of invoices) {
@@ -660,17 +765,24 @@ export class ReportsService {
       existing.invoiceCount++;
       existing.gstCollected += Number(invoice.gstAmount || 0);
       existing.pstCollected += Number(invoice.pstAmount || 0);
-      existing.totalTaxCollected = existing.gstCollected + existing.pstCollected;
+      existing.totalTaxCollected =
+        existing.gstCollected + existing.pstCollected;
 
       monthMap.set(month, existing);
     }
 
     // Sort by month (most recent first)
-    return Array.from(monthMap.values()).sort((a, b) => b.month.localeCompare(a.month));
+    return Array.from(monthMap.values()).sort((a, b) =>
+      b.month.localeCompare(a.month)
+    );
   }
 
-  async getGstPaidReport(filterDto: TaxReportFilterDto): Promise<GstPaidReportResponseDto> {
-    const startDate = filterDto.startDate ? new Date(filterDto.startDate) : undefined;
+  async getGstPaidReport(
+    filterDto: TaxReportFilterDto
+  ): Promise<GstPaidReportResponseDto> {
+    const startDate = filterDto.startDate
+      ? new Date(filterDto.startDate)
+      : undefined;
     const endDate = filterDto.endDate ? new Date(filterDto.endDate) : undefined;
 
     // Build filter conditions for legacy tables (PAID invoices only)
@@ -687,7 +799,10 @@ export class ReportsService {
     // Build filter conditions for unified table (all invoices - no status field)
     const unifiedWhere: any = {};
     if (startDate) {
-      unifiedWhere.invoiceDate = { ...unifiedWhere.invoiceDate, gte: startDate };
+      unifiedWhere.invoiceDate = {
+        ...unifiedWhere.invoiceDate,
+        gte: startDate,
+      };
     }
     if (endDate) {
       unifiedWhere.invoiceDate = { ...unifiedWhere.invoiceDate, lte: endDate };
@@ -731,22 +846,50 @@ export class ReportsService {
     });
 
     // Split unified invoices by type
-    const unifiedPurchaseInvoices = unifiedInvoices.filter(inv => inv.type === 'PURCHASE');
-    const unifiedExpenseInvoices = unifiedInvoices.filter(inv => inv.type === 'EXPENSE');
+    const unifiedPurchaseInvoices = unifiedInvoices.filter(
+      (inv) => inv.type === 'PURCHASE'
+    );
+    const unifiedExpenseInvoices = unifiedInvoices.filter(
+      (inv) => inv.type === 'EXPENSE'
+    );
 
     // Combine legacy and unified invoices
-    const purchaseInvoices = [...legacyPurchaseInvoices, ...unifiedPurchaseInvoices];
-    const expenseInvoices = [...legacyExpenseInvoices, ...unifiedExpenseInvoices];
+    const purchaseInvoices = [
+      ...legacyPurchaseInvoices,
+      ...unifiedPurchaseInvoices,
+    ];
+    const expenseInvoices = [
+      ...legacyExpenseInvoices,
+      ...unifiedExpenseInvoices,
+    ];
 
     // Calculate tax paid from purchase invoices
-    const purchaseGstPaid = purchaseInvoices.reduce((sum, inv) => sum + Number(inv.gstAmount || 0), 0);
-    const purchasePstPaid = purchaseInvoices.reduce((sum, inv) => sum + Number(inv.pstAmount || 0), 0);
-    const purchaseHstPaid = purchaseInvoices.reduce((sum, inv) => sum + Number(inv.hstAmount || 0), 0);
+    const purchaseGstPaid = purchaseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.gstAmount || 0),
+      0
+    );
+    const purchasePstPaid = purchaseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.pstAmount || 0),
+      0
+    );
+    const purchaseHstPaid = purchaseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.hstAmount || 0),
+      0
+    );
 
     // Calculate tax paid from expense invoices
-    const expenseGstPaid = expenseInvoices.reduce((sum, inv) => sum + Number(inv.gstAmount || 0), 0);
-    const expensePstPaid = expenseInvoices.reduce((sum, inv) => sum + Number(inv.pstAmount || 0), 0);
-    const expenseHstPaid = expenseInvoices.reduce((sum, inv) => sum + Number(inv.hstAmount || 0), 0);
+    const expenseGstPaid = expenseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.gstAmount || 0),
+      0
+    );
+    const expensePstPaid = expenseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.pstAmount || 0),
+      0
+    );
+    const expenseHstPaid = expenseInvoices.reduce(
+      (sum, inv) => sum + Number(inv.hstAmount || 0),
+      0
+    );
 
     // Calculate totals
     const totalGstPaid = purchaseGstPaid + expenseGstPaid;
@@ -755,7 +898,10 @@ export class ReportsService {
     const totalTaxPaid = totalGstPaid + totalPstPaid + totalHstPaid;
 
     // Calculate monthly breakdown
-    const monthlyBreakdown = this.calculateMonthlyGstPaidBreakdown(purchaseInvoices, expenseInvoices);
+    const monthlyBreakdown = this.calculateMonthlyGstPaidBreakdown(
+      purchaseInvoices,
+      expenseInvoices
+    );
 
     return {
       totalPurchaseInvoices: purchaseInvoices.length,
@@ -777,7 +923,7 @@ export class ReportsService {
 
   private calculateMonthlyGstPaidBreakdown(
     purchaseInvoices: any[],
-    expenseInvoices: any[],
+    expenseInvoices: any[]
   ): MonthlyGstPaidBreakdownDto[] {
     const monthMap = new Map<string, MonthlyGstPaidBreakdownDto>();
 
@@ -840,10 +986,13 @@ export class ReportsService {
       data.totalGstPaid = data.purchaseGstPaid + data.expenseGstPaid;
       data.totalPstPaid = data.purchasePstPaid + data.expensePstPaid;
       data.totalHstPaid = data.purchaseHstPaid + data.expenseHstPaid;
-      data.totalTaxPaid = data.totalGstPaid + data.totalPstPaid + data.totalHstPaid;
+      data.totalTaxPaid =
+        data.totalGstPaid + data.totalPstPaid + data.totalHstPaid;
     }
 
     // Sort by month (most recent first)
-    return Array.from(monthMap.values()).sort((a, b) => b.month.localeCompare(a.month));
+    return Array.from(monthMap.values()).sort((a, b) =>
+      b.month.localeCompare(a.month)
+    );
   }
 }


### PR DESCRIPTION
Closes [GA-49](https://gt-automotives.atlassian.net/browse/GA-49).

Admins and accountants can list customer invoices for a date range and status, with a row per invoice (date, description, sub total, GST, PST, net total, mode of payment) and a totals row summing each money column.

**Review the second commit only** — the first is a pure prettier reformat. Both touched files predate the prettier hook, so editing them at all made the hook rewrite them wholesale (~600 lines of noise). Splitting it keeps the feature diff at ~230 lines.

## Backend

New `GET /api/reports/sales-report`, guarded `@Roles('ADMIN', 'ACCOUNTANT')`. DTOs live in `libs/data` (`sales-report.dto.ts`); rows and totals are both computed server-side, and totals are rounded because summing `Decimal(10,2)` columns as floats drifts.

## Date filtering — the ticket's AC was wrong here

GA-49 told the implementer to filter with `businessDayUtcRange()`. That would have silently dropped rows. `invoiceDate` is not a timestamp — it's a business calendar date pinned to **midnight UTC** by `toBusinessCalendarDate()`. `businessDayUtcRange('2025-11-05')` spans Nov 5 08:00 → Nov 6 08:00 UTC, which excludes a Nov 5 midnight-UTC value entirely.

It's bounded with the same midnight-UTC representation instead, upper bound exclusive at the day *after* `endDate`, so the whole end day is covered including older rows that still carry a real timestamp. (`businessDayUtcRange()` remains correct for `createdAt`/`paidAt`/`openedAt` — just not for this column.)

Same story on display: the AC said `formatBusinessDate()`, which shifts a `YYYY-MM-DD` string back a day. Used `formatDisplayDate(date, 'short')`, which parses the parts directly.

## Frontend

Added as a report type on the existing Financial Reports page rather than a new page — that page already carries the date range and Generate Report controls and is already in both the admin and accountant navs, so a separate page would have duplicated it. The option is hidden for supervisors and foremen, who share the page but would get a 403 from the endpoint.

## Verification

- 580 tests pass. 12 new backend cases: range bounds, single-day range, status filter, end-before-start → 400, row mapping, description fallback chain, column totals, float rounding, empty range.
- Lint 0 errors; `tsc --noEmit` clean on webApp and server.
- Ran the real Prisma query against a local DB — the mocked unit tests would not catch a bad `select`. It returned real rows, confirmed `invoiceDate` values are midnight UTC as assumed, and confirmed sub + GST + PST reconciles to net total.

## Caveats

- **Legacy tax rows.** Invoices created through the older combined-`taxRate` path have null `gstAmount`/`pstAmount` and carry tax in `taxAmount` only, so their GST/PST columns read 0 while the net total still includes tax. Followed the existing `getTaxReport` precedent rather than inventing an allocation. 0 of 70 local invoices are affected; production may differ.
- **Not exercised in the browser.** Everything above is tests, typecheck and a direct DB query — the page has not been loaded and the button has not been clicked.
- CSV/PDF export, printing and emailing remain out of scope per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)