### PR TITLE
feat(invoices): declined services section, customer signature and terms (GA-51)

### DIFF
--- a/apps/webApp/src/app/app.tsx
+++ b/apps/webApp/src/app/app.tsx
@@ -84,6 +84,7 @@ import { BookingRequests } from './pages/admin/BookingRequests';
 
 // SMS Pages
 import { SmsHistory } from './pages/admin/sms/SmsHistory';
+import AdminSettings from './pages/admin/Settings';
 
 // Email Pages
 import EmployeeSchedule from './pages/admin/EmployeeSchedule';
@@ -326,7 +327,7 @@ export function App() {
               />
               <Route path="analytics" element={<div>Analytics</div>} />
               <Route path="security" element={<div>Security Settings</div>} />
-              <Route path="settings" element={<div>System Settings</div>} />
+              <Route path="settings" element={<AdminSettings />} />
               <Route
                 path="tire-commissions"
                 element={<CommissionManagement />}

--- a/apps/webApp/src/app/components/invoices/InvoiceDetailsDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceDetailsDialog.tsx
@@ -38,13 +38,16 @@ import {
   Cancel as CancelIcon,
   MoreVert as MoreVertIcon,
   Receipt as ReceiptIcon,
+  Draw as DrawIcon,
 } from '@mui/icons-material';
 import { TransitionProps } from '@mui/material/transitions';
 import { invoiceService, Invoice } from '../../requests/invoice.requests';
 import { useAuth } from '../../hooks/useAuth';
 import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
 import { SquarePaymentForm } from '../payments/SquarePaymentForm';
+import { SignatureDialog } from './SignatureDialog';
 import { colors } from '../../theme/colors';
+import { formatBusinessDate } from '../../utils/dateUtils';
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
@@ -91,7 +94,11 @@ export const InvoiceDetailsDialog: React.FC<InvoiceDetailsDialogProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [paymentDialogOpen, setPaymentDialogOpen] = useState(false);
+  const [signatureDialogOpen, setSignatureDialogOpen] = useState(false);
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
+  // Customers view their own invoices here too — they must not be able to
+  // capture or replace the signature on their own record.
+  const canManageSignature = isStaff || isAdmin;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -217,6 +224,56 @@ export const InvoiceDetailsDialog: React.FC<InvoiceDetailsDialogProps> = ({
   };
 
   const canManageInvoice = isStaff || isAdmin;
+
+  const hasDeclinedItems = !!invoice?.declinedItems?.length;
+
+  // Rendered either inside the declined-services card or on its own, mirroring
+  // where the signature prints on the invoice itself.
+  const signatureSection = invoice ? (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 1,
+        }}
+      >
+        <Typography variant={hasDeclinedItems ? 'subtitle1' : 'h6'}>
+          Customer Signature
+        </Typography>
+        {canManageSignature && (
+          <Button
+            size="small"
+            startIcon={<DrawIcon />}
+            onClick={() => setSignatureDialogOpen(true)}
+          >
+            {invoice.signatureUrl ? 'Replace' : 'Capture'}
+          </Button>
+        )}
+      </Box>
+      {invoice.signatureUrl ? (
+        <>
+          <Box
+            component="img"
+            src={invoice.signatureUrl}
+            alt="Customer signature"
+            sx={{ display: 'block', maxHeight: 70, maxWidth: '100%' }}
+          />
+          <Typography variant="caption" color="text.secondary">
+            {invoice.signatureSignedByName || getCustomerName(invoice)}
+            {invoice.signatureSignedAt
+              ? ` — ${formatBusinessDate(invoice.signatureSignedAt)}`
+              : ''}
+          </Typography>
+        </>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          Not signed. The printed invoice shows a blank signature line.
+        </Typography>
+      )}
+    </>
+  ) : null;
 
   return (
     <>
@@ -664,6 +721,53 @@ export const InvoiceDetailsDialog: React.FC<InvoiceDetailsDialogProps> = ({
                       </CardContent>
                     </Card>
                   )}
+
+                  {/* Declined work sits directly below the notes, matching the
+                      printed invoice, and is styled so it can't be mistaken for
+                      billed line items. The signature lives inside this box when
+                      work was declined, so it reads as acknowledgement of that
+                      list — same arrangement as the printed copy. */}
+                  {hasDeclinedItems ? (
+                    <Card
+                      variant="outlined"
+                      sx={{
+                        mt: invoice.notes ? 2 : 0,
+                        borderColor: colors.semantic.warning,
+                        backgroundColor: `${colors.semantic.warning}0d`,
+                      }}
+                    >
+                      <CardContent>
+                        <Typography variant="h6" gutterBottom>
+                          Declined Services &amp; Parts
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ display: 'block', mb: 1 }}
+                        >
+                          Recommended and declined by the customer. Not
+                          performed and not included in the total.
+                        </Typography>
+                        <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+                          {invoice.declinedItems?.map((item, index) => (
+                            <Typography
+                              component="li"
+                              variant="body2"
+                              key={item.id ?? index}
+                            >
+                              {item.description}
+                            </Typography>
+                          ))}
+                        </Box>
+                        <Divider sx={{ my: 1.5 }} />
+                        {signatureSection}
+                      </CardContent>
+                    </Card>
+                  ) : (
+                    <Card variant="outlined" sx={{ mt: invoice.notes ? 2 : 0 }}>
+                      <CardContent>{signatureSection}</CardContent>
+                    </Card>
+                  )}
                 </Grid>
 
                 <Grid size={{ xs: 12, md: 6 }}>
@@ -761,6 +865,18 @@ export const InvoiceDetailsDialog: React.FC<InvoiceDetailsDialogProps> = ({
           )}
         </DialogActions>
       </Dialog>
+
+      {invoice && canManageSignature && (
+        <SignatureDialog
+          open={signatureDialogOpen}
+          onClose={() => setSignatureDialogOpen(false)}
+          invoice={invoice}
+          onSaved={(updated) => {
+            setInvoice(updated);
+            onInvoiceUpdate?.();
+          }}
+        />
+      )}
 
       {/* Square Online Payment Form */}
       {invoice && (

--- a/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
@@ -89,6 +89,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
     notes: '',
     status: 'PENDING',
     invoiceDate: new Date().toISOString().split('T')[0], // Today's date in YYYY-MM-DD format
+    declinedItems: [] as string[],
   });
 
   const [items, setItems] = useState<InvoiceItem[]>([]);
@@ -204,6 +205,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       notes: '',
       status: 'PENDING',
       invoiceDate: new Date().toISOString().split('T')[0],
+      declinedItems: [],
     });
     setItems([]);
     setNewItem({
@@ -246,6 +248,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       invoiceDate: invoiceData.invoiceDate
         ? new Date(invoiceData.invoiceDate).toISOString().split('T')[0]
         : new Date().toISOString().split('T')[0],
+      declinedItems: (invoiceData.declinedItems ?? []).map(
+        (item: any) => item.description
+      ),
     });
 
     // Populate items
@@ -453,6 +458,15 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
       }
       if (formData.status) {
         invoiceData.status = formData.status;
+      }
+      // Always sent (even empty) in edit mode so removing the last declined item
+      // actually clears it — the backend treats an omitted field as "leave alone".
+      const declinedItems = formData.declinedItems
+        .map((description) => description.trim())
+        .filter(Boolean)
+        .map((description, index) => ({ description, sortOrder: index }));
+      if (isEditMode || declinedItems.length > 0) {
+        invoiceData.declinedItems = declinedItems;
       }
       if (formData.invoiceDate) {
         invoiceData.invoiceDate = formData.invoiceDate;

--- a/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
@@ -29,6 +29,7 @@ import {
   Menu,
   ListItemIcon,
   ListItemText,
+  Stack,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -81,6 +82,9 @@ interface InvoiceFormContentProps {
     notes: string;
     status: string;
     invoiceDate: string;
+    // Work the customer was offered and declined. Never billed and never part of
+    // any total — kept as plain descriptions so it can't read like a charge.
+    declinedItems: string[];
   };
   setFormData: (data: any) => void;
   items: InvoiceItem[];
@@ -747,6 +751,84 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       },
                     }}
                   />
+
+                  {/* Declined work. Available on every invoice, not just those
+                      generated from a repair order — a walk-in who turns down a
+                      recommendation should be recorded the same way. */}
+                  <Box>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        mb: 1,
+                      }}
+                    >
+                      <Typography variant="subtitle2">
+                        Declined Services &amp; Parts (Optional)
+                      </Typography>
+                      <Button
+                        size="small"
+                        startIcon={<AddIcon />}
+                        onClick={() =>
+                          setFormData({
+                            ...formData,
+                            declinedItems: [...formData.declinedItems, ''],
+                          })
+                        }
+                      >
+                        Add
+                      </Button>
+                    </Box>
+
+                    {formData.declinedItems.length === 0 ? (
+                      <Typography variant="caption" color="text.secondary">
+                        Anything the customer was offered and turned down.
+                        Printed on the invoice, never charged.
+                      </Typography>
+                    ) : (
+                      <Stack spacing={1}>
+                        {formData.declinedItems.map((description, index) => (
+                          <Box
+                            key={index}
+                            sx={{
+                              display: 'flex',
+                              gap: 1,
+                              alignItems: 'center',
+                            }}
+                          >
+                            <TextField
+                              fullWidth
+                              size="small"
+                              value={description}
+                              placeholder="e.g. Rear brake pads"
+                              onChange={(e) => {
+                                const next = [...formData.declinedItems];
+                                next[index] = e.target.value;
+                                setFormData({
+                                  ...formData,
+                                  declinedItems: next,
+                                });
+                              }}
+                            />
+                            <IconButton
+                              size="small"
+                              onClick={() =>
+                                setFormData({
+                                  ...formData,
+                                  declinedItems: formData.declinedItems.filter(
+                                    (_, i) => i !== index
+                                  ),
+                                })
+                              }
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        ))}
+                      </Stack>
+                    )}
+                  </Box>
 
                   {formData.paymentMethod && (
                     <Alert severity="info" sx={{ mt: 'auto' }}>

--- a/apps/webApp/src/app/components/invoices/SignatureDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/SignatureDialog.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  Close as CloseIcon,
+  Draw as DrawIcon,
+  Delete as DeleteIcon,
+} from '@mui/icons-material';
+import { SignaturePad, SignaturePadHandle } from './SignaturePad';
+import { invoiceService, Invoice } from '../../requests/invoice.requests';
+import { colors } from '../../theme/colors';
+
+interface SignatureDialogProps {
+  open: boolean;
+  onClose: () => void;
+  invoice: Invoice;
+  /** Called with the updated invoice after a capture or a clear. */
+  onSaved: (invoice: Invoice) => void;
+}
+
+/**
+ * Capture (or replace) the customer signature on an invoice.
+ *
+ * Signing is optional throughout: nothing here gates payment, and an invoice
+ * left unsigned simply prints a blank signature line for a wet signature.
+ */
+export function SignatureDialog({
+  open,
+  onClose,
+  invoice,
+  onSaved,
+}: SignatureDialogProps) {
+  const padRef = useRef<SignaturePadHandle>(null);
+  const [signedByName, setSignedByName] = useState('');
+  const [hasSignature, setHasSignature] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const existingSignature = invoice.signatureUrl ?? null;
+
+  const defaultName =
+    [invoice.customer?.firstName, invoice.customer?.lastName]
+      .filter(Boolean)
+      .join(' ') ||
+    invoice.customer?.businessName ||
+    '';
+
+  useEffect(() => {
+    if (open) {
+      setSignedByName(invoice.signatureSignedByName || defaultName);
+      setHasSignature(false);
+      setError(null);
+      padRef.current?.clear();
+    }
+    // defaultName is derived from invoice, which is already a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, invoice]);
+
+  const handleSave = async () => {
+    const dataUrl = padRef.current?.toDataUrl();
+    if (!dataUrl) {
+      setError('Please sign in the box before saving.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await invoiceService.captureSignature(
+        invoice.id,
+        dataUrl,
+        signedByName.trim() || undefined
+      );
+      onSaved(updated);
+      onClose();
+    } catch (err: any) {
+      setError(
+        err?.response?.data?.message ||
+          'Could not save the signature. Please try again.'
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClearExisting = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await invoiceService.clearSignature(invoice.id);
+      onSaved(updated);
+      padRef.current?.clear();
+    } catch (err: any) {
+      setError(
+        err?.response?.data?.message ||
+          'Could not remove the signature. Please try again.'
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <DrawIcon color="primary" />
+          <span>Customer Signature</span>
+        </Box>
+        <IconButton onClick={onClose} size="small" disabled={saving}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Invoice {invoice.invoiceNumber}. Signing is optional — an unsigned
+          invoice prints with a blank signature line.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {existingSignature && (
+          <Box
+            sx={{
+              mb: 2,
+              p: 1.5,
+              border: `1px solid ${colors.neutral[300]}`,
+              borderRadius: 1,
+              backgroundColor: colors.neutral[50],
+            }}
+          >
+            <Typography variant="caption" color="text.secondary">
+              Current signature
+            </Typography>
+            <Box
+              component="img"
+              src={existingSignature}
+              alt="Current customer signature"
+              sx={{
+                display: 'block',
+                maxHeight: 70,
+                maxWidth: '100%',
+                mt: 0.5,
+              }}
+            />
+            <Button
+              size="small"
+              color="error"
+              startIcon={<DeleteIcon />}
+              onClick={handleClearExisting}
+              disabled={saving}
+              sx={{ mt: 1 }}
+            >
+              Remove signature
+            </Button>
+          </Box>
+        )}
+
+        <SignaturePad
+          ref={padRef}
+          onDirtyChange={setHasSignature}
+          disabled={saving}
+        />
+
+        <TextField
+          label="Printed name"
+          value={signedByName}
+          onChange={(e) => setSignedByName(e.target.value)}
+          fullWidth
+          size="small"
+          sx={{ mt: 2 }}
+          disabled={saving}
+          helperText="Printed below the signature on the invoice"
+        />
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={saving || !hasSignature}
+        >
+          {saving
+            ? 'Saving…'
+            : existingSignature
+            ? 'Replace signature'
+            : 'Save signature'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default SignatureDialog;

--- a/apps/webApp/src/app/components/invoices/SignaturePad.tsx
+++ b/apps/webApp/src/app/components/invoices/SignaturePad.tsx
@@ -1,0 +1,237 @@
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { Undo as UndoIcon } from '@mui/icons-material';
+import { colors } from '../../theme/colors';
+
+export interface SignaturePadHandle {
+  /** PNG data URL of the drawing, or null if nothing has been drawn. */
+  toDataUrl: () => string | null;
+  clear: () => void;
+  isEmpty: () => boolean;
+}
+
+interface SignaturePadProps {
+  height?: number;
+  disabled?: boolean;
+  /** Fires whenever the drawing goes from empty to non-empty (or back). */
+  onDirtyChange?: (hasSignature: boolean) => void;
+}
+
+/**
+ * Draw-to-sign pad backed by a canvas.
+ *
+ * Uses Pointer Events rather than separate mouse/touch handlers so a finger on a
+ * phone, a stylus on a tablet and a mouse on desktop all take the same path —
+ * staff take payment on mobile, so touch is the primary input, not an extra.
+ *
+ * The canvas is sized to its own CSS box multiplied by devicePixelRatio, so the
+ * captured PNG is sharp on retina screens instead of a blurry upscale.
+ */
+export const SignaturePad = React.forwardRef<
+  SignaturePadHandle,
+  SignaturePadProps
+>(({ height = 180, disabled = false, onDirtyChange }, ref) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const drawingRef = useRef(false);
+  const hasInkRef = useRef(false);
+  const lastPointRef = useRef<{ x: number; y: number } | null>(null);
+  const [hasInk, setHasInk] = useState(false);
+
+  const markInk = useCallback(
+    (value: boolean) => {
+      if (hasInkRef.current === value) return;
+      hasInkRef.current = value;
+      setHasInk(value);
+      onDirtyChange?.(value);
+    },
+    [onDirtyChange]
+  );
+
+  /** Resize the backing store to match the element's CSS size at device DPI. */
+  const resizeCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ratio = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width === 0) return;
+
+    // Preserve anything already drawn across a resize (e.g. phone rotation).
+    const previous = hasInkRef.current ? canvas.toDataURL('image/png') : null;
+
+    canvas.width = Math.round(rect.width * ratio);
+    canvas.height = Math.round(rect.height * ratio);
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.scale(ratio, ratio);
+    ctx.lineWidth = 2;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.strokeStyle = '#111111';
+
+    if (previous) {
+      const image = new Image();
+      image.onload = () => ctx.drawImage(image, 0, 0, rect.width, rect.height);
+      image.src = previous;
+    }
+  }, []);
+
+  useEffect(() => {
+    resizeCanvas();
+    window.addEventListener('resize', resizeCanvas);
+    return () => window.removeEventListener('resize', resizeCanvas);
+  }, [resizeCanvas]);
+
+  const pointFromEvent = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (disabled) return;
+    event.preventDefault();
+    // Capture the pointer so a stroke that leaves the canvas keeps drawing
+    // instead of ending mid-signature.
+    event.currentTarget.setPointerCapture(event.pointerId);
+    drawingRef.current = true;
+    lastPointRef.current = pointFromEvent(event);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (disabled || !drawingRef.current) return;
+    event.preventDefault();
+
+    const ctx = canvasRef.current?.getContext('2d');
+    const from = lastPointRef.current;
+    if (!ctx || !from) return;
+
+    const to = pointFromEvent(event);
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.stroke();
+
+    lastPointRef.current = to;
+    markInk(true);
+  };
+
+  const endStroke = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!drawingRef.current) return;
+    drawingRef.current = false;
+    lastPointRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const clear = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx) return;
+    // Reset the transform before clearing so the whole backing store is wiped
+    // regardless of the DPI scale currently applied.
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.restore();
+    markInk(false);
+  }, [markInk]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      toDataUrl: () => {
+        if (!hasInkRef.current) return null;
+        return canvasRef.current?.toDataURL('image/png') ?? null;
+      },
+      clear,
+      isEmpty: () => !hasInkRef.current,
+    }),
+    [clear]
+  );
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          position: 'relative',
+          border: `1px solid ${colors.neutral[300]}`,
+          borderRadius: 1,
+          backgroundColor: disabled ? colors.neutral[100] : '#fff',
+          overflow: 'hidden',
+        }}
+      >
+        <canvas
+          ref={canvasRef}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={endStroke}
+          onPointerLeave={endStroke}
+          onPointerCancel={endStroke}
+          style={{
+            display: 'block',
+            width: '100%',
+            height,
+            // Stop the browser scrolling/zooming the page while signing — without
+            // this a finger drag pans the page instead of drawing.
+            touchAction: 'none',
+            cursor: disabled ? 'not-allowed' : 'crosshair',
+          }}
+        />
+        {!hasInk && (
+          <Typography
+            variant="body2"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: colors.neutral[400],
+              pointerEvents: 'none',
+            }}
+          >
+            Sign here
+          </Typography>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mt: 1,
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          Sign with a finger, stylus or mouse
+        </Typography>
+        <Button
+          size="small"
+          startIcon={<UndoIcon />}
+          onClick={clear}
+          disabled={disabled || !hasInk}
+        >
+          Clear
+        </Button>
+      </Box>
+    </Box>
+  );
+});
+
+SignaturePad.displayName = 'SignaturePad';
+
+export default SignaturePad;

--- a/apps/webApp/src/app/pages/admin/Settings.tsx
+++ b/apps/webApp/src/app/pages/admin/Settings.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  Gavel as GavelIcon,
+  Save as SaveIcon,
+  Settings as SettingsIcon,
+} from '@mui/icons-material';
+import { companyService, Company } from '../../requests/company.requests';
+import { colors } from '../../theme/colors';
+
+/**
+ * System settings for admins.
+ *
+ * Currently holds the invoice terms & conditions. Those are a liability
+ * statement owned by the business, so they live on the Company record and are
+ * edited here rather than being baked into the invoice templates — the wording
+ * can change without a deploy.
+ */
+export function Settings() {
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [savedId, setSavedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const load = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await companyService.getCompanies(true);
+      setCompanies(data);
+      setDrafts(
+        Object.fromEntries(
+          data.map((company) => [company.id, company.termsAndConditions ?? ''])
+        )
+      );
+    } catch (err: any) {
+      setError(err?.response?.data?.message || 'Failed to load companies');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async (company: Company) => {
+    setSavingId(company.id);
+    setError(null);
+    setSavedId(null);
+    try {
+      const updated = await companyService.updateTermsAndConditions(
+        company.id,
+        drafts[company.id] ?? ''
+      );
+      setCompanies((prev) =>
+        prev.map((c) => (c.id === updated.id ? updated : c))
+      );
+      setSavedId(company.id);
+    } catch (err: any) {
+      setError(
+        err?.response?.data?.message || 'Failed to save terms and conditions'
+      );
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 3 } }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+        <SettingsIcon color="primary" />
+        <Typography variant="h5">Settings</Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <GavelIcon color="primary" fontSize="small" />
+        <Typography variant="h6">Invoice Terms &amp; Conditions</Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Terms &amp; conditions print at the bottom of every invoice for the
+        company, directly above the customer signature. Leave blank to print no
+        terms at all.
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Stack spacing={3}>
+        {companies.map((company) => (
+          <Card key={company.id} variant="outlined">
+            <CardContent>
+              <Typography variant="h6">{company.name}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                {company.registrationNumber}
+                {company.isDefault ? ' — default company' : ''}
+              </Typography>
+
+              <Divider sx={{ my: 2 }} />
+
+              <TextField
+                fullWidth
+                multiline
+                minRows={6}
+                label="Terms & Conditions"
+                value={drafts[company.id] ?? ''}
+                onChange={(e) =>
+                  setDrafts((prev) => ({
+                    ...prev,
+                    [company.id]: e.target.value,
+                  }))
+                }
+                helperText={`${
+                  (drafts[company.id] ?? '').length
+                } / 4000 characters`}
+                slotProps={{ htmlInput: { maxLength: 4000 } }}
+              />
+
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'flex-end',
+                  gap: 2,
+                  mt: 2,
+                }}
+              >
+                {savedId === company.id && (
+                  <Typography
+                    variant="caption"
+                    sx={{ color: colors.semantic.success }}
+                  >
+                    Saved
+                  </Typography>
+                )}
+                <Button
+                  variant="contained"
+                  startIcon={<SaveIcon />}
+                  onClick={() => handleSave(company)}
+                  disabled={
+                    savingId === company.id ||
+                    (drafts[company.id] ?? '') ===
+                      (company.termsAndConditions ?? '')
+                  }
+                >
+                  {savingId === company.id ? 'Saving…' : 'Save'}
+                </Button>
+              </Box>
+            </CardContent>
+          </Card>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+export default Settings;

--- a/apps/webApp/src/app/requests/company.requests.ts
+++ b/apps/webApp/src/app/requests/company.requests.ts
@@ -19,6 +19,8 @@ export interface Company {
   phone?: string;
   email?: string;
   isDefault: boolean;
+  /** Business-authored terms printed at the foot of this company's invoices. */
+  termsAndConditions?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -26,7 +28,7 @@ export interface Company {
 class CompanyService {
   // Cache for companies data - companies rarely change so we cache them
   private companiesCache: Company[] | null = null;
-  private cacheTimestamp: number = 0;
+  private cacheTimestamp = 0;
   private readonly CACHE_DURATION = 5 * 60 * 1000; // 5 minutes cache
   private fetchPromise: Promise<Company[]> | null = null; // Prevent duplicate requests
 
@@ -59,7 +61,11 @@ class CompanyService {
     const now = Date.now();
 
     // Return cached data if valid and not forcing refresh
-    if (!forceRefresh && this.companiesCache && (now - this.cacheTimestamp) < this.CACHE_DURATION) {
+    if (
+      !forceRefresh &&
+      this.companiesCache &&
+      now - this.cacheTimestamp < this.CACHE_DURATION
+    ) {
       return this.companiesCache;
     }
 
@@ -96,6 +102,20 @@ class CompanyService {
     this.getCompanies().catch(() => {
       // Silently fail prefetch - will retry on actual use
     });
+  }
+
+  /** Admin-only. Invalidates the cache so invoices pick up the new wording. */
+  async updateTermsAndConditions(
+    id: string,
+    termsAndConditions: string
+  ): Promise<Company> {
+    const response = await axios.patch(
+      `${API_URL}/api/companies/${id}/terms`,
+      { termsAndConditions },
+      { headers: await this.getHeaders() }
+    );
+    this.clearCache();
+    return response.data;
   }
 
   async getDefaultCompany(): Promise<Company> {

--- a/apps/webApp/src/app/requests/invoice.requests.ts
+++ b/apps/webApp/src/app/requests/invoice.requests.ts
@@ -5,6 +5,14 @@ import type {
   InvoiceResponseDto,
   UpdateInvoiceDto,
 } from '@gt-automotive/data';
+// Shared with the server-side PDF template so the emailed and printed invoices
+// cannot drift apart (see libs/data/src/lib/utils/invoice-print-sections.ts).
+import {
+  hasPrintableDeclinedItems,
+  renderDeclinedItemsHtml,
+  renderSignatureHtml,
+  renderTermsAndConditionsHtml,
+} from '@gt-automotive/data';
 import gtLogoImage from '../images-and-logos/logo.png';
 import { formatPhoneForDisplay } from '../utils/phone';
 
@@ -221,6 +229,29 @@ class InvoiceService {
       {
         headers: await this.getHeaders(),
       }
+    );
+    return response.data;
+  }
+
+  /** Store a customer signature (PNG data URL straight off the signature pad). */
+  async captureSignature(
+    id: string,
+    imageDataUrl: string,
+    signedByName?: string
+  ): Promise<Invoice> {
+    const response = await axios.post(
+      `${API_URL}/api/invoices/${id}/signature`,
+      { imageDataUrl, signedByName },
+      { headers: await this.getHeaders() }
+    );
+    return response.data;
+  }
+
+  /** Remove a captured signature so it can be re-taken. */
+  async clearSignature(id: string): Promise<Invoice> {
+    const response = await axios.delete(
+      `${API_URL}/api/invoices/${id}/signature`,
+      { headers: await this.getHeaders() }
     );
     return response.data;
   }
@@ -550,6 +581,16 @@ ${
             : ''
         }
 
+        ${renderDeclinedItemsHtml(
+          invoice.declinedItems,
+          {
+            url: invoice.signatureUrl,
+            signedByName: invoice.signatureSignedByName,
+            signedAt: invoice.signatureSignedAt,
+          },
+          this.getCustomerName(invoice)
+        )}
+
         ${
           invoice.customer?.pstExempt
             ? `
@@ -582,6 +623,21 @@ ${
           </div>
         `
             : ''
+        }
+
+        ${renderTermsAndConditionsHtml(invoice.company?.termsAndConditions)}
+
+        ${
+          hasPrintableDeclinedItems(invoice.declinedItems)
+            ? ''
+            : renderSignatureHtml(
+                {
+                  url: invoice.signatureUrl,
+                  signedByName: invoice.signatureSignedByName,
+                  signedAt: invoice.signatureSignedAt,
+                },
+                this.getCustomerName(invoice)
+              )
         }
 
         <div class="footer">
@@ -821,6 +877,16 @@ ${
             : ''
         }
 
+        ${renderDeclinedItemsHtml(
+          invoice.declinedItems,
+          {
+            url: invoice.signatureUrl,
+            signedByName: invoice.signatureSignedByName,
+            signedAt: invoice.signatureSignedAt,
+          },
+          this.getCustomerName(invoice)
+        )}
+
         ${
           invoice.customer?.pstExempt
             ? `
@@ -853,6 +919,21 @@ ${
           </div>
         `
             : ''
+        }
+
+        ${renderTermsAndConditionsHtml(invoice.company?.termsAndConditions)}
+
+        ${
+          hasPrintableDeclinedItems(invoice.declinedItems)
+            ? ''
+            : renderSignatureHtml(
+                {
+                  url: invoice.signatureUrl,
+                  signedByName: invoice.signatureSignedByName,
+                  signedAt: invoice.signatureSignedAt,
+                },
+                this.getCustomerName(invoice)
+              )
         }
 
         <div style="margin-top: 25px; text-align: center; color: #666; font-size: 0.85em;">

--- a/libs/data/src/index.ts
+++ b/libs/data/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/location.dto';
 export * from './lib/customer.dto';
 export * from './lib/vehicle.dto';
 export * from './lib/invoice.dto';
+export * from './lib/company.dto';
 export * from './lib/quotation.dto';
 export * from './lib/job.dto';
 export * from './lib/payment.dto';

--- a/libs/data/src/lib/company.dto.ts
+++ b/libs/data/src/lib/company.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+/**
+ * Update the invoice terms & conditions for a company. The wording is a
+ * liability statement authored by the business, so it lives in the database and
+ * is editable from admin settings rather than being baked into the templates.
+ */
+export class UpdateCompanyTermsDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(4000, {
+    message: 'Terms and conditions cannot exceed 4000 characters',
+  })
+  termsAndConditions?: string | null;
+}

--- a/libs/data/src/lib/invoice.dto.ts
+++ b/libs/data/src/lib/invoice.dto.ts
@@ -67,6 +67,24 @@ export class InvoiceItemDto {
   total?: number;
 }
 
+/**
+ * A service or part the customer was offered and declined. Deliberately not an
+ * InvoiceItem: declined work is never billed and never enters any total, so it
+ * carries a description only — no quantity or price that could read as a charge.
+ */
+export class InvoiceDeclinedItemDto {
+  @IsOptional()
+  @IsString()
+  id?: string;
+
+  @IsString()
+  description!: string;
+
+  @IsOptional()
+  @IsNumber()
+  sortOrder?: number;
+}
+
 export class CreateInvoiceDto {
   @IsOptional()
   @IsString()
@@ -125,6 +143,12 @@ export class CreateInvoiceDto {
   @IsOptional()
   @IsString()
   notes?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => InvoiceDeclinedItemDto)
+  declinedItems?: InvoiceDeclinedItemDto[];
 
   @IsOptional()
   @IsString()
@@ -186,6 +210,16 @@ export class UpdateInvoiceDto {
   @IsString()
   notes?: string;
 
+  /**
+   * When present, replaces the invoice's declined-item list wholesale. Omit the
+   * field to leave the existing list untouched; pass [] to clear it.
+   */
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => InvoiceDeclinedItemDto)
+  declinedItems?: InvoiceDeclinedItemDto[];
+
   @IsOptional()
   @IsString()
   paidAt?: string;
@@ -199,6 +233,20 @@ export class UpdateInvoiceDto {
   companyId?: string;
 }
 
+/**
+ * Payload for capturing a customer signature on an invoice. The image arrives as
+ * a PNG data URL straight off the signature pad canvas; the server strips the
+ * prefix and stores the bytes in Azure Blob.
+ */
+export class CaptureInvoiceSignatureDto {
+  @IsString()
+  imageDataUrl!: string;
+
+  @IsOptional()
+  @IsString()
+  signedByName?: string;
+}
+
 export interface InvoiceCompanyDto {
   id: string;
   name: string;
@@ -208,6 +256,8 @@ export interface InvoiceCompanyDto {
   phone?: string;
   email?: string;
   isDefault: boolean;
+  /** Business-authored terms & conditions printed at the foot of the invoice. */
+  termsAndConditions?: string | null;
 }
 
 export interface InvoiceCustomerDto {
@@ -314,6 +364,29 @@ export class InvoiceResponseDto {
   @IsOptional()
   @IsString()
   notes?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => InvoiceDeclinedItemDto)
+  declinedItems?: InvoiceDeclinedItemDto[];
+
+  /**
+   * Signature fields are null when the invoice is unsigned — the templates then
+   * print a blank ruled line. `signatureUrl` is re-signed as a short-lived Azure
+   * SAS URL on read, because the storage account forbids public blob access.
+   */
+  @IsOptional()
+  @IsString()
+  signatureUrl?: string | null;
+
+  @IsOptional()
+  @IsString()
+  signatureSignedByName?: string | null;
+
+  @IsOptional()
+  @IsString()
+  signatureSignedAt?: string | null;
 
   @IsString()
   createdBy!: string;

--- a/libs/data/src/lib/utils/index.ts
+++ b/libs/data/src/lib/utils/index.ts
@@ -2,3 +2,4 @@ export * from './string-utils';
 export * from './file-utils';
 export * from './decorator-utils';
 export * from './mapped-types';
+export * from './invoice-print-sections';

--- a/libs/data/src/lib/utils/invoice-print-sections.spec.ts
+++ b/libs/data/src/lib/utils/invoice-print-sections.spec.ts
@@ -1,0 +1,191 @@
+import {
+  escapeInvoiceHtml,
+  hasPrintableDeclinedItems,
+  renderDeclinedItemsHtml,
+  renderSignatureHtml,
+  renderTermsAndConditionsHtml,
+} from './invoice-print-sections';
+
+describe('invoice print sections', () => {
+  describe('renderDeclinedItemsHtml', () => {
+    it('renders nothing when there are no declined items', () => {
+      // An invoice without declined work must print exactly as it did before
+      // this section existed.
+      expect(renderDeclinedItemsHtml(undefined)).toBe('');
+      expect(renderDeclinedItemsHtml(null)).toBe('');
+      expect(renderDeclinedItemsHtml([])).toBe('');
+    });
+
+    it('renders nothing when every description is blank', () => {
+      expect(renderDeclinedItemsHtml([{ description: '   ' }])).toBe('');
+    });
+
+    it('lists each declined item and drops blank ones', () => {
+      const html = renderDeclinedItemsHtml([
+        { description: 'Rear brake pads' },
+        { description: '  ' },
+        { description: 'Cabin air filter' },
+      ]);
+
+      expect(html.match(/<li/g)).toHaveLength(2);
+      expect(html).toContain('Rear brake pads');
+      expect(html).toContain('Cabin air filter');
+    });
+
+    it('never prints a price or quantity', () => {
+      const html = renderDeclinedItemsHtml([
+        { description: 'Rear brake pads' },
+      ]);
+      expect(html).not.toMatch(/\$\d/);
+    });
+
+    it('states that declined work is excluded from the total', () => {
+      const html = renderDeclinedItemsHtml([
+        { description: 'Rear brake pads' },
+      ]);
+      expect(html).toContain('not included in the total');
+    });
+
+    it('escapes descriptions', () => {
+      const html = renderDeclinedItemsHtml([
+        { description: '<script>alert(1)</script>' },
+      ]);
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('signature inside the declined box', () => {
+    it('renders the signature inside the declined box when one is passed', () => {
+      const html = renderDeclinedItemsHtml(
+        [{ description: 'Rear brake pads' }],
+        { url: 'https://blob.example/sig.png', signedByName: 'Jane Doe' },
+        'Jane Doe'
+      );
+
+      // One box containing both the declined list and the signature.
+      expect(html).toContain('Rear brake pads');
+      expect(html).toContain('Customer Signature');
+      expect(html).toContain('https://blob.example/sig.png');
+      expect(html).toContain(
+        'confirms the above services and parts were recommended and declined'
+      );
+    });
+
+    it('still shows a blank signature line in the box when unsigned', () => {
+      const html = renderDeclinedItemsHtml([
+        { description: 'Rear brake pads' },
+      ]);
+      expect(html).toContain('Customer Signature');
+      expect(html).not.toContain('<img');
+    });
+  });
+
+  describe('hasPrintableDeclinedItems', () => {
+    it('is false when there is nothing to print', () => {
+      expect(hasPrintableDeclinedItems(undefined)).toBe(false);
+      expect(hasPrintableDeclinedItems(null)).toBe(false);
+      expect(hasPrintableDeclinedItems([])).toBe(false);
+      expect(hasPrintableDeclinedItems([{ description: '  ' }])).toBe(false);
+    });
+
+    it('is true when at least one item has a description', () => {
+      expect(
+        hasPrintableDeclinedItems([
+          { description: '' },
+          { description: 'Pads' },
+        ])
+      ).toBe(true);
+    });
+  });
+
+  describe('renderTermsAndConditionsHtml', () => {
+    it('renders nothing when no terms are set', () => {
+      expect(renderTermsAndConditionsHtml(undefined)).toBe('');
+      expect(renderTermsAndConditionsHtml(null)).toBe('');
+      expect(renderTermsAndConditionsHtml('   ')).toBe('');
+    });
+
+    it('renders the business-supplied wording verbatim', () => {
+      const terms = 'No guarantee on customer-supplied parts.';
+      expect(renderTermsAndConditionsHtml(terms)).toContain(terms);
+    });
+
+    it('escapes the wording', () => {
+      expect(renderTermsAndConditionsHtml('a & b <c>')).toContain(
+        'a &amp; b &lt;c&gt;'
+      );
+    });
+
+    it('prints a blank initials line at the far end of the heading', () => {
+      const html = renderTermsAndConditionsHtml('Some terms.');
+      expect(html).toContain('Initials:');
+      expect(html).toContain('text-align: right');
+      // The heading and the initials line share a row.
+      expect(html.indexOf('Terms &amp; Conditions')).toBeLessThan(
+        html.indexOf('Initials:')
+      );
+    });
+
+    it('prints no initials line when there are no terms', () => {
+      expect(renderTermsAndConditionsHtml('')).not.toContain('Initials:');
+    });
+  });
+
+  describe('renderSignatureHtml', () => {
+    it('prints a blank ruled line when the invoice is unsigned', () => {
+      const html = renderSignatureHtml(null, 'Jane Doe');
+      expect(html).toContain('Customer Signature');
+      expect(html).toContain('border-top: 1px solid #333');
+      expect(html).not.toContain('<img');
+    });
+
+    it('embeds the signature image once captured', () => {
+      const html = renderSignatureHtml({
+        url: 'https://blob.example/sig.png?sas=1',
+        signedByName: 'Jane Doe',
+        signedAt: '2026-08-05T18:00:00.000Z',
+      });
+
+      expect(html).toContain('<img');
+      expect(html).toContain('https://blob.example/sig.png?sas=1');
+      expect(html).toContain('Jane Doe');
+    });
+
+    it('falls back to the customer name when no printed name was given', () => {
+      const html = renderSignatureHtml({ url: 'x' }, 'Acme Towing');
+      expect(html).toContain('Acme Towing');
+    });
+
+    it('renders the signing date in the shop timezone, not UTC', () => {
+      // 2026-08-05T02:00Z is still Aug 4 in Vancouver (PDT). The printed copy
+      // must show the shop's calendar day.
+      const html = renderSignatureHtml({
+        url: 'x',
+        signedAt: '2026-08-05T02:00:00.000Z',
+      });
+      expect(html).toContain('Aug 4, 2026');
+    });
+
+    it('omits the date when the invoice is unsigned', () => {
+      const html = renderSignatureHtml({ url: null, signedAt: null });
+      expect(html).toContain('Date');
+      expect(html).not.toMatch(/\d{4}/);
+    });
+
+    it('avoids splitting the block across pages', () => {
+      expect(renderSignatureHtml(null)).toContain('page-break-inside: avoid');
+    });
+  });
+
+  describe('escapeInvoiceHtml', () => {
+    it('escapes all HTML-significant characters', () => {
+      expect(escapeInvoiceHtml(`<&>"'`)).toBe('&lt;&amp;&gt;&quot;&#39;');
+    });
+
+    it('renders null and undefined as empty strings', () => {
+      expect(escapeInvoiceHtml(null)).toBe('');
+      expect(escapeInvoiceHtml(undefined)).toBe('');
+    });
+  });
+});

--- a/libs/data/src/lib/utils/invoice-print-sections.ts
+++ b/libs/data/src/lib/utils/invoice-print-sections.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared HTML fragments for the invoice document.
+ *
+ * The invoice exists as three separate templates — the emailed/downloaded PDF
+ * (server/src/pdf/pdf.service.ts) and two browser print/preview templates
+ * (apps/webApp/src/app/requests/invoice.requests.ts). Historically any change
+ * had to be hand-applied to each, and the emailed PDF and the printed copy drift
+ * apart the moment one is missed.
+ *
+ * These builders are the single source of truth for the declined-items,
+ * signature and terms sections so all three templates cannot disagree. They are
+ * deliberately dependency-free, inline-styled strings: the PDF is rendered by
+ * Puppeteer from a standalone HTML document with no stylesheet, and the print
+ * templates are written into a fresh window.
+ */
+
+export interface PrintableDeclinedItem {
+  description: string;
+}
+
+export interface PrintableSignature {
+  url?: string | null;
+  signedByName?: string | null;
+  signedAt?: string | Date | null;
+}
+
+/** Escape text interpolated into the templates. */
+export function escapeInvoiceHtml(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatSignatureDate(value?: string | Date | null): string {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  // The shop is in one timezone; show the signing date as that calendar day
+  // rather than the viewer's, so a phone in another province cannot disagree
+  // with the printed copy.
+  return date.toLocaleDateString('en-CA', {
+    timeZone: 'America/Vancouver',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * True when there is at least one declined item worth printing.
+ *
+ * Templates use this to decide where the signature goes: inside the declined
+ * box when work was declined, otherwise in its own block at the foot of the
+ * invoice.
+ */
+export function hasPrintableDeclinedItems(
+  items?: PrintableDeclinedItem[] | null
+): boolean {
+  return (items ?? []).some((item) => item?.description?.trim());
+}
+
+/**
+ * Services and parts the customer declined, printed directly below the
+ * technician notes.
+ *
+ * Description only, and visually distinct from the billed line items — a
+ * declined item must never be mistaken for a charge. Returns '' when there is
+ * nothing declined, so an invoice without declined work is byte-identical to
+ * how it printed before this section existed.
+ *
+ * When a signature is passed it is rendered INSIDE this box, so the customer
+ * signs against the declined list itself rather than somewhere further down the
+ * page — the signature is the acknowledgement that this work was offered and
+ * refused, which is the whole reason for printing it.
+ */
+export function renderDeclinedItemsHtml(
+  items?: PrintableDeclinedItem[] | null,
+  signature?: PrintableSignature | null,
+  customerName?: string | null
+): string {
+  const declined = (items ?? []).filter((item) => item?.description?.trim());
+  if (declined.length === 0) return '';
+
+  const rows = declined
+    .map(
+      (item) =>
+        `<li style="margin: 0 0 3px 0;">${escapeInvoiceHtml(
+          item.description.trim()
+        )}</li>`
+    )
+    .join('');
+
+  return `
+    <div style="margin-top: 12px; padding: 8px 12px; border: 1px solid #e0a800; border-left: 4px solid #e0a800; border-radius: 4px; background: #fffaf0; page-break-inside: avoid;">
+      <h3 style="margin: 0 0 6px 0; font-size: 13px; color: #8a6100; text-transform: uppercase; letter-spacing: 0.03em;">Declined Services &amp; Parts</h3>
+      <p style="margin: 0 0 6px 0; font-size: 11px; color: #666;">
+        The following were recommended and declined by the customer. They were not performed and are not included in the total.
+      </p>
+      <ul style="margin: 0; padding-left: 18px; font-size: 12px;">${rows}</ul>
+      <p style="margin: 8px 0 0 0; font-size: 11px; color: #666;">
+        By signing below, the customer confirms the above services and parts were recommended and declined.
+      </p>
+      ${renderSignatureHtml(signature, customerName)}
+    </div>
+  `;
+}
+
+/**
+ * Terms &amp; conditions block. The wording is business-authored and stored on the
+ * Company record, so this only lays it out. Sits directly above the signature so
+ * the signature reads as acceptance of the terms.
+ */
+export function renderTermsAndConditionsHtml(terms?: string | null): string {
+  if (!terms?.trim()) return '';
+
+  // The heading row is a table so the initials line stays pinned to the right
+  // edge in both Puppeteer and the browser print dialog — flexbox is less
+  // predictable across the two print paths.
+  return `
+    <div style="margin-top: 14px; padding-top: 8px; border-top: 1px solid #ddd; page-break-inside: avoid;">
+      <table style="width: 100%; border-collapse: collapse; margin: 0 0 4px 0;">
+        <tr>
+          <td style="padding: 0; vertical-align: bottom;">
+            <h3 style="margin: 0; font-size: 11px; text-transform: uppercase; letter-spacing: 0.03em; color: #555;">Terms &amp; Conditions</h3>
+          </td>
+          <td style="padding: 0; vertical-align: bottom; text-align: right; white-space: nowrap;">
+            <span style="font-size: 10px; color: #555;">Initials:</span>
+            <span style="display: inline-block; width: 70px; border-bottom: 1px solid #333; margin-left: 4px;">&nbsp;</span>
+          </td>
+        </tr>
+      </table>
+      <p style="margin: 0; font-size: 10px; line-height: 1.45; color: #555; white-space: pre-wrap;">${escapeInvoiceHtml(
+        terms.trim()
+      )}</p>
+    </div>
+  `;
+}
+
+/**
+ * Customer signature block, with a printed-name and date line beneath it.
+ *
+ * Always renders: an unsigned invoice prints an empty ruled line so it can be
+ * signed by hand, which is the whole point of printing it in the shop.
+ */
+/** Height of the blank signing area above the rule, in px. */
+const SIGNATURE_LINE_HEIGHT_PX = 34;
+
+export function renderSignatureHtml(
+  signature?: PrintableSignature | null,
+  customerName?: string | null
+): string {
+  const hasImage = !!signature?.url;
+  const signedDate = formatSignatureDate(signature?.signedAt);
+  const printedName =
+    signature?.signedByName?.trim() || customerName?.trim() || '';
+
+  // Just enough room to sign by hand without leaving a dead band of white space
+  // above the rule — the block is often reprinted on a single-page invoice.
+  const signatureArea = hasImage
+    ? `<img src="${escapeInvoiceHtml(
+        signature?.url
+      )}" alt="Customer signature" style="max-height: ${SIGNATURE_LINE_HEIGHT_PX}px; max-width: 100%; display: block;" />`
+    : `<div style="height: ${SIGNATURE_LINE_HEIGHT_PX}px;"></div>`;
+
+  return `
+    <div style="margin-top: 8px; page-break-inside: avoid;">
+      <table style="width: 100%; border-collapse: collapse;">
+        <tr>
+          <td style="width: 60%; vertical-align: bottom; padding: 0 16px 0 0;">
+            ${signatureArea}
+            <div style="border-top: 1px solid #333; padding-top: 3px; font-size: 10px; color: #555;">
+              Customer Signature${
+                printedName ? ` &mdash; ${escapeInvoiceHtml(printedName)}` : ''
+              }
+            </div>
+          </td>
+          <td style="width: 40%; vertical-align: bottom;">
+            <div style="height: ${SIGNATURE_LINE_HEIGHT_PX}px; display: flex; align-items: flex-end;">
+              <span style="font-size: 12px;">${escapeInvoiceHtml(
+                signedDate
+              )}</span>
+            </div>
+            <div style="border-top: 1px solid #333; padding-top: 3px; font-size: 10px; color: #555;">Date</div>
+          </td>
+        </tr>
+      </table>
+    </div>
+  `;
+}

--- a/libs/database/src/lib/prisma/migrations/20260805195313_add_invoice_declined_items_signature_and_company_terms/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260805195313_add_invoice_declined_items_signature_and_company_terms/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "public"."Company" ADD COLUMN     "termsAndConditions" TEXT;
+
+-- AlterTable
+ALTER TABLE "public"."Invoice" ADD COLUMN     "signatureBlobName" TEXT,
+ADD COLUMN     "signatureCapturedBy" TEXT,
+ADD COLUMN     "signatureContainerName" TEXT,
+ADD COLUMN     "signatureSignedAt" TIMESTAMP(3),
+ADD COLUMN     "signatureSignedByName" TEXT;
+
+-- CreateTable
+CREATE TABLE "public"."InvoiceDeclinedItem" (
+    "id" TEXT NOT NULL,
+    "invoiceId" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "roServiceId" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InvoiceDeclinedItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "InvoiceDeclinedItem_invoiceId_idx" ON "public"."InvoiceDeclinedItem"("invoiceId");
+
+-- AddForeignKey
+ALTER TABLE "public"."InvoiceDeclinedItem" ADD CONSTRAINT "InvoiceDeclinedItem_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "public"."Invoice"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/database/src/lib/prisma/migrations/20260805195400_seed_default_company_terms/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260805195400_seed_default_company_terms/migration.sql
@@ -1,0 +1,7 @@
+-- Seed a starting terms & conditions block so invoices are not blank on day one.
+-- This is placeholder wording: it is a liability statement and is expected to be
+-- reviewed and replaced by the business from Admin > Companies. Only fills rows
+-- that have no terms set, so it never overwrites business-authored text.
+UPDATE "public"."Company"
+SET "termsAndConditions" = 'GT Automotives provides no guarantee or warranty on parts supplied or purchased by the customer. Warranty on parts supplied and installed by GT Automotives is limited to the manufacturer''s warranty. Services and parts listed as declined on this invoice were recommended by GT Automotives and refused by the customer; GT Automotives accepts no liability for any failure or damage arising from work that was declined.'
+WHERE "termsAndConditions" IS NULL;

--- a/libs/database/src/lib/prisma/migrations/20260805195747_add_invoice_signature_url/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260805195747_add_invoice_signature_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Invoice" ADD COLUMN     "signatureUrl" TEXT;

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -226,6 +226,11 @@ model Company {
   phone              String?
   email              String?
   isDefault          Boolean   @default(false)
+  // Free-text terms & conditions printed at the bottom of this company's
+  // invoices, above the signature block. Business-authored (it is a liability
+  // statement), editable from admin settings so the wording can change without
+  // a deploy. Null/blank means no T&C block is rendered.
+  termsAndConditions String?
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
   invoices           Invoice[]
@@ -255,6 +260,19 @@ model Invoice {
   gstRate        Decimal?        @db.Decimal(5, 4)
   pstAmount      Decimal?        @db.Decimal(10, 2)
   pstRate        Decimal?        @db.Decimal(5, 4)
+  // Customer signature captured at handover. Always optional — an unsigned
+  // invoice prints a blank signature line for a wet signature. The image lives
+  // in Azure Blob; that account forbids public blob access, so it is served via
+  // a short-lived SAS URL generated on read (mirrors ROMedia).
+  signatureBlobName      String?
+  signatureContainerName String?
+  // Resolved URL as returned by the uploader. In production this is the private
+  // blob URL (re-signed as a SAS URL on read); in development, where Azure is
+  // not configured, it is an inline data URL so the pad still works locally.
+  signatureUrl           String?
+  signatureSignedByName  String?   // Printed name, shown under the signature
+  signatureSignedAt      DateTime?
+  signatureCapturedBy    String?   // User id of the staff member who witnessed it
   // Combined-invoice consolidation: a parent invoice rolls up several pending children
   combinedInvoiceId String?
   customer       Customer        @relation(fields: [customerId], references: [id])
@@ -262,6 +280,7 @@ model Invoice {
   company        Company         @relation(fields: [companyId], references: [id])
   appointment    Appointment?    @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
   items          InvoiceItem[]
+  declinedItems  InvoiceDeclinedItem[] // Work the customer declined; never billed
   payments       InvoicePayment[] // Payment ledger (supports partial/split payments)
   inspections    Inspection[]
   squarePayments SquarePayment[] // Square payments for this invoice
@@ -311,6 +330,25 @@ model InvoiceItem {
   updatedAt   DateTime        @updatedAt
   invoice     Invoice         @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
   tire        Tire?           @relation(fields: [tireId], references: [id])
+}
+
+/// Services or parts the customer was offered and declined. Recorded so the
+/// invoice can show what was NOT done, which protects the shop if a declined
+/// item later fails. These rows are never billed and never enter any total —
+/// they are deliberately separate from InvoiceItem for exactly that reason.
+model InvoiceDeclinedItem {
+  id          String   @id @default(cuid())
+  invoiceId   String
+  description String
+  // Set when this row was derived from a repair order line, so re-closing an RO
+  // can rebuild the derived rows without discarding manually added ones.
+  roServiceId String?
+  sortOrder   Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  invoice     Invoice  @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+
+  @@index([invoiceId])
 }
 
 model SquarePayment {

--- a/server/src/common/services/azure-blob.service.ts
+++ b/server/src/common/services/azure-blob.service.ts
@@ -310,6 +310,64 @@ export class AzureBlobService {
   }
 
   /**
+   * Upload a customer signature image (PNG off the signature pad canvas).
+   *
+   * Same private-container rule as RO media: the storage account has "Allow Blob
+   * public access" disabled, so the container is created private and the image
+   * is served through a short-lived SAS URL on read.
+   */
+  async uploadInvoiceSignature(
+    buffer: Buffer,
+    invoiceId: string
+  ): Promise<UploadResult> {
+    if (!this.isConfigured) {
+      // Dev fallback: return the signature inline so the feature is testable
+      // locally without an Azure account.
+      this.logger.warn(
+        '⚠️ Azure Storage not configured - returning inline data URL for signature'
+      );
+      return {
+        blobUrl: `data:image/png;base64,${buffer.toString('base64')}`,
+        blobName: `mock-signature-${invoiceId}`,
+        containerName: 'invoice-signatures',
+        size: buffer.length,
+      };
+    }
+
+    try {
+      const containerName = 'invoice-signatures';
+      const containerClient =
+        this.blobServiceClient!.getContainerClient(containerName);
+      await containerClient.createIfNotExists();
+
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = String(now.getMonth() + 1).padStart(2, '0');
+      const safeInvoiceId = invoiceId.replace(/[^a-zA-Z0-9-]/g, '');
+      const blobName = `${year}/${month}/signature-${safeInvoiceId}-${Date.now()}.png`;
+
+      const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+      await blockBlobClient.upload(buffer, buffer.length, {
+        blobHTTPHeaders: { blobContentType: 'image/png' },
+      });
+
+      this.logger.log(`Uploaded invoice signature: ${blobName}`);
+      return {
+        blobName,
+        blobUrl: blockBlobClient.url,
+        containerName,
+        size: buffer.length,
+      };
+    } catch (error) {
+      this.logger.error(
+        'Error uploading invoice signature to Azure Blob Storage',
+        error
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Delete invoice image from Azure Blob Storage
    */
   async deleteInvoiceImage(

--- a/server/src/companies/companies.controller.ts
+++ b/server/src/companies/companies.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
 import { CompaniesService } from './companies.service';
 import { Roles } from '../auth/decorators/roles.decorator';
+import { UpdateCompanyTermsDto } from '@gt-automotive/data';
 
 @Controller('companies')
 export class CompaniesController {
@@ -16,5 +17,16 @@ export class CompaniesController {
   @Roles('ADMIN', 'FOREMAN', 'ACCOUNTANT', 'STAFF', 'SUPERVISOR')
   findDefault() {
     return this.companiesService.findDefault();
+  }
+
+  // Admin-only: the terms & conditions are a liability statement, so editing
+  // them is deliberately not a general staff permission.
+  @Patch(':id/terms')
+  @Roles('ADMIN')
+  updateTerms(@Param('id') id: string, @Body() dto: UpdateCompanyTermsDto) {
+    return this.companiesService.updateTermsAndConditions(
+      id,
+      dto.termsAndConditions ?? null
+    );
   }
 }

--- a/server/src/companies/companies.service.ts
+++ b/server/src/companies/companies.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '@gt-automotive/database';
 
 @Injectable()
@@ -7,22 +7,41 @@ export class CompaniesService {
 
   async findAll() {
     return this.prisma.company.findMany({
-      orderBy: [
-        { isDefault: 'desc' },
-        { name: 'asc' }
-      ]
+      orderBy: [{ isDefault: 'desc' }, { name: 'asc' }],
     });
   }
 
   async findDefault() {
     return this.prisma.company.findFirst({
-      where: { isDefault: true }
+      where: { isDefault: true },
     });
   }
 
   async findById(id: string) {
     return this.prisma.company.findUnique({
-      where: { id }
+      where: { id },
+    });
+  }
+
+  /**
+   * Update the terms & conditions printed at the foot of this company's
+   * invoices. Kept editable from admin settings because the wording is a
+   * liability statement owned by the business, not by the code.
+   */
+  async updateTermsAndConditions(
+    id: string,
+    termsAndConditions: string | null
+  ) {
+    const company = await this.prisma.company.findUnique({ where: { id } });
+    if (!company) {
+      throw new NotFoundException(`Company with ID ${id} not found`);
+    }
+
+    const trimmed = termsAndConditions?.trim();
+    return this.prisma.company.update({
+      where: { id },
+      // Blank input clears the block entirely rather than printing an empty box.
+      data: { termsAndConditions: trimmed ? trimmed : null },
     });
   }
 }

--- a/server/src/invoices/invoices-signature.service.spec.ts
+++ b/server/src/invoices/invoices-signature.service.spec.ts
@@ -1,0 +1,157 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { InvoicesService } from './invoices.service';
+
+/**
+ * Unit tests for invoice signature capture.
+ *
+ * The service is built directly with mocked collaborators (no Nest DI) so these
+ * focus on the data-URL validation — the endpoint accepts a caller-supplied
+ * string and writes it to blob storage, so it must not be usable to upload
+ * arbitrary content.
+ */
+describe('InvoicesService — customer signature', () => {
+  let service: InvoicesService;
+  let setSignature: jest.Mock;
+  let clearSignature: jest.Mock;
+  let uploadInvoiceSignature: jest.Mock;
+  let deleteInvoiceImage: jest.Mock;
+  let findById: jest.Mock;
+
+  /** A real 1x1 PNG, so the magic-number check passes. */
+  const validPngDataUrl =
+    'data:image/png;base64,' +
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+  beforeEach(() => {
+    findById = jest.fn().mockResolvedValue({
+      id: 'invoice-1',
+      signatureBlobName: null,
+      signatureContainerName: null,
+    });
+    setSignature = jest.fn(async (id: string, signature: any) => ({
+      id,
+      ...signature,
+    }));
+    clearSignature = jest.fn(async (id: string) => ({ id }));
+    uploadInvoiceSignature = jest.fn().mockResolvedValue({
+      blobName: '2026/08/signature-invoice-1-123.png',
+      containerName: 'invoice-signatures',
+      blobUrl: 'https://blob.example/signature.png',
+      size: 100,
+    });
+    deleteInvoiceImage = jest.fn().mockResolvedValue(true);
+
+    service = new InvoicesService(
+      { findById, setSignature, clearSignature } as any,
+      { create: jest.fn().mockResolvedValue({}) } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        uploadInvoiceSignature,
+        deleteInvoiceImage,
+        generateSasUrl: jest.fn(),
+      } as any
+    );
+  });
+
+  it('stores a valid PNG signature and records who witnessed it', async () => {
+    await service.captureSignature(
+      'invoice-1',
+      { imageDataUrl: validPngDataUrl, signedByName: '  Jane Doe  ' },
+      'user-1'
+    );
+
+    expect(uploadInvoiceSignature).toHaveBeenCalledTimes(1);
+    const [buffer, invoiceId] = uploadInvoiceSignature.mock.calls[0];
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(invoiceId).toBe('invoice-1');
+
+    const [, signature] = setSignature.mock.calls[0];
+    expect(signature.blobName).toBe('2026/08/signature-invoice-1-123.png');
+    expect(signature.containerName).toBe('invoice-signatures');
+    // Name is trimmed before it is printed on the invoice.
+    expect(signature.signedByName).toBe('Jane Doe');
+    expect(signature.capturedBy).toBe('user-1');
+  });
+
+  it('stores null rather than an empty printed name', async () => {
+    await service.captureSignature(
+      'invoice-1',
+      { imageDataUrl: validPngDataUrl, signedByName: '   ' },
+      'user-1'
+    );
+
+    const [, signature] = setSignature.mock.calls[0];
+    expect(signature.signedByName).toBeNull();
+  });
+
+  it.each([
+    ['a plain string', 'not-a-data-url'],
+    ['a non-PNG mime type', 'data:image/svg+xml;base64,PHN2Zy8+'],
+    ['an empty payload', 'data:image/png;base64,'],
+    ['a remote URL', 'https://evil.example/payload.png'],
+  ])('rejects %s', async (_label, imageDataUrl) => {
+    await expect(
+      service.captureSignature('invoice-1', { imageDataUrl }, 'user-1')
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(uploadInvoiceSignature).not.toHaveBeenCalled();
+  });
+
+  it('rejects base64 that decodes to something other than a PNG', async () => {
+    // Valid base64, correct prefix, but the bytes are not a PNG.
+    const notAPng = `data:image/png;base64,${Buffer.from(
+      'GIF89a-this-is-not-a-png'
+    ).toString('base64')}`;
+
+    await expect(
+      service.captureSignature('invoice-1', { imageDataUrl: notAPng }, 'user-1')
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(uploadInvoiceSignature).not.toHaveBeenCalled();
+  });
+
+  it('throws when the invoice does not exist', async () => {
+    findById.mockResolvedValueOnce(null);
+
+    await expect(
+      service.captureSignature(
+        'missing',
+        { imageDataUrl: validPngDataUrl },
+        'user-1'
+      )
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('deletes the stored blob when a signature is cleared', async () => {
+    findById.mockResolvedValueOnce({
+      id: 'invoice-1',
+      signatureBlobName: 'sig.png',
+      signatureContainerName: 'invoice-signatures',
+    });
+
+    await service.clearSignature('invoice-1', 'user-1');
+
+    expect(deleteInvoiceImage).toHaveBeenCalledWith(
+      'invoice-signatures',
+      'sig.png'
+    );
+    expect(clearSignature).toHaveBeenCalledWith('invoice-1');
+  });
+
+  it('still clears the signature when blob deletion fails', async () => {
+    findById.mockResolvedValueOnce({
+      id: 'invoice-1',
+      signatureBlobName: 'sig.png',
+      signatureContainerName: 'invoice-signatures',
+    });
+    deleteInvoiceImage.mockRejectedValueOnce(new Error('blob gone'));
+
+    await expect(
+      service.clearSignature('invoice-1', 'user-1')
+    ).resolves.toBeDefined();
+    expect(clearSignature).toHaveBeenCalledWith('invoice-1');
+  });
+});

--- a/server/src/invoices/invoices.controller.ts
+++ b/server/src/invoices/invoices.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import { InvoicesService } from './invoices.service';
 import {
+  CaptureInvoiceSignatureDto,
   CreateInvoiceDto,
   CreateServiceDto,
   UpdateInvoiceDto,
@@ -121,6 +122,24 @@ export class InvoicesController {
     @CurrentUser() user: any
   ) {
     return this.invoicesService.update(id, updateInvoiceDto, user.id);
+  }
+
+  @Post(':id/signature')
+  @UseGuards(RoleGuard)
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF', 'ACCOUNTANT')
+  captureSignature(
+    @Param('id') id: string,
+    @Body() dto: CaptureInvoiceSignatureDto,
+    @CurrentUser() user: any
+  ) {
+    return this.invoicesService.captureSignature(id, dto, user.id);
+  }
+
+  @Delete(':id/signature')
+  @UseGuards(RoleGuard)
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF', 'ACCOUNTANT')
+  clearSignature(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.invoicesService.clearSignature(id, user.id);
   }
 
   @Post(':id/pay')

--- a/server/src/invoices/invoices.module.ts
+++ b/server/src/invoices/invoices.module.ts
@@ -9,6 +9,7 @@ import { PrismaService } from '@gt-automotive/database';
 import { PdfModule } from '../pdf/pdf.module';
 import { EmailModule } from '../email/email.module';
 import { CarfaxModule } from '../carfax/carfax.module';
+import { AzureBlobService } from '../common/services/azure-blob.service';
 
 @Module({
   imports: [PdfModule, EmailModule, CarfaxModule],
@@ -20,6 +21,7 @@ import { CarfaxModule } from '../carfax/carfax.module';
     CustomerRepository,
     ServiceRepository,
     PrismaService,
+    AzureBlobService,
   ],
   exports: [InvoicesService, InvoiceRepository],
 })

--- a/server/src/invoices/invoices.service.spec.ts
+++ b/server/src/invoices/invoices.service.spec.ts
@@ -32,6 +32,8 @@ describe('InvoicesService.create — totals calculation', () => {
     const serviceRepository = {};
     const pdfService = {};
     const emailService = {};
+    const carfaxService = { reportInvoice: jest.fn().mockResolvedValue({}) };
+    const azureBlob = {};
 
     service = new InvoicesService(
       invoiceRepository as any,
@@ -39,7 +41,9 @@ describe('InvoicesService.create — totals calculation', () => {
       customerRepository as any,
       serviceRepository as any,
       pdfService as any,
-      emailService as any
+      emailService as any,
+      carfaxService as any,
+      azureBlob as any
     );
   });
 

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { InvoiceRepository } from './repositories/invoice.repository';
 import {
+  CaptureInvoiceSignatureDto,
   CreateInvoiceDto,
   CreateServiceDto,
   UpdateInvoiceDto,
@@ -28,6 +29,39 @@ import { EmailService } from '../email/email.service';
 import { CarfaxService } from '../carfax/carfax.service';
 import { buildAdjustmentItems } from './invoice-adjustments';
 import { toBusinessCalendarDate } from '../config/timezone.config';
+import { AzureBlobService } from '../common/services/azure-blob.service';
+
+/** Largest signature image accepted, decoded. A pad drawing is a few tens of KB. */
+const MAX_SIGNATURE_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Decode the `data:image/png;base64,...` payload produced by the signature pad
+ * canvas. Rejects anything that is not a PNG data URL so the endpoint cannot be
+ * used to push arbitrary files into blob storage.
+ */
+function decodePngDataUrl(dataUrl: string): Buffer {
+  const match = /^data:image\/png;base64,([A-Za-z0-9+/=]+)$/.exec(
+    (dataUrl || '').trim()
+  );
+  if (!match) {
+    throw new BadRequestException(
+      'Signature must be a base64-encoded PNG data URL'
+    );
+  }
+
+  const buffer = Buffer.from(match[1], 'base64');
+  if (buffer.length === 0) {
+    throw new BadRequestException('Signature image is empty');
+  }
+  if (buffer.length > MAX_SIGNATURE_BYTES) {
+    throw new BadRequestException('Signature image is too large');
+  }
+  // PNG magic number — guards against a base64 body that decodes to something else.
+  if (!buffer.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex'))) {
+    throw new BadRequestException('Signature image is not a valid PNG');
+  }
+  return buffer;
+}
 
 @Injectable()
 export class InvoicesService {
@@ -38,7 +72,8 @@ export class InvoicesService {
     private readonly serviceRepository: ServiceRepository,
     private readonly pdfService: PdfService,
     private readonly emailService: EmailService,
-    private readonly carfaxService: CarfaxService
+    private readonly carfaxService: CarfaxService,
+    private readonly azureBlob: AzureBlobService
   ) {}
 
   async create(
@@ -229,7 +264,8 @@ export class InvoicesService {
             paidAt: new Date(),
             createdBy: userId,
           }
-        : undefined
+        : undefined,
+      createInvoiceDto.declinedItems
     );
 
     // Log the creation
@@ -287,7 +323,9 @@ export class InvoicesService {
       throw new ForbiddenException('You can only view your own invoices');
     }
 
-    return invoice;
+    // The signature blob is private; hand back a short-lived SAS URL so the
+    // detail view and the browser print template can render it.
+    return this.withSignatureUrl(invoice);
   }
 
   async update(
@@ -472,10 +510,19 @@ export class InvoicesService {
       updateData.paidAt = null;
     }
 
-    // Use updateWithItems if items are provided, otherwise use regular update
-    const updated = items
-      ? await this.invoiceRepository.updateWithItems(id, updateData, items)
-      : await this.invoiceRepository.update(id, updateData);
+    // Use updateWithItems if items or declined items are provided, otherwise use
+    // regular update. Declined items are replaced wholesale, so an explicit []
+    // clears them while omitting the field leaves them alone.
+    const declinedItems = updateInvoiceDto.declinedItems;
+    const updated =
+      items || declinedItems
+        ? await this.invoiceRepository.updateWithItems(
+            id,
+            updateData,
+            items,
+            declinedItems
+          )
+        : await this.invoiceRepository.update(id, updateData);
 
     if (revertToUnpaid) {
       await this.invoiceRepository.clearPayments(id);
@@ -505,6 +552,103 @@ export class InvoicesService {
     });
 
     return updated;
+  }
+
+  /**
+   * Store a customer signature captured on the signature pad. Signing is always
+   * optional — nothing here gates payment; an unsigned invoice simply prints a
+   * blank signature line.
+   */
+  async captureSignature(
+    id: string,
+    dto: CaptureInvoiceSignatureDto,
+    userId: string
+  ): Promise<Invoice> {
+    const invoice = await this.invoiceRepository.findById(id);
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID ${id} not found`);
+    }
+
+    const buffer = decodePngDataUrl(dto.imageDataUrl);
+
+    const upload = await this.azureBlob.uploadInvoiceSignature(buffer, id);
+
+    const updated = await this.invoiceRepository.setSignature(id, {
+      blobName: upload.blobName,
+      containerName: upload.containerName,
+      url: upload.blobUrl,
+      signedByName: dto.signedByName?.trim() || null,
+      capturedBy: userId,
+    });
+
+    await this.auditRepository.create({
+      userId,
+      action: 'CAPTURE_INVOICE_SIGNATURE',
+      entityType: 'invoice',
+      entityId: id,
+      details: {
+        signedByName: dto.signedByName ?? null,
+        blobName: upload.blobName,
+      } as any,
+    });
+
+    return this.withSignatureUrl(updated);
+  }
+
+  /** Remove a captured signature so it can be re-taken. */
+  async clearSignature(id: string, userId: string): Promise<Invoice> {
+    const invoice = await this.invoiceRepository.findById(id);
+    if (!invoice) {
+      throw new NotFoundException(`Invoice with ID ${id} not found`);
+    }
+
+    // Best-effort blob cleanup — a leftover blob must never block clearing the
+    // signature on the invoice itself.
+    if (invoice.signatureContainerName && invoice.signatureBlobName) {
+      await this.azureBlob
+        .deleteInvoiceImage(
+          invoice.signatureContainerName,
+          invoice.signatureBlobName
+        )
+        .catch(() => undefined);
+    }
+
+    const updated = await this.invoiceRepository.clearSignature(id);
+
+    await this.auditRepository.create({
+      userId,
+      action: 'CLEAR_INVOICE_SIGNATURE',
+      entityType: 'invoice',
+      entityId: id,
+      details: { previousBlobName: invoice.signatureBlobName } as any,
+    });
+
+    return updated;
+  }
+
+  /**
+   * Swap the stored (private) signature URL for a short-lived SAS URL so the
+   * browser and the PDF renderer can actually load the image. Data URLs from the
+   * development fallback are passed through untouched.
+   */
+  private async withSignatureUrl<T extends Invoice>(invoice: T): Promise<T> {
+    if (!invoice?.signatureBlobName || !invoice.signatureContainerName) {
+      return invoice;
+    }
+    if (invoice.signatureUrl?.startsWith('data:')) {
+      return invoice;
+    }
+    try {
+      const signatureUrl = await this.azureBlob.generateSasUrl(
+        invoice.signatureContainerName,
+        invoice.signatureBlobName,
+        120
+      );
+      return { ...invoice, signatureUrl };
+    } catch {
+      // Fall back to the stored URL rather than failing the whole request.
+      return invoice;
+    }
   }
 
   async remove(id: string, userId: string): Promise<void> {
@@ -1074,7 +1218,11 @@ export class InvoicesService {
 
     try {
       // Generate PDF
-      const pdfBase64 = await this.pdfService.generateInvoicePdf(invoice);
+      // Puppeteer fetches the signature over the network, so it needs a SAS URL —
+      // the raw blob URL is private and would render as a broken image.
+      const pdfBase64 = await this.pdfService.generateInvoicePdf(
+        await this.withSignatureUrl(invoice)
+      );
 
       // Send email to all recipients
       const emailResult = await this.emailService.sendInvoiceEmail(

--- a/server/src/invoices/repositories/invoice.repository.ts
+++ b/server/src/invoices/repositories/invoice.repository.ts
@@ -9,6 +9,48 @@ import {
   POSTGRES_TIMEZONE,
 } from '../../config/timezone.config';
 
+/**
+ * Everything the invoice detail view, the emailed PDF and the browser print
+ * template need. Kept in one place because it is used by every method that
+ * returns a fully-formed invoice — declined items in particular must ride along
+ * on all of them, or the "declined" section silently disappears on whichever
+ * path was missed.
+ */
+const INVOICE_DETAIL_INCLUDE = {
+  customer: true,
+  vehicle: true,
+  company: true,
+  items: {
+    include: {
+      tire: true,
+    },
+  },
+  declinedItems: {
+    orderBy: { sortOrder: 'asc' },
+  },
+} as const satisfies Prisma.InvoiceInclude;
+
+export interface DeclinedItemInput {
+  description: string;
+  roServiceId?: string | null;
+  sortOrder?: number;
+}
+
+/**
+ * Normalize declined rows for insert: blank descriptions are dropped (an empty
+ * bullet on a printed invoice looks like a mistake) and order is made explicit
+ * so the printed list matches what the user arranged on screen.
+ */
+function toDeclinedItemRows(items: DeclinedItemInput[]) {
+  return items
+    .filter((item) => item.description?.trim())
+    .map((item, index) => ({
+      description: item.description.trim(),
+      roServiceId: item.roServiceId ?? null,
+      sortOrder: item.sortOrder ?? index,
+    }));
+}
+
 @Injectable()
 export class InvoiceRepository extends BaseRepository<
   Invoice,
@@ -56,16 +98,9 @@ export class InvoiceRepository extends BaseRepository<
     return this.prisma.invoice.findUnique({
       where: { id },
       include: {
-        customer: true,
-        vehicle: true,
-        company: true,
+        ...INVOICE_DETAIL_INCLUDE,
         repairOrder: {
           select: { id: true, roNumber: true, status: true },
-        },
-        items: {
-          include: {
-            tire: true,
-          },
         },
       },
     });
@@ -81,7 +116,8 @@ export class InvoiceRepository extends BaseRepository<
       paymentMethod: PaymentMethod;
       paidAt: Date;
       createdBy: string;
-    }
+    },
+    declinedItems?: DeclinedItemInput[]
   ): Promise<Invoice> {
     return this.prisma.$transaction(async (tx) => {
       const invoice = await tx.invoice.create({
@@ -90,16 +126,12 @@ export class InvoiceRepository extends BaseRepository<
           items: {
             create: items,
           },
+          ...(declinedItems?.length
+            ? { declinedItems: { create: toDeclinedItemRows(declinedItems) } }
+            : {}),
         },
         include: {
-          customer: true,
-          vehicle: true,
-          company: true,
-          items: {
-            include: {
-              tire: true,
-            },
-          },
+          ...INVOICE_DETAIL_INCLUDE,
         },
       });
 
@@ -145,14 +177,7 @@ export class InvoiceRepository extends BaseRepository<
         paidAt: status === 'PAID' ? paidAt || new Date() : undefined,
       },
       include: {
-        customer: true,
-        vehicle: true,
-        company: true,
-        items: {
-          include: {
-            tire: true,
-          },
-        },
+        ...INVOICE_DETAIL_INCLUDE,
       },
     });
   }
@@ -160,9 +185,16 @@ export class InvoiceRepository extends BaseRepository<
   async updateWithItems(
     id: string,
     invoiceData: Prisma.InvoiceUpdateInput,
-    items?: Prisma.InvoiceItemCreateWithoutInvoiceInput[]
+    items?: Prisma.InvoiceItemCreateWithoutInvoiceInput[],
+    // Undefined leaves the existing declined list alone; an array (including an
+    // empty one) replaces it wholesale.
+    declinedItems?: DeclinedItemInput[]
   ): Promise<Invoice> {
     return this.prisma.$transaction(async (tx) => {
+      if (declinedItems) {
+        await tx.invoiceDeclinedItem.deleteMany({ where: { invoiceId: id } });
+      }
+
       // If items are provided, delete old items and create new ones
       if (items) {
         // Get existing items to restore tire inventory
@@ -203,16 +235,12 @@ export class InvoiceRepository extends BaseRepository<
               create: items,
             },
           }),
+          ...(declinedItems?.length
+            ? { declinedItems: { create: toDeclinedItemRows(declinedItems) } }
+            : {}),
         },
         include: {
-          customer: true,
-          vehicle: true,
-          company: true,
-          items: {
-            include: {
-              tire: true,
-            },
-          },
+          ...INVOICE_DETAIL_INCLUDE,
         },
       });
 
@@ -233,6 +261,54 @@ export class InvoiceRepository extends BaseRepository<
       }
 
       return invoice;
+    });
+  }
+
+  // ---- Customer signature -------------------------------------------------
+
+  /**
+   * Attach a captured signature to an invoice. Only blob coordinates are stored;
+   * the image itself is served later through a short-lived SAS URL because the
+   * storage account forbids public blob access.
+   */
+  async setSignature(
+    id: string,
+    signature: {
+      blobName: string;
+      containerName: string;
+      url: string;
+      signedByName?: string | null;
+      capturedBy: string;
+      signedAt?: Date;
+    }
+  ): Promise<Invoice> {
+    return this.prisma.invoice.update({
+      where: { id },
+      data: {
+        signatureBlobName: signature.blobName,
+        signatureContainerName: signature.containerName,
+        signatureUrl: signature.url,
+        signatureSignedByName: signature.signedByName ?? null,
+        signatureCapturedBy: signature.capturedBy,
+        signatureSignedAt: signature.signedAt ?? new Date(),
+      },
+      include: { ...INVOICE_DETAIL_INCLUDE },
+    });
+  }
+
+  /** Clear a signature, returning the invoice to its unsigned (blank line) state. */
+  async clearSignature(id: string): Promise<Invoice> {
+    return this.prisma.invoice.update({
+      where: { id },
+      data: {
+        signatureBlobName: null,
+        signatureContainerName: null,
+        signatureUrl: null,
+        signatureSignedByName: null,
+        signatureCapturedBy: null,
+        signatureSignedAt: null,
+      },
+      include: { ...INVOICE_DETAIL_INCLUDE },
     });
   }
 
@@ -301,10 +377,7 @@ export class InvoiceRepository extends BaseRepository<
         where: { id: invoiceId },
         data: invoiceUpdate,
         include: {
-          customer: true,
-          vehicle: true,
-          company: true,
-          items: { include: { tire: true } },
+          ...INVOICE_DETAIL_INCLUDE,
         },
       });
     });

--- a/server/src/pdf/pdf.service.ts
+++ b/server/src/pdf/pdf.service.ts
@@ -2,6 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 import puppeteer from 'puppeteer';
 import * as fs from 'fs';
 import * as path from 'path';
+import {
+  hasPrintableDeclinedItems,
+  renderDeclinedItemsHtml,
+  renderSignatureHtml,
+  renderTermsAndConditionsHtml,
+} from '@gt-automotive/data';
 
 @Injectable()
 export class PdfService {
@@ -62,6 +68,25 @@ export class PdfService {
    * Generate invoice HTML from invoice data
    */
   generateInvoiceHtml(invoice: any): string {
+    // The signature prints inside the declined-services box when work was
+    // declined (so it acknowledges that list), and on its own at the foot of the
+    // invoice otherwise. Either way there is exactly one signature line.
+    const signature = {
+      url: invoice.signatureUrl,
+      signedByName: invoice.signatureSignedByName,
+      signedAt: invoice.signatureSignedAt,
+    };
+    const signatureCustomerName =
+      [invoice.customer?.firstName, invoice.customer?.lastName]
+        .filter(Boolean)
+        .join(' ') ||
+      invoice.customer?.name ||
+      invoice.customer?.businessName ||
+      '';
+    const signatureInDeclinedBox = hasPrintableDeclinedItems(
+      invoice.declinedItems
+    );
+
     const formatCurrency = (amount: number | string) => {
       const numAmount =
         typeof amount === 'string' ? parseFloat(amount) : amount;
@@ -338,6 +363,12 @@ ${
               : ''
           }
 
+          ${renderDeclinedItemsHtml(
+            invoice.declinedItems,
+            signature,
+            signatureCustomerName
+          )}
+
           ${
             invoice.customer?.pstExempt
               ? `
@@ -370,6 +401,14 @@ ${
             </div>
           `
               : ''
+          }
+
+          ${renderTermsAndConditionsHtml(invoice.company?.termsAndConditions)}
+
+          ${
+            signatureInDeclinedBox
+              ? ''
+              : renderSignatureHtml(signature, signatureCustomerName)
           }
 
           <div style="margin-top: 25px; text-align: center; color: #666; font-size: 0.85em;">

--- a/server/src/repair-orders/repair-orders.service.ts
+++ b/server/src/repair-orders/repair-orders.service.ts
@@ -724,16 +724,29 @@ export class RepairOrdersService {
    * technician notes followed by a list of any customer-declined items (which
    * are not billed, so they only appear here for the customer's record).
    */
-  private async buildRoInvoiceNotes(
-    roId: string,
+  private buildRoInvoiceNotes(
     technicianNotes?: string | null
-  ): Promise<string | undefined> {
-    const parts: string[] = [];
-
-    if (technicianNotes && technicianNotes.trim()) {
-      parts.push(`Technician Notes:\n${technicianNotes.trim()}`);
+  ): string | undefined {
+    if (!technicianNotes?.trim()) {
+      return undefined;
     }
+    return `Technician Notes:\n${technicianNotes.trim()}`;
+  }
 
+  /**
+   * Declined services/parts for an RO, as structured invoice rows.
+   *
+   * These used to be appended as text into the invoice's `notes` field, which
+   * meant they could not be styled or separated from whatever else was typed
+   * into notes. They are now real rows on the invoice so the templates can print
+   * them as their own clearly-headed section. Description only — a declined item
+   * must never read like a charge.
+   */
+  private async buildRoDeclinedItems(
+    roId: string
+  ): Promise<
+    { description: string; roServiceId: string; sortOrder: number }[]
+  > {
     const declined = await this.prisma.rOService.findMany({
       where: {
         repairOrderId: roId,
@@ -742,13 +755,12 @@ export class RepairOrdersService {
       },
       orderBy: { createdAt: 'asc' },
     });
-    if (declined.length > 0) {
-      // List declined items by name only (no quantity/price).
-      const lines = declined.map((s: any) => `• ${s.description}`).join('\n');
-      parts.push(`Customer Declined Items:\n${lines}`);
-    }
 
-    return parts.length > 0 ? parts.join('\n\n') : undefined;
+    return declined.map((service: any, index: number) => ({
+      description: service.description,
+      roServiceId: service.id,
+      sortOrder: index,
+    }));
   }
 
   private buildRoInvoiceTotals(
@@ -885,8 +897,10 @@ export class RepairOrdersService {
 
     // Carry the RO's technician notes and any customer-declined items onto the
     // invoice so they print/email with it. Declined items aren't billed (they're
-    // not in `items`), so they're listed here for the customer's record.
-    const invoiceNotes = await this.buildRoInvoiceNotes(id, ro.technicianNotes);
+    // not in `items`) and are stored as their own rows, so the invoice can print
+    // them as a distinct section below the technician notes.
+    const invoiceNotes = this.buildRoInvoiceNotes(ro.technicianNotes);
+    const declinedItems = await this.buildRoDeclinedItems(id);
 
     // Re-sync path: reopened RO with an existing unpaid invoice. Rebuild its line
     // items and totals in place, keeping the same invoice id/number and PENDING
@@ -896,6 +910,14 @@ export class RepairOrdersService {
       return this.prisma.$transaction(async (tx) => {
         await tx.invoiceItem.deleteMany({
           where: { invoiceId: existingInvoice.id },
+        });
+        // Rebuild only the rows derived from this RO. Declined items added by
+        // hand on the invoice (roServiceId null) survive a re-sync.
+        await tx.invoiceDeclinedItem.deleteMany({
+          where: {
+            invoiceId: existingInvoice.id,
+            roServiceId: { not: null },
+          },
         });
         const invoice = await tx.invoice.update({
           where: { id: existingInvoice.id },
@@ -915,6 +937,9 @@ export class RepairOrdersService {
             // RO re-closed after 5 PM PST isn't dated to the next (UTC) day.
             invoiceDate: toBusinessCalendarDate(),
             items: { create: items as any },
+            ...(declinedItems.length
+              ? { declinedItems: { create: declinedItems } }
+              : {}),
           },
         });
         if (inspectionIdsToLink.length) {
@@ -966,6 +991,9 @@ export class RepairOrdersService {
         items: {
           create: items as any,
         },
+        ...(declinedItems.length
+          ? { declinedItems: { create: declinedItems } }
+          : {}),
       },
     });
 


### PR DESCRIPTION
Closes [GA-51](https://gt-automotives.atlassian.net/browse/GA-51).

Three additions to the invoice document, applied to **all three templates** — the emailed PDF (`pdf.service.ts`) and both browser print templates (`invoice.requests.ts`).

## 1. Declined services & parts

The RO flow already appended a `Customer Declined Items:` block into the invoice's free-text `notes`. That could not be styled or separated from anything else typed into notes, and only existed for RO-generated invoices.

- Replaced with real `InvoiceDeclinedItem` rows.
- Available on **any** invoice, not just those from a repair order — a walk-in who turns down a recommendation is recorded the same way.
- Description only, never quantity or price, and excluded from all totals, so a declined item can never read as a charge.
- Re-closing an RO rebuilds only the rows derived from it (`roServiceId` set); declined items added by hand on the invoice survive the re-sync.

## 2. Customer signature

- Draw-to-sign pad on **Pointer Events**, so finger, stylus and mouse take the same path. `touch-action: none` stops a finger drag scrolling the page instead of drawing, and the canvas is scaled by `devicePixelRatio` so the capture isn't a blurry upscale.
- Stored in a **private** Azure Blob container, served via short-lived SAS URLs — the storage account forbids public blob access.
- **Always optional.** An unsigned invoice prints a blank ruled line for a wet signature.
- Prints **inside the declined-services box** when work was declined, so the signature acknowledges that list; otherwise at the foot of the invoice. Either way there is exactly one signature line.
- The capture endpoint accepts only a base64 PNG data URL, verified by magic number and size, so it can't be used to push arbitrary files into blob storage.

## 3. Terms & conditions

- Stored on the `Company` record, edited from **Admin → Settings** (that route was previously a placeholder `<div>`). The wording is a liability statement owned by the business and must be changeable without a deploy.
- Blank initials line at the far right of the heading.
- ⚠️ Seeded with **placeholder wording** — the business needs to replace it with its own text before this reaches customers.

## Why the shared module

The three templates duplicated their markup, so every change had to be hand-applied to each and the emailed and printed copies drifted the moment one was missed. All three new sections live in a single shared module, `libs/data/src/lib/utils/invoice-print-sections.ts`, imported by both the server and the browser.

## Migrations

Three, all additive:

- `20260805195313_add_invoice_declined_items_signature_and_company_terms`
- `20260805195400_seed_default_company_terms` — fills only rows where terms are null
- `20260805195747_add_invoice_signature_url`

## Testing

- 613 tests pass across `server`, `data` and `webApp` (29 new: HTML section renderers, signature data-URL validation, blob cleanup).
- Lint 0 errors; both apps typecheck and build.
- Layout verified by rendering real PDFs through Puppeteer in four states: unsigned with declined items, signed with declined items, no declined items, and no terms configured.

### Not covered

Existing RO invoices keep their declined items as text in `notes` — no backfill. Stripping that text from historical records is riskier than leaving it, and rendering both would duplicate the list. Reprints of old invoices still show the information, just in the Notes block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)