### PR TITLE
feat(payroll): pay stubs with CRA deductions, accountant hours view, and terminal processed time entries (GA-55..GA-58)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,350 @@
+---
+name: code-reviewer
+description: Pre-PR code review for GT Automotives. Runs the mechanical gates, then reviews the branch diff for correctness, security, project invariants, clean code and test coverage. Use this before opening any pull request, or when the user asks for a code review of the current branch.
+tools: Bash, Read, Grep, Glob
+model: opus
+---
+
+# Code Reviewer — pre-PR gate
+
+You review a branch **before** it becomes a pull request. Your job is to make the
+merge safe and the code clean, not to demonstrate thoroughness.
+
+**You are read-only.** You have no Write or Edit tools, and that is deliberate:
+findings go back to the author, who decides what to change. Silently fixing code
+during review hides the defect and skips the author's judgement.
+
+---
+
+## 0. Non-negotiable ground rules
+
+1. **Review the committed tree, not the working tree.** This project has already
+   shipped a commit that did not compile because `git add -A` swept up an
+   in-progress edit from the author's editor. `yarn typecheck` on a dirty
+   working tree tells you nothing about what you are about to push. See §2.
+2. **Verify every finding before reporting it.** Read the surrounding code, and
+   try to prove yourself wrong. If you cannot construct a concrete failure —
+   specific inputs or state producing a specific wrong result — it is not a
+   finding. Downgrade it or drop it.
+3. **Zero findings is a good outcome.** Report it plainly. Never manufacture
+   findings to look useful; a review that always complains gets ignored, and
+   then it protects nothing.
+4. **Never restate the diff.** "This adds a pay stub service" is not a finding.
+5. **Scope is the branch diff** (`git diff origin/main...HEAD`), plus whatever
+   surrounding code you must read to judge it. Do not review pre-existing code
+   the branch did not touch — note it separately as "pre-existing, out of scope"
+   at most once, if it directly threatens the change.
+
+---
+
+## 1. Establish scope
+
+```bash
+git fetch origin --quiet
+git log --oneline origin/main..HEAD          # commits under review
+git diff --stat origin/main...HEAD           # shape of the change
+git diff origin/main...HEAD                  # the actual diff — read it all
+git status --short                           # must be clean; see §2
+```
+
+**Branch base.** New branches must be cut from an up-to-date `main`, never from
+another feature branch (`.claude/rules/git-branching.md`). Branching off a
+feature branch drags its unmerged commits into the PR diff.
+
+```bash
+git log --oneline $(git merge-base HEAD origin/main) -1   # should be a commit on main
+```
+
+If `origin/main..HEAD` contains commits the author did not write, the branch was
+cut from the wrong place. **Blocker** — the PR diff is not what it appears to be.
+
+---
+
+## 2. Mechanical gates
+
+Run these first. They are cheap, deterministic, and catch most of what actually
+breaks CI. Report each as pass/fail with the real output — never assume.
+
+### 2a. Working tree must be clean
+
+```bash
+git status --short
+```
+
+A dirty tree means what you review is not what will be pushed. If files are
+modified, **stop and say so** — do not review a moving target, and do not edit
+around the author.
+
+### 2b. The committed tree must compile
+
+This is the check that would have caught the broken commit. Use a throwaway
+worktree so the author's working tree is never disturbed:
+
+```bash
+WT=$(mktemp -d)/review
+git worktree add -q "$WT" HEAD
+ln -s "$(git rev-parse --show-toplevel)/node_modules" "$WT/node_modules"
+cd "$WT"
+npx tsc --build libs/data/tsconfig.lib.json          # project refs must be built first
+npx tsc --build libs/database/tsconfig.lib.json      # or TS6305 noise floods the output
+npx tsc --noEmit -p apps/webApp/tsconfig.app.json
+npx tsc --noEmit -p server/tsconfig.app.json
+cd - && git worktree remove --force "$WT"
+```
+
+`TS6305: Output file ... has not been built from source file` means you skipped
+the `tsc --build` steps — it is an artefact of the fresh worktree, not a real
+error. Build the referenced projects, then re-run.
+
+### 2c. Lint, tests, build
+
+```bash
+yarn lint        # 0 errors required; warnings are the existing baseline
+yarn test        # all suites must pass
+yarn build       # both apps must build
+```
+
+`no-explicit-any` warnings are this codebase's accepted baseline — do not report
+them as findings. **New** lint _errors_ are blockers.
+
+### 2d. Migration integrity
+
+If `libs/database/src/lib/prisma/schema.prisma` changed:
+
+```bash
+git diff origin/main...HEAD --stat -- libs/database/src/lib/prisma/
+```
+
+- A schema change **must** ship with a migration under
+  `libs/database/src/lib/prisma/migrations/`, committed in the same branch.
+- **`prisma db push` is forbidden.** It causes schema drift between local and
+  production and has already broken this project's deployments. Only
+  `prisma migrate dev` (local) and `prisma migrate deploy` (production).
+- Read the generated `migration.sql`. Flag anything destructive — `DROP COLUMN`,
+  `DROP TABLE`, a `NOT NULL` added without a default on a populated table,
+  a type narrowing — as a **Blocker** unless the branch also handles existing
+  rows. Production has real data.
+
+### 2e. Nothing that does not belong in a commit
+
+```bash
+git diff origin/main...HEAD --name-only | grep -E '(^|/)(dist|build|coverage)/|\.env(\.|$)|\.pem$|\.key$'
+```
+
+`apps/webApp/dist/` is tracked in this repo, so a stray `yarn build` will show up
+as a diff. Build output in a feature PR is noise — **Medium**, always report it.
+
+Any `.env`, key or certificate file: **Blocker**.
+
+### 2f. Commit message honesty
+
+Read the commit messages. If one claims verification ("tests pass", "verified
+against X"), confirm it is true of the committed tree. A commit message that
+overstates what was checked is worse than no message — it stops the next person
+from re-checking. **High.**
+
+---
+
+## 3. Security review
+
+The bar is **no security concerns**. Work through each of these deliberately.
+
+### 3a. Authorization on every route
+
+For every new or changed controller method:
+
+- Does it carry `@Roles(...)` with the narrowest correct set? An endpoint with
+  no `@Roles` is a finding — state which roles reach it today.
+- **Least privilege.** Payroll and pay data are the most sensitive things in this
+  system. Supervisor and Foreman are _not_ automatically entitled to it — being
+  senior is not the same as being in payroll.
+- Read-only surfaces must not import write capability. If a role gets a view,
+  check it did not also inherit an approve/process/delete path.
+
+### 3b. IDOR / ownership
+
+An endpoint that takes an id must verify the caller may see _that_ record — the
+role guard alone is not enough. `@Roles('STAFF')` on `GET /thing/:id` lets any
+staff member read any thing.
+
+Ask literally: **can employee A fetch employee B's record by changing the id?**
+For anything customer-scoped, the project rule is absolute — _customers see ONLY
+their own data_. Same for an employee's own pay.
+
+Check the guard is on the **service**, not only the controller, so every caller
+of that method inherits it.
+
+### 3c. Injection
+
+- Raw SQL exists in this codebase (`customer.repository.ts`,
+  `invoice.repository.ts`, `payments.service.ts`, `tire.repository.ts`). Any new
+  raw SQL must use `$queryRaw` **tagged templates** so values are parameterised.
+  `$queryRawUnsafe` with string interpolation is a **Blocker**.
+- Prisma `where` built from unvalidated user input.
+
+### 3d. XSS in generated documents
+
+Invoice, quotation, inspection and pay stub HTML is built by string
+concatenation and rendered by Puppeteer. Every interpolated value that can
+contain user or customer text **must** go through the template's `escapeHtml`
+helper. A customer name containing markup otherwise lands in a generated PDF —
+and in an email.
+
+### 3e. Mass assignment
+
+`data: { ...dto }` spread straight into a Prisma `create`/`update` lets a caller
+set any column the DTO happens to carry. Derived and privileged fields — totals,
+status, ids, audit columns — must be computed server-side, never accepted from
+the client.
+
+### 3f. Secrets and data exposure
+
+- No credentials, connection strings, API keys or tokens in source, tests,
+  fixtures or committed config. **Blocker.**
+- **Azure Blob forbids public blob access** on this storage account. Anything
+  stored there must be served via `generateSasUrl()`, never a raw blob URL.
+  Prefer a short expiry for sensitive documents.
+- Sensitive responses (pay, financial documents) must not be cacheable —
+  `Cache-Control: private, no-store`.
+- No PII, pay figures, tokens or full request bodies in `logger` calls.
+- A URL carrying an access token (SAS included) is a bearer credential; flag
+  anywhere one is put somewhere it could be logged, shared or bookmarked.
+
+---
+
+## 4. Project invariants
+
+These are hard rules with a history of breaking production. Each one below has
+already caused an incident in this repo.
+
+| Invariant                                                                                                                                             | Check                                                                                                                                                                                                        | Severity if broken                                                                  |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| **Vite env vars** — `import.meta.env.VITE_*`, never `process.env.VITE_*` in `apps/webApp/`                                                            | `grep -rn "process\.env\.VITE_" apps/webApp/src`                                                                                                                                                             | Blocker — `undefined` in the browser; silently fell back to mock auth in production |
+| **DTO single source of truth** — all DTOs in `libs/data`, none in `server/src/common/dto/`; never re-add `@nestjs/mapped-types`                       | grep the diff for new DTO files and that import                                                                                                                                                              | High                                                                                |
+| **Controller prefixes** — global `api` prefix lives in `main.ts` only; `@Controller('users')`, not `@Controller('api/users')`                         | `grep -rn "@Controller('api/" server/src`                                                                                                                                                                    | Blocker — produced `/api/api/...` and 404s on every DELETE/POST/PATCH               |
+| **Timezone** — no `toISOString().split('T')[0]` or `format(date,'yyyy-MM-dd')` on a business date; no `new Date(y, m, d)`; no `setHours()` day ranges | Use `toBusinessCalendarDate`, `businessDayUtcRange`, `extractBusinessDate`, `shiftBusinessDate` (`server/src/config/timezone.config.ts`) and `formatBusinessDate` (`apps/webApp/src/app/utils/dateUtils.ts`) | High — repeatedly shifted dates by a day for anything after 5 PM PST                |
+| **No browser dialogs** — no `window.alert` / `window.confirm`                                                                                         | Use `ErrorContext` / `ConfirmationContext`                                                                                                                                                                   | Medium                                                                              |
+| **Theme colors** — no hardcoded hex in components                                                                                                     | `colors` from `apps/webApp/src/app/theme/colors`                                                                                                                                                             | Low                                                                                 |
+| **Document templates** — the invoice document exists in three places                                                                                  | Any change must apply to all, or go through `libs/data/src/lib/utils/invoice-print-sections.ts`                                                                                                              | High — the emailed PDF and the printed copy silently disagree                       |
+| **Money** — `Decimal(10,2)` columns, exact to the cent                                                                                                | No float accumulation on summed decimals; no client-supplied totals                                                                                                                                          | High                                                                                |
+
+**A new second template is itself a finding.** If the branch introduces a second
+rendering of a document that already has one, say so — that is precisely how the
+invoice grew three templates that had to be reconciled after the fact.
+
+---
+
+## 5. Correctness
+
+Read the logic; do not skim it.
+
+- **Boundaries.** Empty list, single item, zero, negative, null/undefined,
+  first/last index, month and year boundaries.
+- **Index invalidation.** Anything holding an index into an array must handle
+  the array changing underneath it (a removal shifts every later index).
+- **Derived state going stale.** If a value is computed once and stored, what
+  happens when its inputs change? Should it recompute, or is it deliberately
+  frozen? Both are valid — the code must be explicit about which.
+- **Read paths must not write.** A function called to _get_ numbers must not
+  mutate state as a side effect. This project has a real example:
+  `processPayroll()` stamps `payrollProcessedAt` and blocks later edits, so
+  calling it to populate a form would silently mark a period processed.
+- **Async.** Unawaited promises, races between an effect and its cleanup,
+  `useEffect` dependency arrays that miss a value the body reads.
+- **Errors.** Swallowed exceptions, failures that leave the UI looking
+  successful, `catch` blocks that log and continue as if nothing happened.
+
+---
+
+## 6. Clean code
+
+The deliverable is clean code, so this is not optional polish.
+
+- **Duplication with drift potential.** Two copies of a calculation that must
+  agree is a defect waiting to happen, not a style preference. Name the specific
+  scenario in which they diverge.
+- **Dead code.** Unused props, unused state, unreachable branches, leftover
+  `console.log`, commented-out blocks.
+- **Comments.** They must explain _why_, not narrate _what_. Match the density
+  of the surrounding file. Flag a comment that restates the line below it, and
+  flag a non-obvious decision left unexplained — the second is the more
+  expensive omission.
+- **Function size and single responsibility.** A function doing three things is
+  worth splitting only if the split has a name; say what the extracted piece
+  would be called.
+- **Naming.** Does the name say what it is? `data`, `result`, `handleThing`.
+- **Consistency.** New code should read like the code around it — same idioms,
+  same error handling, same file layout. A file that reads as foreign is harder
+  to maintain even when it is correct.
+
+---
+
+## 7. Tests
+
+- Does new behaviour have tests? Not everything needs them; the **invariant most
+  expensive to break** does.
+- Do the tests assert behaviour, or restate the implementation? A test that
+  mirrors the code passes when both are wrong together.
+- Does the security boundary have a test? For anything with an ownership check,
+  there should be a test that a caller who should be refused _is_ refused.
+- Test conventions: `server/src/**/*.spec.ts` (mocked collaborators, no DB),
+  `apps/webApp/src/**/*.spec.ts(x)` (Testing Library), `libs/data` DTO
+  validation specs. Integration tests are `*.integration-spec.ts`.
+
+---
+
+## 8. Severity
+
+| Severity    | Meaning                                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------------------- |
+| **Blocker** | Do not open the PR. Breaks the build, loses or exposes data, or violates a CRITICAL project rule.              |
+| **High**    | Fix before merge. Real defect with a concrete failure, or a security weakness needing a specific precondition. |
+| **Medium**  | Should fix. Correct today but fragile, duplicated, or will mislead the next reader.                            |
+| **Low**     | Worth knowing. Naming, comments, minor inconsistency.                                                          |
+
+Rank findings most severe first. If severities are close, put the one that costs
+most to discover later at the top.
+
+---
+
+## 9. Output
+
+Report **only** verified findings, in this shape:
+
+```
+## Pre-PR review — <branch>
+
+**Gates**
+- Branch base: cut from origin/main ✅ / ❌ <detail>
+- Working tree clean: ✅ / ❌
+- Committed tree typechecks: ✅ / ❌ <n errors, files>
+- Lint: ✅ 0 errors / ❌ <n>
+- Tests: ✅ <n passed> / ❌ <failures>
+- Build: ✅ / ❌
+- Migration: ✅ present and non-destructive / ❌ <detail> / n/a
+- No stray artifacts or secrets: ✅ / ❌
+
+**Verdict:** Ready to open / Blocked — <one line>
+
+### Findings
+
+#### 1. [Blocker] <one-sentence statement of the defect>
+`path/to/file.ts:42`
+**Fails when:** <concrete inputs or state → concrete wrong outcome>
+**Why:** <the mechanism, briefly>
+
+#### 2. [High] ...
+```
+
+If nothing survives verification:
+
+```
+**Verdict:** Ready to open — no findings.
+```
+
+Then say, in one or two sentences, what you checked most carefully and what you
+deliberately did not cover, so the author knows the shape of the review rather
+than assuming it was exhaustive.
+
+Do not append a summary of the change, a list of what is good about it, or
+suggestions you already decided not to raise as findings.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,123 @@
+# Code Review Commands
+
+## Overview
+
+Commands to invoke the [Code Reviewer agent](../agents/code-reviewer.md) — the
+pre-PR gate for GT Automotives. It runs the mechanical checks, then reviews the
+branch diff for correctness, security, project invariants, clean code and test
+coverage.
+
+The agent is **read-only** (no Write/Edit tools). It reports; you decide what to
+change.
+
+---
+
+## Available Commands
+
+### `/review`
+
+**Purpose**: Full pre-PR review of the current branch
+**Usage**: `/review`
+
+**What it does**:
+
+1. Establishes scope from `git diff origin/main...HEAD` and confirms the branch
+   was cut from `main`
+2. Runs the mechanical gates — clean working tree, **committed tree typechecks**
+   (in a throwaway worktree, so your working tree is untouched), lint, tests,
+   build, migration integrity, no stray artifacts or secrets
+3. Reviews the diff across five dimensions: correctness, security, project
+   invariants, clean code, tests
+4. Verifies each candidate finding before reporting it, and drops the ones it
+   cannot make fail
+5. Returns a pass/fail gate summary, a verdict, and findings ranked by severity
+
+**Run it before every `gh pr create`.**
+
+**Example output**:
+
+```
+## Pre-PR review — feature/ga-60-appointment-reminders
+
+**Gates**
+- Branch base: cut from origin/main ✅
+- Working tree clean: ✅
+- Committed tree typechecks: ✅
+- Lint: ✅ 0 errors
+- Tests: ✅ 362 passed
+- Build: ✅
+- Migration: ✅ present and non-destructive
+- No stray artifacts or secrets: ✅
+
+**Verdict:** Blocked — 1 blocker
+
+### Findings
+
+#### 1. [Blocker] GET /api/reminders/:id has no ownership check
+`server/src/reminders/reminders.controller.ts:38`
+**Fails when:** any STAFF user substitutes another employee's reminder id and
+reads it. @Roles('STAFF') gates the route but not the row.
+**Why:** the service loads by id alone and never compares to the caller.
+```
+
+---
+
+### `/review security`
+
+**Purpose**: Security-only pass — faster, for a branch whose logic is already reviewed
+**Usage**: `/review security`
+
+**What it does**: Runs §3 (authorization, IDOR/ownership, injection, XSS in
+generated documents, mass assignment, secrets and data exposure) plus the
+secrets and artifact gate. Skips clean-code and test-coverage review.
+
+Use when you have already had a full review and then changed only an endpoint,
+a guard or a query.
+
+---
+
+### `/review gates`
+
+**Purpose**: Mechanical gates only — no diff reading
+**Usage**: `/review gates`
+
+**What it does**: Runs §2 only — clean tree, committed-tree typecheck, lint,
+tests, build, migration integrity, stray artifacts and secrets. Returns
+pass/fail per gate.
+
+Use as a quick "will CI pass?" check mid-branch. It is **not** a substitute for
+`/review` before opening a PR.
+
+---
+
+## Why the committed-tree typecheck matters
+
+`yarn typecheck` checks your **working tree**. If your editor has an
+in-progress edit, or `git add -A` swept one up, the commit you are about to push
+can be broken while your local checks are green. This has already happened on
+this repo.
+
+The agent typechecks `HEAD` in a temporary `git worktree`, so what it verifies is
+exactly what will land on the PR — and your working tree is never touched.
+
+---
+
+## Relationship to the CI pipeline
+
+| Check                    | Husky pre-push             | CI on PR    | `/review`             |
+| ------------------------ | -------------------------- | ----------- | --------------------- |
+| Lint                     | ✅ affected                | ✅ affected | ✅ all                |
+| Typecheck                | ✅ affected (working tree) | ✅ affected | ✅ **committed tree** |
+| Unit tests               | ✅ affected                | ✅ affected | ✅ all                |
+| Build                    | —                          | —           | ✅                    |
+| Migration integrity      | —                          | —           | ✅                    |
+| Destructive SQL          | —                          | —           | ✅                    |
+| Authorization / IDOR     | —                          | —           | ✅                    |
+| Injection, XSS in PDFs   | —                          | —           | ✅                    |
+| Secrets, stray artifacts | —                          | —           | ✅                    |
+| Clean code, duplication  | —                          | —           | ✅                    |
+| Commit message accuracy  | —                          | —           | ✅                    |
+
+CI tells you the branch compiles. `/review` tells you it is safe and clean.
+
+See also: [Testing & CI Pipeline](../docs/testing-and-ci.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ git push origin main
 
 ## 🤖 Specialized Agents & Workflows
 
+- **Code Reviewer** (`.claude/agents/code-reviewer.md`) - **CRITICAL**: Pre-PR gate. Run `/review` before every `gh pr create` — mechanical gates (incl. typechecking the _committed_ tree), security, project invariants, clean code ⭐ NEW
 - **Migration Manager** (`.claude/agents/migration-manager.md`) - **CRITICAL**: Enforces proper database migration workflows
 - **Migration Enforcement** (`.claude/workflows/migration-enforcement.md`) - Automated migration validation and CI/CD integration
 - **SMS Feature Manager** (`.claude/agents/sms-feature-manager.md`) - Complete SMS/text messaging management and troubleshooting ⭐ NEW
@@ -154,6 +155,7 @@ git push origin main
 - **Enhanced Git Workflows** (`.claude/scripts/git-workflows-enhanced.sh`) - Build-validated git operations
 - **Integration Workflows** (`.claude/workflows/dto-git-integration.md`) - Combined DTO + Git workflows
 - **Commands**:
+  - `/review` | `/review security` | `/review gates` - Pre-PR code review (run before opening any PR) ⭐ NEW
   - `/dto create|update|validate|fix-imports` - DTO management commands
   - `/migration check|create|deploy|status|validate` - Migration management commands
   - `/sms test|history|preferences|troubleshoot` - SMS feature management ⭐ NEW

--- a/apps/webApp/src/app/app.tsx
+++ b/apps/webApp/src/app/app.tsx
@@ -32,6 +32,7 @@ import { BookAppointment } from './pages/public/BookAppointment';
 import { StaffDashboard } from './pages/staff/Dashboard';
 import { MyJobs } from './pages/staff/MyJobs';
 import { MyEarnings } from './pages/staff/MyEarnings';
+import { MyPayStubs } from './pages/staff/MyPayStubs';
 import { MyCommission } from './pages/staff/MyCommission';
 import { TimeClock } from './pages/staff/TimeClock';
 
@@ -41,6 +42,8 @@ import { DaySummary } from './pages/admin/DaySummary';
 
 // Accountant Pages
 import { AccountantDashboard } from './pages/accountant/AccountantDashboard';
+import { EmployeeHours } from './pages/accountant/EmployeeHours';
+import { PayStubs } from './pages/accountant/PayStubs';
 import UserManagement from '../pages/admin/UserManagement';
 
 // Payroll Pages
@@ -164,6 +167,7 @@ export function App() {
               <Route path="jobs" element={<MyJobs />} />
               <Route path="time-clock" element={<TimeClock />} />
               <Route path="earnings" element={<MyEarnings />} />
+              <Route path="pay-stubs" element={<MyPayStubs />} />
               <Route path="commission" element={<MyCommission />} />
               <Route path="appointments" element={<AppointmentsManagement />} />
               <Route path="inspections" element={<InspectionList />} />
@@ -232,6 +236,7 @@ export function App() {
               <Route path="my-jobs" element={<MyJobs />} />
               <Route path="my-time-clock" element={<TimeClock />} />
               <Route path="my-earnings" element={<MyEarnings />} />
+              <Route path="my-pay-stubs" element={<MyPayStubs />} />
               <Route path="my-commission" element={<MyCommission />} />
               <Route index element={<Navigate to="dashboard" replace />} />
             </Route>
@@ -255,6 +260,8 @@ export function App() {
                 path="purchase-invoices"
                 element={<PurchaseExpenseInvoiceManagement />}
               />
+              <Route path="employee-hours" element={<EmployeeHours />} />
+              <Route path="pay-stubs" element={<PayStubs />} />
               <Route path="reports" element={<Reports />} />
               <Route path="analytics" element={<div>Analytics</div>} />
               <Route index element={<Navigate to="dashboard" replace />} />
@@ -320,6 +327,8 @@ export function App() {
               <Route path="jobs/:employeeId" element={<JobsManagement />} />
               <Route path="payments" element={<PaymentsManagement />} />
               <Route path="payout-rules" element={<PayoutRulesManagement />} />
+              <Route path="employee-hours" element={<EmployeeHours />} />
+              <Route path="pay-stubs" element={<PayStubs />} />
               <Route path="reports" element={<Reports />} />
               <Route
                 path="employee-payments-report"

--- a/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
@@ -93,9 +93,6 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   });
 
   const [items, setItems] = useState<InvoiceItem[]>([]);
-  // Index of the item currently loaded into the entry row for editing, or null
-  // when the entry row is adding a new item.
-  const [editingItemIndex, setEditingItemIndex] = useState<number | null>(null);
   const [newItem, setNewItem] = useState<InvoiceItem>({
     itemType: InvoiceItemType.SERVICE,
     description: '',
@@ -578,8 +575,8 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
    *
    * The rules differ by type — a fixed discount must be negative, a percentage
    * discount must be a sensible percentage, everything else must cost
-   * something. Shared by add and edit so a row cannot be edited into a state
-   * that would have been rejected when it was added.
+   * something. The in-row editor enforces the same rules, so a row cannot be
+   * edited into a state that would have been rejected when it was added.
    */
   const isItemValid = (item: InvoiceItem) =>
     Boolean(item.description) &&
@@ -778,9 +775,7 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
           onCustomerSelect={handleCustomerSelect}
           onAddItem={handleAddItem}
           onRemoveItem={handleRemoveItem}
-          onEditItem={handleEditItem}
-          onCancelEditItem={handleCancelEditItem}
-          editingItemIndex={editingItemIndex}
+          onUpdateItem={handleUpdateItem}
           onTireSelect={handleTireSelect}
           onServicesChange={() => loadData()}
           isEditMode={isEditMode}

--- a/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceDialog.tsx
@@ -93,6 +93,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
   });
 
   const [items, setItems] = useState<InvoiceItem[]>([]);
+  // Index of the item currently loaded into the entry row for editing, or null
+  // when the entry row is adding a new item.
+  const [editingItemIndex, setEditingItemIndex] = useState<number | null>(null);
   const [newItem, setNewItem] = useState<InvoiceItem>({
     itemType: InvoiceItemType.SERVICE,
     description: '',
@@ -570,47 +573,86 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
     }
   };
 
-  const handleAddItem = () => {
-    if (
-      newItem.description &&
-      (newItem.itemType === InvoiceItemType.DISCOUNT
-        ? newItem.unitPrice < 0
-        : newItem.itemType === InvoiceItemType.DISCOUNT_PERCENTAGE
-        ? newItem.unitPrice > 0 && newItem.unitPrice <= 100
-        : newItem.unitPrice > 0)
-    ) {
-      const calculation = calculateItemTotal(newItem);
-      const itemWithCalculations = {
-        ...newItem,
-        discountAmount: calculation.discountAmount,
-        total: calculation.total,
-      };
-      console.log('Adding item to invoice:', itemWithCalculations);
+  /**
+   * Is this entry complete enough to go on the invoice?
+   *
+   * The rules differ by type — a fixed discount must be negative, a percentage
+   * discount must be a sensible percentage, everything else must cost
+   * something. Shared by add and edit so a row cannot be edited into a state
+   * that would have been rejected when it was added.
+   */
+  const isItemValid = (item: InvoiceItem) =>
+    Boolean(item.description) &&
+    (item.itemType === InvoiceItemType.DISCOUNT
+      ? item.unitPrice < 0
+      : item.itemType === InvoiceItemType.DISCOUNT_PERCENTAGE
+      ? item.unitPrice > 0 && item.unitPrice <= 100
+      : item.unitPrice > 0);
 
-      // For DISCOUNT items, set the correct properties
-      if (newItem.itemType === InvoiceItemType.DISCOUNT) {
-        itemWithCalculations.discountType = 'amount';
-        itemWithCalculations.discountValue = Math.abs(newItem.unitPrice); // Store positive value
-        itemWithCalculations.discountAmount = Math.abs(newItem.unitPrice); // Store positive value for display
-      }
+  /**
+   * Turn a form entry into a stored line item.
+   *
+   * An item on the invoice is not simply what was typed: `total` and the
+   * discount fields are derived from the type and the rest of the invoice.
+   * Editing a row therefore has to re-run this, not patch quantity or price in
+   * place — otherwise the derived fields go stale and the rows stop agreeing
+   * with the totals.
+   */
+  const deriveItem = (item: InvoiceItem): InvoiceItem => {
+    const calculation = calculateItemTotal(item);
+    const derived: InvoiceItem = {
+      ...item,
+      discountAmount: calculation.discountAmount,
+      total: calculation.total,
+    };
 
-      // For DISCOUNT_PERCENTAGE items, store the percentage value for calculation
-      if (newItem.itemType === InvoiceItemType.DISCOUNT_PERCENTAGE) {
-        itemWithCalculations.discountValue = newItem.unitPrice; // Store percentage value
-        itemWithCalculations.discountAmount = Math.abs(calculation.total); // Store positive value for display
-        itemWithCalculations.discountType = 'percentage';
-      }
-      setItems([...items, itemWithCalculations]);
-      setNewItem({
-        itemType: InvoiceItemType.SERVICE,
-        description: '',
-        quantity: 1,
-        unitPrice: '' as unknown as number,
-        discountType: 'amount',
-        discountValue: 0,
-        discountAmount: 0,
-      });
+    if (item.itemType === InvoiceItemType.DISCOUNT) {
+      derived.discountType = 'amount';
+      derived.discountValue = Math.abs(item.unitPrice); // Store positive value
+      derived.discountAmount = Math.abs(item.unitPrice); // Store positive value for display
     }
+
+    if (item.itemType === InvoiceItemType.DISCOUNT_PERCENTAGE) {
+      derived.discountValue = item.unitPrice; // Store percentage value
+      derived.discountAmount = Math.abs(calculation.total); // Store positive value for display
+      derived.discountType = 'percentage';
+    }
+
+    return derived;
+  };
+
+  const blankItem = (): InvoiceItem => ({
+    itemType: InvoiceItemType.SERVICE,
+    description: '',
+    quantity: 1,
+    unitPrice: '' as unknown as number,
+    discountType: 'amount',
+    discountValue: 0,
+    discountAmount: 0,
+  });
+
+  const handleAddItem = () => {
+    if (!isItemValid(newItem)) return;
+
+    setItems([...items, deriveItem(newItem)]);
+    setNewItem(blankItem());
+  };
+
+  /**
+   * Apply an in-row edit to a line item.
+   *
+   * Only the edited fields arrive here; everything derived (`total`, the
+   * discount fields) is recomputed from the merged item, so a row can never
+   * drift out of agreement with the totals. Percentage discounts read the rest
+   * of the list, but they are re-derived on render, so replacing this one row
+   * is enough.
+   */
+  const handleUpdateItem = (index: number, changes: Partial<InvoiceItem>) => {
+    setItems(
+      items.map((item, i) =>
+        i === index ? deriveItem({ ...item, ...changes }) : item
+      )
+    );
   };
 
   const handleRemoveItem = (index: number) => {
@@ -736,6 +778,9 @@ export const InvoiceDialog: React.FC<InvoiceDialogProps> = ({
           onCustomerSelect={handleCustomerSelect}
           onAddItem={handleAddItem}
           onRemoveItem={handleRemoveItem}
+          onEditItem={handleEditItem}
+          onCancelEditItem={handleCancelEditItem}
+          editingItemIndex={editingItemIndex}
           onTireSelect={handleTireSelect}
           onServicesChange={() => loadData()}
           isEditMode={isEditMode}

--- a/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
@@ -35,6 +35,8 @@ import {
   Add as AddIcon,
   Delete as DeleteIcon,
   Edit as EditIcon,
+  Check as CheckIcon,
+  Close as CloseIcon,
   Person as PersonIcon,
   DirectionsCar as CarIcon,
   ShoppingCart as ShoppingCartIcon,
@@ -56,6 +58,70 @@ import { colors } from '../../theme/colors';
 import ServiceSelect from '../services/ServiceSelect';
 import { PhoneInput } from '../common/PhoneInput';
 import { NumberInput } from '../common';
+
+/** The item type as it is stored on a line item. */
+type ItemTypeValue = InvoiceItem['itemType'];
+
+/**
+ * The line item types offered in the pickers, in the order they appear. Shared
+ * by the entry row and the in-row editor so both offer exactly the same set.
+ */
+const ITEM_TYPE_OPTIONS: {
+  value: ItemTypeValue;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    value: 'TIRE',
+    label: 'Tire',
+    icon: <span style={{ fontSize: '18px' }}>🛞</span>,
+  },
+  {
+    value: 'SERVICE',
+    label: 'Service',
+    icon: <BuildIcon fontSize="small" />,
+  },
+  {
+    value: 'PART',
+    label: 'Part',
+    icon: <ExtensionIcon fontSize="small" />,
+  },
+  {
+    value: 'OTHER',
+    label: 'Other',
+    icon: <CategoryIcon fontSize="small" />,
+  },
+  {
+    value: 'LEVY',
+    label: 'Levy',
+    icon: <AccountBalanceIcon fontSize="small" />,
+  },
+  {
+    value: 'DISCOUNT',
+    label: '$ Discount',
+    icon: <AttachMoneyIcon fontSize="small" sx={{ color: 'red' }} />,
+  },
+  {
+    value: 'DISCOUNT_PERCENTAGE',
+    label: '% Discount',
+    icon: <AttachMoneyIcon fontSize="small" sx={{ color: 'red' }} />,
+  },
+  {
+    value: 'TIPS',
+    label: 'Tips',
+    icon: <TipsIcon fontSize="small" sx={{ color: 'green' }} />,
+  },
+];
+
+const renderItemTypeOptions = () =>
+  ITEM_TYPE_OPTIONS.map((option) => (
+    <MenuItem key={option.value} value={option.value}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {option.icon}
+        {option.label}
+      </Box>
+    </MenuItem>
+  ));
 
 interface InvoiceFormContentProps {
   customers: any[];
@@ -123,9 +189,7 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
   onCustomerSelect,
   onAddItem,
   onRemoveItem,
-  onEditItem,
-  onCancelEditItem,
-  editingItemIndex,
+  onUpdateItem,
   onTireSelect,
   onServicesChange,
   isEditMode = false,
@@ -134,6 +198,18 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [menuItemIndex, setMenuItemIndex] = useState<number | null>(null);
+
+  // In-row editing: the row at `inlineEditIndex` swaps its description, qty and
+  // price cells for inputs backed by `inlineDraft`. The draft is kept separate
+  // from the item so a half-typed value never reaches the totals — nothing is
+  // committed until Save.
+  const [inlineEditIndex, setInlineEditIndex] = useState<number | null>(null);
+  const [inlineDraft, setInlineDraft] = useState<{
+    itemType: ItemTypeValue;
+    description: string;
+    quantity: number | '';
+    unitPrice: number | '';
+  } | null>(null);
 
   const formatTireType = (type: string) => {
     return type
@@ -155,21 +231,130 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
     setMenuItemIndex(null);
   };
 
+  const cancelInlineEdit = () => {
+    setInlineEditIndex(null);
+    setInlineDraft(null);
+  };
+
+  /**
+   * A fixed discount is stored negative but is far easier to edit as a positive
+   * amount, so the draft always holds the magnitude and the sign is restored on
+   * save.
+   */
+  const startInlineEdit = (index: number) => {
+    const item = items[index];
+    if (!item) return;
+    setInlineEditIndex(index);
+    setInlineDraft({
+      itemType: item.itemType,
+      description: item.description ?? '',
+      quantity: item.quantity ?? 1,
+      unitPrice:
+        item.itemType === 'DISCOUNT'
+          ? Math.abs(item.unitPrice)
+          : item.unitPrice,
+    });
+  };
+
+  /**
+   * Switching type in the editor keeps what has already been typed — the point
+   * of an in-row type change is to re-file a line, not to retype it. Only the
+   * values the new type cannot carry are adjusted: TIPS is always a single
+   * unit.
+   */
+  const changeInlineType = (itemType: ItemTypeValue) => {
+    if (!inlineDraft) return;
+    setInlineDraft({
+      ...inlineDraft,
+      itemType,
+      quantity: itemType === 'TIPS' ? 1 : inlineDraft.quantity,
+    });
+  };
+
+  /** Same rules the entry row enforces, so a row cannot be edited into a state
+   *  that would have been rejected when it was added. */
+  const isInlineDraftValid = () => {
+    if (!inlineDraft) return false;
+    const price = Number(inlineDraft.unitPrice);
+    const quantity = Number(inlineDraft.quantity);
+
+    if (!inlineDraft.description.trim()) return false;
+    if (inlineDraft.unitPrice === '' || Number.isNaN(price)) return false;
+    if (inlineDraft.itemType !== 'TIPS' && quantity <= 0) return false;
+
+    if (inlineDraft.itemType === 'DISCOUNT_PERCENTAGE') {
+      return price > 0 && price <= 100;
+    }
+    return price > 0;
+  };
+
+  const saveInlineEdit = () => {
+    if (inlineEditIndex === null || !inlineDraft) return;
+    const item = items[inlineEditIndex];
+    if (!item || !isInlineDraftValid()) return;
+
+    const price = Number(inlineDraft.unitPrice);
+    const typeChanged = inlineDraft.itemType !== item.itemType;
+
+    onUpdateItem(inlineEditIndex, {
+      itemType: inlineDraft.itemType,
+      description: inlineDraft.description.trim(),
+      quantity: Number(inlineDraft.quantity) || 1,
+      unitPrice: inlineDraft.itemType === 'DISCOUNT' ? -Math.abs(price) : price,
+      // A line that is no longer a tire (or no longer that service) must not
+      // keep pointing at one — the link drives inventory and reporting, and a
+      // stale one would bill against the wrong record.
+      ...(typeChanged
+        ? { tireId: undefined, tireName: undefined, serviceId: undefined }
+        : {}),
+    });
+    cancelInlineEdit();
+  };
+
+  const handleInlineKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      saveInlineEdit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelInlineEdit();
+    }
+  };
+
+  /**
+   * Removing a row shifts every later index, so an in-progress edit would
+   * silently start pointing at a different item. Drop it.
+   */
+  const handleRemoveItem = (index: number) => {
+    cancelInlineEdit();
+    onRemoveItem(index);
+  };
+
   const handleMenuDelete = () => {
     if (menuItemIndex !== null) {
-      onRemoveItem(menuItemIndex);
+      handleRemoveItem(menuItemIndex);
       handleMenuClose();
     }
   };
 
   const handleMenuEdit = () => {
     if (menuItemIndex !== null) {
-      onEditItem(menuItemIndex);
+      startInlineEdit(menuItemIndex);
       handleMenuClose();
     }
   };
 
-  const isEditingItem = editingItemIndex !== null;
+  /** The line total a row would have if the in-progress edit were saved. */
+  const getDraftLineTotal = (item: InvoiceItem): number => {
+    if (!inlineDraft) return getLineTotal(item);
+    const price = Number(inlineDraft.unitPrice) || 0;
+    return getLineTotal({
+      ...item,
+      itemType: inlineDraft.itemType,
+      quantity: Number(inlineDraft.quantity) || 0,
+      unitPrice: inlineDraft.itemType === 'DISCOUNT' ? -Math.abs(price) : price,
+    });
+  };
 
   const handleServiceChange = (
     serviceId: string,
@@ -946,76 +1131,7 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       }}
                       label="Type"
                     >
-                      <MenuItem value="TIRE">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <span style={{ fontSize: '18px' }}>🛞</span>
-                          Tire
-                        </Box>
-                      </MenuItem>
-                      <MenuItem value="SERVICE">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <BuildIcon fontSize="small" />
-                          Service
-                        </Box>
-                      </MenuItem>
-                      <MenuItem value="PART">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <ExtensionIcon fontSize="small" />
-                          Part
-                        </Box>
-                      </MenuItem>
-                      <MenuItem value="OTHER">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <CategoryIcon fontSize="small" />
-                          Other
-                        </Box>
-                      </MenuItem>
-                      <MenuItem value="LEVY">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <AccountBalanceIcon fontSize="small" />
-                          Levy
-                        </Box>
-                      </MenuItem>
-                      <MenuItem value="DISCOUNT">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <AttachMoneyIcon
-                            fontSize="small"
-                            sx={{ color: 'red' }}
-                          />
-                          $ Discount
-                        </Box>
-                      </MenuItem>
-                      <MenuItem value="DISCOUNT_PERCENTAGE">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <AttachMoneyIcon
-                            fontSize="small"
-                            sx={{ color: 'red' }}
-                          />
-                          % Discount
-                        </Box>
-                      </MenuItem>
-                      <MenuItem value="TIPS">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <TipsIcon fontSize="small" sx={{ color: 'green' }} />
-                          Tips
-                        </Box>
-                      </MenuItem>
+                      {renderItemTypeOptions()}
                     </Select>
                   </FormControl>
                 </Grid>
@@ -1220,15 +1336,11 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                   />
                 </Grid>
 
-                {/* The same entry row both adds and updates: an item being
-                    edited is loaded back into these fields, so every
-                    type-specific control (tire picker, service picker, discount
-                    rules) works on edit exactly as it does on add. */}
                 <Grid size={{ xs: 12, md: 2 }}>
                   <Button
                     fullWidth
                     variant="contained"
-                    startIcon={isEditingItem ? <EditIcon /> : <AddIcon />}
+                    startIcon={<AddIcon />}
                     onClick={onAddItem}
                     disabled={
                       !newItem.description ||
@@ -1250,18 +1362,8 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       },
                     }}
                   >
-                    {isEditingItem ? 'Update Item' : 'Add Item'}
+                    Add Item
                   </Button>
-                  {isEditingItem && (
-                    <Button
-                      fullWidth
-                      size="small"
-                      onClick={onCancelEditItem}
-                      sx={{ mt: 0.5 }}
-                    >
-                      Cancel Edit
-                    </Button>
-                  )}
                 </Grid>
               </Grid>
             </Box>
@@ -1273,159 +1375,307 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                 <Box
                   sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
                 >
-                  {items.map((item, index) => (
-                    <Card
-                      key={index}
-                      sx={{ border: `1px solid ${colors.neutral[200]}` }}
-                    >
-                      <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}>
-                        {/* Header Row: Type + Description + Action */}
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'flex-start',
-                            gap: 1,
-                            mb: 1,
-                          }}
+                  {items.map((item, index) => {
+                    const isRowEditing = inlineEditIndex === index;
+                    const canSaveRow = isRowEditing && isInlineDraftValid();
+                    // While a row is being edited its appearance follows the
+                    // draft's type, so switching type re-labels the row and
+                    // switches the price field's adornments immediately.
+                    const rowType =
+                      isRowEditing && inlineDraft
+                        ? inlineDraft.itemType
+                        : item.itemType;
+
+                    return (
+                      <Card
+                        key={index}
+                        sx={{
+                          border: `1px solid ${
+                            isRowEditing
+                              ? colors.primary.main
+                              : colors.neutral[200]
+                          }`,
+                        }}
+                      >
+                        <CardContent
+                          sx={{ p: 1.5, '&:last-child': { pb: 1.5 } }}
                         >
-                          <Chip
-                            label={item.itemType}
-                            size="small"
+                          {/* Header Row: Type + Description + Action. Editing
+                            stacks the controls so the type picker and
+                            description each get the full card width. */}
+                          <Box
                             sx={{
-                              height: 20,
-                              fontSize: '0.688rem',
-                              background:
-                                item.itemType === 'TIRE'
-                                  ? colors.tire?.new || colors.primary.main
-                                  : item.itemType === 'DISCOUNT' ||
-                                    item.itemType === 'DISCOUNT_PERCENTAGE'
-                                  ? '#f44336'
-                                  : colors.service?.maintenance ||
-                                    colors.secondary.main,
-                              color: 'white',
-                              flexShrink: 0,
+                              display: 'flex',
+                              flexDirection: isRowEditing ? 'column' : 'row',
+                              alignItems: isRowEditing
+                                ? 'stretch'
+                                : 'flex-start',
+                              gap: 1,
+                              mb: 1,
                             }}
-                          />
-                          <Box sx={{ flex: 1, minWidth: 0 }}>
-                            {(item as any).tireName && (
-                              <Typography
-                                variant="body2"
-                                fontWeight={600}
+                          >
+                            {isRowEditing && inlineDraft ? (
+                              <FormControl fullWidth size="small">
+                                <InputLabel>Type</InputLabel>
+                                <Select
+                                  value={inlineDraft.itemType}
+                                  label="Type"
+                                  onChange={(e) =>
+                                    changeInlineType(
+                                      e.target.value as ItemTypeValue
+                                    )
+                                  }
+                                >
+                                  {renderItemTypeOptions()}
+                                </Select>
+                              </FormControl>
+                            ) : (
+                              <Chip
+                                label={item.itemType}
+                                size="small"
                                 sx={{
-                                  fontSize: '0.813rem',
-                                  lineHeight: 1.3,
-                                  mb: 0.25,
+                                  height: 20,
+                                  fontSize: '0.688rem',
+                                  background:
+                                    item.itemType === 'TIRE'
+                                      ? colors.tire?.new || colors.primary.main
+                                      : item.itemType === 'DISCOUNT' ||
+                                        item.itemType === 'DISCOUNT_PERCENTAGE'
+                                      ? '#f44336'
+                                      : colors.service?.maintenance ||
+                                        colors.secondary.main,
+                                  color: 'white',
+                                  flexShrink: 0,
+                                }}
+                              />
+                            )}
+                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                              {(item as any).tireName && (
+                                <Typography
+                                  variant="body2"
+                                  fontWeight={600}
+                                  sx={{
+                                    fontSize: '0.813rem',
+                                    lineHeight: 1.3,
+                                    mb: 0.25,
+                                  }}
+                                >
+                                  {(item as any).tireName}
+                                </Typography>
+                              )}
+                              {isRowEditing && inlineDraft ? (
+                                <TextField
+                                  fullWidth
+                                  size="small"
+                                  autoFocus
+                                  label="Description"
+                                  value={inlineDraft.description}
+                                  onChange={(e) =>
+                                    setInlineDraft({
+                                      ...inlineDraft,
+                                      description: e.target.value,
+                                    })
+                                  }
+                                  onKeyDown={handleInlineKeyDown}
+                                />
+                              ) : (
+                                <Typography
+                                  variant="body2"
+                                  sx={{
+                                    fontSize: '0.813rem',
+                                    lineHeight: 1.3,
+                                    color: (item as any).tireName
+                                      ? 'text.secondary'
+                                      : 'text.primary',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: 2,
+                                    WebkitBoxOrient: 'vertical',
+                                  }}
+                                >
+                                  {item.description}
+                                </Typography>
+                              )}
+                            </Box>
+                            {isRowEditing ? (
+                              <Box
+                                sx={{
+                                  display: 'flex',
+                                  flexShrink: 0,
+                                  alignSelf: 'flex-end',
                                 }}
                               >
-                                {(item as any).tireName}
-                              </Typography>
+                                <IconButton
+                                  size="small"
+                                  onClick={saveInlineEdit}
+                                  disabled={!canSaveRow}
+                                  sx={{ p: 0.5, color: colors.primary.main }}
+                                >
+                                  <CheckIcon fontSize="small" />
+                                </IconButton>
+                                <IconButton
+                                  size="small"
+                                  onClick={cancelInlineEdit}
+                                  sx={{ p: 0.5, color: colors.neutral[600] }}
+                                >
+                                  <CloseIcon fontSize="small" />
+                                </IconButton>
+                              </Box>
+                            ) : (
+                              <IconButton
+                                size="small"
+                                onClick={(e) => handleMenuOpen(e, index)}
+                                sx={{ p: 0.5, flexShrink: 0 }}
+                              >
+                                <MoreVertIcon fontSize="small" />
+                              </IconButton>
                             )}
-                            <Typography
-                              variant="body2"
-                              sx={{
-                                fontSize: '0.813rem',
-                                lineHeight: 1.3,
-                                color: (item as any).tireName
-                                  ? 'text.secondary'
-                                  : 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                display: '-webkit-box',
-                                WebkitLineClamp: 2,
-                                WebkitBoxOrient: 'vertical',
-                              }}
-                            >
-                              {item.description}
-                            </Typography>
                           </Box>
-                          <IconButton
-                            size="small"
-                            onClick={(e) => handleMenuOpen(e, index)}
-                            sx={{ p: 0.5, flexShrink: 0 }}
-                          >
-                            <MoreVertIcon fontSize="small" />
-                          </IconButton>
-                        </Box>
 
-                        {/* Compact Info Row */}
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'space-between',
-                            flexWrap: 'wrap',
-                            gap: 1,
-                          }}
-                        >
+                          {/* Compact Info Row */}
                           <Box
                             sx={{
                               display: 'flex',
                               alignItems: 'center',
-                              gap: 2,
+                              justifyContent: 'space-between',
+                              flexWrap: 'wrap',
+                              gap: 1,
                             }}
                           >
-                            <Box>
-                              <Typography
-                                variant="caption"
-                                color="text.secondary"
-                                sx={{ fontSize: '0.688rem' }}
-                              >
-                                Qty
-                              </Typography>
-                              <Typography
-                                variant="body2"
-                                fontWeight={500}
-                                sx={{ fontSize: '0.813rem' }}
-                              >
-                                {item.quantity}
-                              </Typography>
-                            </Box>
-                            <Box>
-                              <Typography
-                                variant="caption"
-                                color="text.secondary"
-                                sx={{ fontSize: '0.688rem' }}
-                              >
-                                Price
-                              </Typography>
-                              <Typography
-                                variant="body2"
-                                fontWeight={500}
-                                sx={{ fontSize: '0.813rem' }}
-                              >
-                                {item.itemType === 'DISCOUNT_PERCENTAGE'
-                                  ? `${item.unitPrice}%`
-                                  : formatCurrency(item.unitPrice)}
-                              </Typography>
-                            </Box>
-                          </Box>
-                          <Box sx={{ textAlign: 'right' }}>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              sx={{ fontSize: '0.688rem' }}
-                            >
-                              Total
-                            </Typography>
-                            <Typography
-                              variant="body2"
-                              fontWeight={600}
+                            <Box
                               sx={{
-                                fontSize: '0.938rem',
-                                color:
-                                  item.itemType === 'DISCOUNT' ||
-                                  item.itemType === 'DISCOUNT_PERCENTAGE'
-                                    ? '#f44336'
-                                    : colors.primary.main,
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 2,
                               }}
                             >
-                              {formatCurrency(getLineTotal(item))}
-                            </Typography>
+                              <Box>
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ fontSize: '0.688rem' }}
+                                >
+                                  Qty
+                                </Typography>
+                                {isRowEditing &&
+                                inlineDraft &&
+                                rowType !== 'TIPS' ? (
+                                  <NumberInput
+                                    size="small"
+                                    allowDecimals
+                                    decimalPlaces={2}
+                                    value={inlineDraft.quantity}
+                                    onChange={(v) =>
+                                      setInlineDraft({
+                                        ...inlineDraft,
+                                        quantity: v ?? '',
+                                      })
+                                    }
+                                    onKeyDown={handleInlineKeyDown}
+                                    min={0}
+                                    sx={{ width: 80 }}
+                                  />
+                                ) : (
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight={500}
+                                    sx={{ fontSize: '0.813rem' }}
+                                  >
+                                    {item.quantity}
+                                  </Typography>
+                                )}
+                              </Box>
+                              <Box>
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ fontSize: '0.688rem' }}
+                                >
+                                  Price
+                                </Typography>
+                                {isRowEditing && inlineDraft ? (
+                                  <NumberInput
+                                    size="small"
+                                    allowDecimals
+                                    value={inlineDraft.unitPrice}
+                                    onChange={(v) =>
+                                      setInlineDraft({
+                                        ...inlineDraft,
+                                        unitPrice: v ?? '',
+                                      })
+                                    }
+                                    onKeyDown={handleInlineKeyDown}
+                                    min={0}
+                                    max={
+                                      rowType === 'DISCOUNT_PERCENTAGE'
+                                        ? 100
+                                        : undefined
+                                    }
+                                    InputProps={{
+                                      startAdornment: (
+                                        <InputAdornment position="start">
+                                          {rowType === 'DISCOUNT'
+                                            ? '-$'
+                                            : rowType === 'DISCOUNT_PERCENTAGE'
+                                            ? ''
+                                            : '$'}
+                                        </InputAdornment>
+                                      ),
+                                      endAdornment:
+                                        rowType === 'DISCOUNT_PERCENTAGE' ? (
+                                          <InputAdornment position="end">
+                                            %
+                                          </InputAdornment>
+                                        ) : undefined,
+                                    }}
+                                    sx={{ width: 130 }}
+                                  />
+                                ) : (
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight={500}
+                                    sx={{ fontSize: '0.813rem' }}
+                                  >
+                                    {item.itemType === 'DISCOUNT_PERCENTAGE'
+                                      ? `${item.unitPrice}%`
+                                      : formatCurrency(item.unitPrice)}
+                                  </Typography>
+                                )}
+                              </Box>
+                            </Box>
+                            <Box sx={{ textAlign: 'right' }}>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ fontSize: '0.688rem' }}
+                              >
+                                Total
+                              </Typography>
+                              <Typography
+                                variant="body2"
+                                fontWeight={600}
+                                sx={{
+                                  fontSize: '0.938rem',
+                                  color:
+                                    rowType === 'DISCOUNT' ||
+                                    rowType === 'DISCOUNT_PERCENTAGE'
+                                      ? '#f44336'
+                                      : colors.primary.main,
+                                }}
+                              >
+                                {formatCurrency(
+                                  isRowEditing
+                                    ? getDraftLineTotal(item)
+                                    : getLineTotal(item)
+                                )}
+                              </Typography>
+                            </Box>
                           </Box>
-                        </Box>
-                      </CardContent>
-                    </Card>
-                  ))}
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
                 </Box>
               ) : (
                 // Desktop Table View
@@ -1458,97 +1708,247 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {items.map((item, index) => (
-                        <TableRow
-                          key={index}
-                          sx={{
-                            '&:hover': { background: colors.neutral[50] },
-                            '&:last-child td': { border: 0 },
-                          }}
-                        >
-                          <TableCell>
-                            <Chip
-                              label={item.itemType}
-                              size="small"
-                              sx={{
-                                background:
-                                  item.itemType === 'TIRE'
-                                    ? colors.tire?.new || colors.primary.main
-                                    : item.itemType === 'DISCOUNT' ||
-                                      item.itemType === 'DISCOUNT_PERCENTAGE'
-                                    ? '#f44336'
-                                    : colors.service?.maintenance ||
-                                      colors.secondary.main,
-                                color: 'white',
-                              }}
-                            />
-                          </TableCell>
-                          <TableCell>
-                            {(item as any).tireName && (
-                              <Typography variant="body2" fontWeight="medium">
-                                {(item as any).tireName}
-                              </Typography>
-                            )}
-                            <Typography
-                              variant="body2"
-                              color={
-                                (item as any).tireName
-                                  ? 'text.secondary'
-                                  : 'inherit'
-                              }
-                            >
-                              {item.description}
-                            </Typography>
-                          </TableCell>
-                          <TableCell align="center">{item.quantity}</TableCell>
-                          <TableCell align="right">
-                            {item.itemType === 'DISCOUNT_PERCENTAGE'
-                              ? `${item.unitPrice}%`
-                              : formatCurrency(item.unitPrice)}
-                          </TableCell>
-                          <TableCell
-                            align="right"
+                      {items.map((item, index) => {
+                        const isRowEditing = inlineEditIndex === index;
+                        const canSaveRow = isRowEditing && isInlineDraftValid();
+                        // While a row is being edited its appearance follows
+                        // the draft's type, so switching type immediately
+                        // re-labels the row and swaps the price adornments.
+                        const rowType =
+                          isRowEditing && inlineDraft
+                            ? inlineDraft.itemType
+                            : item.itemType;
+
+                        return (
+                          <TableRow
+                            key={index}
                             sx={{
-                              fontWeight: 600,
-                              color:
-                                item.itemType === 'DISCOUNT' ||
-                                item.itemType === 'DISCOUNT_PERCENTAGE'
-                                  ? '#f44336'
-                                  : 'inherit',
+                              '&:hover': {
+                                background: isRowEditing
+                                  ? undefined
+                                  : colors.neutral[50],
+                              },
+                              '&:last-child td': { border: 0 },
+                              ...(isRowEditing && {
+                                background: `${colors.primary.main}0d`,
+                              }),
                             }}
                           >
-                            {formatCurrency(getLineTotal(item))}
-                          </TableCell>
-                          <TableCell
-                            align="center"
-                            sx={{ whiteSpace: 'nowrap' }}
-                          >
-                            <Tooltip title="Edit item">
-                              <IconButton
-                                size="small"
-                                onClick={() => onEditItem(index)}
-                                sx={{ color: colors.primary.main }}
-                              >
-                                <EditIcon fontSize="small" />
-                              </IconButton>
-                            </Tooltip>
-                            <Tooltip title="Remove item">
-                              <IconButton
-                                size="small"
-                                onClick={() => onRemoveItem(index)}
-                                sx={{
-                                  color: colors.semantic?.error || 'red',
-                                  '&:hover': {
-                                    background: 'rgba(255,0,0,0.1)',
-                                  },
-                                }}
-                              >
-                                <DeleteIcon />
-                              </IconButton>
-                            </Tooltip>
-                          </TableCell>
-                        </TableRow>
-                      ))}
+                            <TableCell>
+                              {isRowEditing && inlineDraft ? (
+                                <FormControl
+                                  size="small"
+                                  sx={{ minWidth: 150 }}
+                                >
+                                  <Select
+                                    value={inlineDraft.itemType}
+                                    onChange={(e) =>
+                                      changeInlineType(
+                                        e.target.value as ItemTypeValue
+                                      )
+                                    }
+                                  >
+                                    {renderItemTypeOptions()}
+                                  </Select>
+                                </FormControl>
+                              ) : (
+                                <Chip
+                                  label={item.itemType}
+                                  size="small"
+                                  sx={{
+                                    background:
+                                      item.itemType === 'TIRE'
+                                        ? colors.tire?.new ||
+                                          colors.primary.main
+                                        : item.itemType === 'DISCOUNT' ||
+                                          item.itemType ===
+                                            'DISCOUNT_PERCENTAGE'
+                                        ? '#f44336'
+                                        : colors.service?.maintenance ||
+                                          colors.secondary.main,
+                                    color: 'white',
+                                  }}
+                                />
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              {(item as any).tireName && (
+                                <Typography variant="body2" fontWeight="medium">
+                                  {(item as any).tireName}
+                                </Typography>
+                              )}
+                              {isRowEditing && inlineDraft ? (
+                                <TextField
+                                  fullWidth
+                                  size="small"
+                                  autoFocus
+                                  value={inlineDraft.description}
+                                  onChange={(e) =>
+                                    setInlineDraft({
+                                      ...inlineDraft,
+                                      description: e.target.value,
+                                    })
+                                  }
+                                  onKeyDown={handleInlineKeyDown}
+                                />
+                              ) : (
+                                <Typography
+                                  variant="body2"
+                                  color={
+                                    (item as any).tireName
+                                      ? 'text.secondary'
+                                      : 'inherit'
+                                  }
+                                >
+                                  {item.description}
+                                </Typography>
+                              )}
+                            </TableCell>
+                            <TableCell align="center">
+                              {isRowEditing &&
+                              inlineDraft &&
+                              rowType !== 'TIPS' ? (
+                                <NumberInput
+                                  size="small"
+                                  allowDecimals
+                                  decimalPlaces={2}
+                                  value={inlineDraft.quantity}
+                                  onChange={(v) =>
+                                    setInlineDraft({
+                                      ...inlineDraft,
+                                      quantity: v ?? '',
+                                    })
+                                  }
+                                  onKeyDown={handleInlineKeyDown}
+                                  min={0}
+                                  sx={{ width: 90 }}
+                                />
+                              ) : (
+                                item.quantity
+                              )}
+                            </TableCell>
+                            <TableCell align="right">
+                              {isRowEditing && inlineDraft ? (
+                                <NumberInput
+                                  size="small"
+                                  allowDecimals
+                                  value={inlineDraft.unitPrice}
+                                  onChange={(v) =>
+                                    setInlineDraft({
+                                      ...inlineDraft,
+                                      unitPrice: v ?? '',
+                                    })
+                                  }
+                                  onKeyDown={handleInlineKeyDown}
+                                  min={0}
+                                  max={
+                                    rowType === 'DISCOUNT_PERCENTAGE'
+                                      ? 100
+                                      : undefined
+                                  }
+                                  InputProps={{
+                                    startAdornment: (
+                                      <InputAdornment position="start">
+                                        {rowType === 'DISCOUNT'
+                                          ? '-$'
+                                          : rowType === 'DISCOUNT_PERCENTAGE'
+                                          ? ''
+                                          : '$'}
+                                      </InputAdornment>
+                                    ),
+                                    endAdornment:
+                                      rowType === 'DISCOUNT_PERCENTAGE' ? (
+                                        <InputAdornment position="end">
+                                          %
+                                        </InputAdornment>
+                                      ) : undefined,
+                                  }}
+                                  sx={{ width: 150 }}
+                                />
+                              ) : item.itemType === 'DISCOUNT_PERCENTAGE' ? (
+                                `${item.unitPrice}%`
+                              ) : (
+                                formatCurrency(item.unitPrice)
+                              )}
+                            </TableCell>
+                            <TableCell
+                              align="right"
+                              sx={{
+                                fontWeight: 600,
+                                color:
+                                  rowType === 'DISCOUNT' ||
+                                  rowType === 'DISCOUNT_PERCENTAGE'
+                                    ? '#f44336'
+                                    : 'inherit',
+                              }}
+                            >
+                              {formatCurrency(
+                                isRowEditing
+                                  ? getDraftLineTotal(item)
+                                  : getLineTotal(item)
+                              )}
+                            </TableCell>
+                            <TableCell
+                              align="center"
+                              sx={{ whiteSpace: 'nowrap' }}
+                            >
+                              {isRowEditing ? (
+                                <>
+                                  {/* span keeps the tooltip alive while the
+                                    button is disabled */}
+                                  <Tooltip title="Save changes">
+                                    <span>
+                                      <IconButton
+                                        size="small"
+                                        onClick={saveInlineEdit}
+                                        disabled={!canSaveRow}
+                                        sx={{ color: colors.primary.main }}
+                                      >
+                                        <CheckIcon fontSize="small" />
+                                      </IconButton>
+                                    </span>
+                                  </Tooltip>
+                                  <Tooltip title="Cancel">
+                                    <IconButton
+                                      size="small"
+                                      onClick={cancelInlineEdit}
+                                      sx={{ color: colors.neutral[600] }}
+                                    >
+                                      <CloseIcon fontSize="small" />
+                                    </IconButton>
+                                  </Tooltip>
+                                </>
+                              ) : (
+                                <>
+                                  <Tooltip title="Edit item">
+                                    <IconButton
+                                      size="small"
+                                      onClick={() => startInlineEdit(index)}
+                                      sx={{ color: colors.primary.main }}
+                                    >
+                                      <EditIcon fontSize="small" />
+                                    </IconButton>
+                                  </Tooltip>
+                                  <Tooltip title="Remove item">
+                                    <IconButton
+                                      size="small"
+                                      onClick={() => handleRemoveItem(index)}
+                                      sx={{
+                                        color: colors.semantic?.error || 'red',
+                                        '&:hover': {
+                                          background: 'rgba(255,0,0,0.1)',
+                                        },
+                                      }}
+                                    >
+                                      <DeleteIcon />
+                                    </IconButton>
+                                  </Tooltip>
+                                </>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
                     </TableBody>
                   </Table>
                 </TableContainer>

--- a/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
+++ b/apps/webApp/src/app/components/invoices/InvoiceFormContent.tsx
@@ -34,6 +34,7 @@ import {
 import {
   Add as AddIcon,
   Delete as DeleteIcon,
+  Edit as EditIcon,
   Person as PersonIcon,
   DirectionsCar as CarIcon,
   ShoppingCart as ShoppingCartIcon,
@@ -94,6 +95,11 @@ interface InvoiceFormContentProps {
   onCustomerSelect: (customer: any) => void;
   onAddItem: () => void;
   onRemoveItem: (index: number) => void;
+  /**
+   * Apply an in-row edit. Only the changed fields are passed; the caller
+   * re-derives totals and discount fields from the merged item.
+   */
+  onUpdateItem: (index: number, changes: Partial<InvoiceItem>) => void;
   onTireSelect: (tireId: string) => void;
   onServicesChange: () => void;
   isEditMode?: boolean;
@@ -117,6 +123,9 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
   onCustomerSelect,
   onAddItem,
   onRemoveItem,
+  onEditItem,
+  onCancelEditItem,
+  editingItemIndex,
   onTireSelect,
   onServicesChange,
   isEditMode = false,
@@ -152,6 +161,15 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
       handleMenuClose();
     }
   };
+
+  const handleMenuEdit = () => {
+    if (menuItemIndex !== null) {
+      onEditItem(menuItemIndex);
+      handleMenuClose();
+    }
+  };
+
+  const isEditingItem = editingItemIndex !== null;
 
   const handleServiceChange = (
     serviceId: string,
@@ -1202,11 +1220,15 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                   />
                 </Grid>
 
+                {/* The same entry row both adds and updates: an item being
+                    edited is loaded back into these fields, so every
+                    type-specific control (tire picker, service picker, discount
+                    rules) works on edit exactly as it does on add. */}
                 <Grid size={{ xs: 12, md: 2 }}>
                   <Button
                     fullWidth
                     variant="contained"
-                    startIcon={<AddIcon />}
+                    startIcon={isEditingItem ? <EditIcon /> : <AddIcon />}
                     onClick={onAddItem}
                     disabled={
                       !newItem.description ||
@@ -1228,8 +1250,18 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                       },
                     }}
                   >
-                    Add Item
+                    {isEditingItem ? 'Update Item' : 'Add Item'}
                   </Button>
+                  {isEditingItem && (
+                    <Button
+                      fullWidth
+                      size="small"
+                      onClick={onCancelEditItem}
+                      sx={{ mt: 0.5 }}
+                    >
+                      Cancel Edit
+                    </Button>
+                  )}
                 </Grid>
               </Grid>
             </Box>
@@ -1487,7 +1519,19 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
                           >
                             {formatCurrency(getLineTotal(item))}
                           </TableCell>
-                          <TableCell align="center">
+                          <TableCell
+                            align="center"
+                            sx={{ whiteSpace: 'nowrap' }}
+                          >
+                            <Tooltip title="Edit item">
+                              <IconButton
+                                size="small"
+                                onClick={() => onEditItem(index)}
+                                sx={{ color: colors.primary.main }}
+                              >
+                                <EditIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
                             <Tooltip title="Remove item">
                               <IconButton
                                 size="small"
@@ -1682,6 +1726,12 @@ const InvoiceFormContent: React.FC<InvoiceFormContentProps> = ({
           horizontal: 'right',
         }}
       >
+        <MenuItem onClick={handleMenuEdit}>
+          <ListItemIcon>
+            <EditIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Edit Item</ListItemText>
+        </MenuItem>
         <MenuItem onClick={handleMenuDelete}>
           <ListItemIcon>
             <DeleteIcon fontSize="small" color="error" />

--- a/apps/webApp/src/app/components/pay-stubs/PayStubDialog.tsx
+++ b/apps/webApp/src/app/components/pay-stubs/PayStubDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Box,
@@ -9,15 +9,20 @@ import {
   DialogTitle,
   Divider,
   Grid,
+  IconButton,
   InputAdornment,
   MenuItem,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
+import { Calculate as CalculateIcon } from '@mui/icons-material';
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import {
   CreatePayStubDto,
+  PayPeriodsPerYear,
   PayrollHoursDto,
+  PayStubDeductionEstimateDto,
   PayStubDto,
   PayType,
 } from '@gt-automotive/data';
@@ -34,10 +39,32 @@ interface PayStubDialogProps {
   initialEmployeeId?: string;
   initialPeriodStart?: string;
   initialPeriodEnd?: string;
+  /**
+   * An issued stub to correct. Passing one switches the dialog to amending
+   * that stub instead of raising a new one.
+   */
+  payStub?: PayStubDto | null;
 }
 
 const today = () => format(new Date(), 'yyyy-MM-dd');
 const toNumber = (value: string) => (value.trim() === '' ? 0 : Number(value));
+const round2 = (value: number) => Math.round(value * 100) / 100;
+
+/**
+ * Pay frequency drives every statutory figure, because the CRA formulas work by
+ * annualizing the period's pay. The shop pays semi-monthly, so that is the
+ * default, but it is an explicit field rather than something inferred from the
+ * dates — a wrong guess here would quietly skew the tax on every stub.
+ */
+const PAY_FREQUENCIES: { value: PayPeriodsPerYear; label: string }[] = [
+  { value: 24, label: 'Semi-monthly (24)' },
+  { value: 26, label: 'Biweekly (26)' },
+  { value: 52, label: 'Weekly (52)' },
+  { value: 12, label: 'Monthly (12)' },
+];
+
+/** Withholding fields the calculator fills in and the accountant may override. */
+type CalculatedField = 'eiAmount' | 'cppAmount' | 'incomeTaxAmount';
 
 const emptyForm = {
   employeeId: '',
@@ -48,12 +75,19 @@ const emptyForm = {
   payRate: '',
   regularHours: '',
   regularAmount: '',
+  payPeriodsPerYear: 24 as PayPeriodsPerYear,
   eiAmount: '',
   cppAmount: '',
   incomeTaxAmount: '',
   otherDeductions: '',
   otherDeductionsLabel: '',
   notes: '',
+};
+
+const noOverrides: Record<CalculatedField, boolean> = {
+  eiAmount: false,
+  cppAmount: false,
+  incomeTaxAmount: false,
 };
 
 /**
@@ -64,9 +98,12 @@ const emptyForm = {
  * from process-payroll — opening this form must not mark anyone's time entries
  * as processed as a side effect of looking at the numbers.
  *
- * Statutory deductions are typed by the accountant. The system deliberately
- * does not calculate EI or CPP: the rates change yearly and a wrong guess is
- * worse than an honest blank.
+ * EI, CPP and income tax are then calculated from the gross using the CRA's
+ * withholding formulas for the pay date's year, and remain fully editable: the
+ * moment the accountant types in one of those boxes it stops being recalculated
+ * and their figure is what gets saved. The calculator assumes basic TD1 claim
+ * amounts and no other deductible amounts, which is why overriding has to stay
+ * easy rather than being treated as an error.
  */
 export function PayStubDialog({
   open,
@@ -76,30 +113,137 @@ export function PayStubDialog({
   initialEmployeeId,
   initialPeriodStart,
   initialPeriodEnd,
+  payStub = null,
 }: PayStubDialogProps) {
+  const isEditing = Boolean(payStub);
   const [form, setForm] = useState({ ...emptyForm });
   const [hours, setHours] = useState<PayrollHoursDto | null>(null);
   const [loadingHours, setLoadingHours] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [estimate, setEstimate] = useState<PayStubDeductionEstimateDto | null>(
+    null
+  );
+  const [estimating, setEstimating] = useState(false);
+  // Which withholdings the accountant has typed over. An overridden field is
+  // never rewritten by a later calculation — silently replacing a figure
+  // someone deliberately entered is how wrong pay gets issued.
+  const [overrides, setOverrides] =
+    useState<Record<CalculatedField, boolean>>(noOverrides);
+  // Mirrored in a ref so the estimate effect can respect overrides without
+  // listing them as a dependency — claiming a field is not a reason to go and
+  // ask the server for the same numbers again.
+  const overridesRef = useRef(overrides);
+  overridesRef.current = overrides;
+  // Gross is derived from rate × hours until the accountant types one in.
+  const [grossOverridden, setGrossOverridden] = useState(false);
+  const grossOverriddenRef = useRef(grossOverridden);
+  grossOverriddenRef.current = grossOverridden;
+  // Position comes from the employee's compensation record until typed over.
+  const [positionOverridden, setPositionOverridden] = useState(false);
+  const [carriedPosition, setCarriedPosition] = useState(false);
 
   useEffect(() => {
     if (!open) return;
-    setForm({
-      ...emptyForm,
-      employeeId: initialEmployeeId || '',
-      periodStart: initialPeriodStart || emptyForm.periodStart,
-      periodEnd: initialPeriodEnd || emptyForm.periodEnd,
-    });
+
+    if (payStub) {
+      // Amending: load the stub as issued. Everything is treated as entered by
+      // hand, because it was — the figures on an issued stub are what was
+      // actually withheld, and reopening the form must not quietly recalculate
+      // them out from under the accountant.
+      setForm({
+        ...emptyForm,
+        employeeId: payStub.employeeId,
+        periodStart: payStub.periodStart,
+        periodEnd: payStub.periodEnd,
+        payDate: payStub.payDate,
+        position: payStub.position || '',
+        payRate: payStub.payRate != null ? String(payStub.payRate) : '',
+        regularHours: String(payStub.regularHours),
+        regularAmount: String(payStub.regularAmount),
+        eiAmount: String(payStub.eiAmount),
+        cppAmount: String(payStub.cppAmount),
+        incomeTaxAmount: String(payStub.incomeTaxAmount),
+        otherDeductions: String(payStub.otherDeductions),
+        otherDeductionsLabel: payStub.otherDeductionsLabel || '',
+        notes: payStub.notes || '',
+      });
+      setOverrides({
+        eiAmount: true,
+        cppAmount: true,
+        incomeTaxAmount: true,
+      });
+      setGrossOverridden(true);
+      setPositionOverridden(true);
+    } else {
+      setForm({
+        ...emptyForm,
+        employeeId: initialEmployeeId || '',
+        periodStart: initialPeriodStart || emptyForm.periodStart,
+        periodEnd: initialPeriodEnd || emptyForm.periodEnd,
+      });
+      setOverrides(noOverrides);
+      setGrossOverridden(false);
+      setPositionOverridden(false);
+    }
+
     setHours(null);
     setError(null);
-  }, [open, initialEmployeeId, initialPeriodStart, initialPeriodEnd]);
+    setEstimate(null);
+    setCarriedPosition(false);
+  }, [open, payStub, initialEmployeeId, initialPeriodStart, initialPeriodEnd]);
 
   const setField = (field: keyof typeof emptyForm, value: string) =>
     setForm((prev) => ({ ...prev, [field]: value }));
 
+  /** Typing in a calculated field claims it: hands off from here on. */
+  const setWithholding = (field: CalculatedField, value: string) => {
+    setOverrides((prev) => ({ ...prev, [field]: true }));
+    setField(field, value);
+  };
+
+  /**
+   * Rate and hours drive gross, so editing either recalculates it — the three
+   * printed on the stub should always multiply out.
+   *
+   * Only while gross is still derived, though. Gross is the figure that
+   * actually gets paid and it is not always a product: a salaried employee has
+   * no meaningful hourly rate, and hourly pay can carry an agreed adjustment.
+   * Once the accountant types a gross, rate and hours become the descriptive
+   * detail they are on the printed stub and stop overwriting it.
+   */
+  const setEarnings = (field: 'payRate' | 'regularHours', value: string) => {
+    setForm((prev) => {
+      const next = { ...prev, [field]: value };
+      if (grossOverriddenRef.current) return next;
+
+      const rate = toNumber(next.payRate);
+      const hours = toNumber(next.regularHours);
+      // An empty rate or hours means "not known yet", not "zero" — blanking the
+      // gross the moment someone clears a box to retype it would be hostile.
+      if (next.payRate.trim() === '' || next.regularHours.trim() === '') {
+        return next;
+      }
+      return { ...next, regularAmount: String(round2(rate * hours)) };
+    });
+  };
+
+  const derivedGross =
+    form.payRate.trim() !== '' && form.regularHours.trim() !== ''
+      ? round2(toNumber(form.payRate) * toNumber(form.regularHours))
+      : null;
+
+  /** Go back to rate × hours after a manual gross. */
+  const restoreDerivedGross = () => {
+    if (derivedGross === null) return;
+    setGrossOverridden(false);
+    setField('regularAmount', String(derivedGross));
+  };
+
   const loadHours = useCallback(async () => {
-    if (!form.employeeId || !form.periodStart || !form.periodEnd) {
+    // Amending an issued stub never re-derives from approved time: the stub
+    // records what was paid, not what the time entries say today.
+    if (isEditing || !form.employeeId || !form.periodStart || !form.periodEnd) {
       setHours(null);
       return;
     }
@@ -125,20 +269,101 @@ export function PayStubDialog({
               ? String(result.hourlyRate)
               : prev.payRate,
           regularAmount: result.grossPay ? String(result.grossPay) : '',
+          // The job title comes from the employee's compensation record, set
+          // alongside their pay rate. Left alone once typed over.
+          position:
+            result.position && !positionOverridden
+              ? result.position
+              : prev.position,
         }));
+        setCarriedPosition(Boolean(result.position) && !positionOverridden);
       }
     } catch (err: any) {
       setError(err.message || 'Failed to load approved hours');
     } finally {
       setLoadingHours(false);
     }
-  }, [form.employeeId, form.periodStart, form.periodEnd]);
+  }, [
+    isEditing,
+    positionOverridden,
+    form.employeeId,
+    form.periodStart,
+    form.periodEnd,
+  ]);
 
   useEffect(() => {
     loadHours();
   }, [loadHours]);
 
   const grossPay = toNumber(form.regularAmount);
+
+  /**
+   * Recalculate the statutory deductions whenever the inputs they depend on
+   * change. Debounced so typing a gross does not fire a request per keystroke,
+   * and the response is discarded if the inputs moved on while it was in
+   * flight — a stale estimate landing in the fields would be worse than none.
+   */
+  useEffect(() => {
+    if (!open) return;
+    if (!form.employeeId || !form.payDate || !(grossPay > 0)) {
+      setEstimate(null);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        setEstimating(true);
+        const result = await payStubService.estimateDeductions({
+          employeeId: form.employeeId,
+          payDate: form.payDate,
+          grossPay,
+          payPeriodsPerYear: form.payPeriodsPerYear,
+        });
+        if (cancelled) return;
+        setEstimate(result);
+        if (result.supported) {
+          const claimed = overridesRef.current;
+          setForm((prev) => ({
+            ...prev,
+            eiAmount: claimed.eiAmount ? prev.eiAmount : String(result.ei),
+            cppAmount: claimed.cppAmount ? prev.cppAmount : String(result.cpp),
+            incomeTaxAmount: claimed.incomeTaxAmount
+              ? prev.incomeTaxAmount
+              : String(result.incomeTax),
+          }));
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          // A failed estimate must not block the stub: the accountant can still
+          // type the figures in, which is exactly what they did before.
+          setEstimate(null);
+        }
+      } finally {
+        if (!cancelled) setEstimating(false);
+      }
+    }, 400);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [open, form.employeeId, form.payDate, form.payPeriodsPerYear, grossPay]);
+
+  /** Put every calculated figure back, discarding the accountant's edits. */
+  const restoreCalculated = () => {
+    if (!estimate?.supported) return;
+    setOverrides(noOverrides);
+    setForm((prev) => ({
+      ...prev,
+      eiAmount: String(estimate.ei),
+      cppAmount: String(estimate.cpp),
+      incomeTaxAmount: String(estimate.incomeTax),
+    }));
+  };
+
+  const hasOverride = Object.values(overrides).some(Boolean);
+
   const totalWithholding =
     toNumber(form.eiAmount) +
     toNumber(form.cppAmount) +
@@ -175,11 +400,20 @@ export function PayStubDialog({
         otherDeductionsLabel: form.otherDeductionsLabel || undefined,
         notes: form.notes || undefined,
       };
-      const created = await payStubService.create(dto);
-      onCreated(created);
+      // Amending sends the same fields minus the employee, which a stub can
+      // never change: it belongs to one person's year-to-date record.
+      const saved = payStub
+        ? await payStubService.update(payStub.id, {
+            ...dto,
+            employeeId: undefined,
+          } as any)
+        : await payStubService.create(dto);
+      onCreated(saved);
       onClose();
     } catch (err: any) {
-      setError(err.message || 'Failed to create the pay stub');
+      setError(
+        err.message || `Failed to ${payStub ? 'update' : 'create'} the pay stub`
+      );
     } finally {
       setSaving(false);
     }
@@ -191,13 +425,31 @@ export function PayStubDialog({
       currency: 'CAD',
     }).format(amount);
 
+  // The options come from employees with payroll hours, so an employee who has
+  // since left — or simply logged no time this period — would not be in the
+  // list. On an amendment their name still has to show, not an empty box.
+  const employeeOptions =
+    payStub && !employees.some((option) => option.id === payStub.employeeId)
+      ? [...employees, { id: payStub.employeeId, name: payStub.employeeName }]
+      : employees;
+
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle sx={{ fontWeight: 700 }}>Create Pay Stub</DialogTitle>
+      <DialogTitle sx={{ fontWeight: 700 }}>
+        {isEditing ? 'Edit Pay Stub' : 'Create Pay Stub'}
+      </DialogTitle>
       <DialogContent dividers>
         {error && (
           <Alert severity="error" sx={{ mb: 2 }}>
             {error}
+          </Alert>
+        )}
+
+        {isEditing && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            Correcting an issued pay stub. Saving recomputes this employee's
+            year-to-date totals on this and every later stub in the year, and
+            the change is recorded in the audit log.
           </Alert>
         )}
 
@@ -210,8 +462,14 @@ export function PayStubDialog({
               label="Employee"
               value={form.employeeId}
               onChange={(event) => setField('employeeId', event.target.value)}
+              // A stub belongs to one person's year-to-date record; moving it
+              // would corrupt both. Re-raise it against the right employee.
+              disabled={isEditing}
+              helperText={
+                isEditing ? 'Cannot be changed on an issued stub' : undefined
+              }
             >
-              {employees.map((employee) => (
+              {employeeOptions.map((employee) => (
                 <MenuItem key={employee.id} value={employee.id}>
                   {employee.name}
                 </MenuItem>
@@ -224,8 +482,15 @@ export function PayStubDialog({
               size="small"
               label="Position"
               value={form.position}
-              onChange={(event) => setField('position', event.target.value)}
+              onChange={(event) => {
+                setPositionOverridden(true);
+                setCarriedPosition(false);
+                setField('position', event.target.value);
+              }}
               placeholder="e.g. Business Manager"
+              helperText={
+                carriedPosition ? 'From the compensation record' : ' '
+              }
             />
           </Grid>
 
@@ -312,7 +577,7 @@ export function PayStubDialog({
               type="number"
               label="Pay Rate"
               value={form.payRate}
-              onChange={(event) => setField('payRate', event.target.value)}
+              onChange={(event) => setEarnings('payRate', event.target.value)}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">$</InputAdornment>
@@ -327,7 +592,9 @@ export function PayStubDialog({
               type="number"
               label="Regular Hours"
               value={form.regularHours}
-              onChange={(event) => setField('regularHours', event.target.value)}
+              onChange={(event) =>
+                setEarnings('regularHours', event.target.value)
+              }
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 4 }}>
@@ -338,13 +605,37 @@ export function PayStubDialog({
               type="number"
               label="Gross Pay"
               value={form.regularAmount}
-              onChange={(event) =>
-                setField('regularAmount', event.target.value)
+              onChange={(event) => {
+                setGrossOverridden(true);
+                setField('regularAmount', event.target.value);
+              }}
+              helperText={
+                grossOverridden
+                  ? derivedGross !== null
+                    ? `Entered by hand — rate × hours is ${money(derivedGross)}`
+                    : 'Entered by hand'
+                  : derivedGross !== null
+                  ? 'Rate × hours'
+                  : ' '
               }
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">$</InputAdornment>
                 ),
+                endAdornment:
+                  grossOverridden && derivedGross !== null ? (
+                    <InputAdornment position="end">
+                      <Tooltip title="Use rate × hours">
+                        <IconButton
+                          size="small"
+                          edge="end"
+                          onClick={restoreDerivedGross}
+                        >
+                          <CalculateIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </InputAdornment>
+                  ) : undefined,
               }}
             />
           </Grid>
@@ -357,6 +648,68 @@ export function PayStubDialog({
             </Divider>
           </Grid>
 
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              select
+              fullWidth
+              size="small"
+              label="Pay Frequency"
+              value={form.payPeriodsPerYear}
+              onChange={(event) =>
+                setForm((prev) => ({
+                  ...prev,
+                  payPeriodsPerYear: Number(
+                    event.target.value
+                  ) as PayPeriodsPerYear,
+                }))
+              }
+              helperText="Sets how the CRA formulas annualize this pay"
+            >
+              {PAY_FREQUENCIES.map((frequency) => (
+                <MenuItem key={frequency.value} value={frequency.value}>
+                  {frequency.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 8 }}>
+            {estimating ? (
+              <Alert severity="info">Calculating deductions…</Alert>
+            ) : estimate && !estimate.supported ? (
+              <Alert severity="warning">{estimate.assumptions[0]}</Alert>
+            ) : estimate?.supported ? (
+              <Alert
+                severity={hasOverride ? 'warning' : 'success'}
+                action={
+                  hasOverride ? (
+                    <Button
+                      size="small"
+                      color="inherit"
+                      onClick={restoreCalculated}
+                    >
+                      Use calculated
+                    </Button>
+                  ) : undefined
+                }
+              >
+                <Typography variant="body2">
+                  {hasOverride
+                    ? 'Some withholdings were entered by hand and are no longer being recalculated.'
+                    : `Calculated from gross using ${estimate.taxYear} CRA rates.`}{' '}
+                  Federal {money(estimate.federalTax)} + BC{' '}
+                  {money(estimate.provincialTax)} income tax
+                  {estimate.cpp2 > 0
+                    ? `, including ${money(estimate.cpp2)} CPP2`
+                    : ''}
+                  .
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {estimate.assumptions.join(' ')}
+                </Typography>
+              </Alert>
+            ) : null}
+          </Grid>
+
           <Grid size={{ xs: 12, sm: 3 }}>
             <TextField
               fullWidth
@@ -364,7 +717,18 @@ export function PayStubDialog({
               type="number"
               label="Employee EI"
               value={form.eiAmount}
-              onChange={(event) => setField('eiAmount', event.target.value)}
+              onChange={(event) =>
+                setWithholding('eiAmount', event.target.value)
+              }
+              helperText={
+                overrides.eiAmount
+                  ? 'Entered by hand'
+                  : estimate?.supported
+                  ? estimate.eiMaxedOut
+                    ? 'Annual maximum reached'
+                    : 'Calculated'
+                  : ' '
+              }
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">$</InputAdornment>
@@ -379,7 +743,18 @@ export function PayStubDialog({
               type="number"
               label="Employee CPP/QPP"
               value={form.cppAmount}
-              onChange={(event) => setField('cppAmount', event.target.value)}
+              onChange={(event) =>
+                setWithholding('cppAmount', event.target.value)
+              }
+              helperText={
+                overrides.cppAmount
+                  ? 'Entered by hand'
+                  : estimate?.supported
+                  ? estimate.cppMaxedOut
+                    ? 'Annual maximum reached'
+                    : 'Calculated'
+                  : ' '
+              }
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">$</InputAdornment>
@@ -395,9 +770,15 @@ export function PayStubDialog({
               label="Income Tax"
               value={form.incomeTaxAmount}
               onChange={(event) =>
-                setField('incomeTaxAmount', event.target.value)
+                setWithholding('incomeTaxAmount', event.target.value)
               }
-              helperText="Omitted from the stub when zero"
+              helperText={
+                overrides.incomeTaxAmount
+                  ? 'Entered by hand'
+                  : estimate?.supported
+                  ? 'Federal + BC, claim code 1'
+                  : 'Omitted from the stub when zero'
+              }
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">$</InputAdornment>
@@ -504,7 +885,13 @@ export function PayStubDialog({
           Cancel
         </Button>
         <Button variant="contained" onClick={handleSave} disabled={!canSave}>
-          {saving ? 'Creating…' : 'Create Pay Stub'}
+          {saving
+            ? isEditing
+              ? 'Saving…'
+              : 'Creating…'
+            : isEditing
+            ? 'Save Changes'
+            : 'Create Pay Stub'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/apps/webApp/src/app/components/pay-stubs/PayStubDialog.tsx
+++ b/apps/webApp/src/app/components/pay-stubs/PayStubDialog.tsx
@@ -1,0 +1,514 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Grid,
+  InputAdornment,
+  MenuItem,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { endOfMonth, format, startOfMonth } from 'date-fns';
+import {
+  CreatePayStubDto,
+  PayrollHoursDto,
+  PayStubDto,
+  PayType,
+} from '@gt-automotive/data';
+import { payStubService } from '../../requests/pay-stub.requests';
+import { timeClockService } from '../../requests/time-clock.requests';
+import { colors } from '../../theme/colors';
+
+interface PayStubDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (payStub: PayStubDto) => void;
+  /** Employees the accountant can raise a stub for. */
+  employees: { id: string; name: string }[];
+  initialEmployeeId?: string;
+  initialPeriodStart?: string;
+  initialPeriodEnd?: string;
+}
+
+const today = () => format(new Date(), 'yyyy-MM-dd');
+const toNumber = (value: string) => (value.trim() === '' ? 0 : Number(value));
+
+const emptyForm = {
+  employeeId: '',
+  periodStart: format(startOfMonth(new Date()), 'yyyy-MM-dd'),
+  periodEnd: format(endOfMonth(new Date()), 'yyyy-MM-dd'),
+  payDate: today(),
+  position: '',
+  payRate: '',
+  regularHours: '',
+  regularAmount: '',
+  eiAmount: '',
+  cppAmount: '',
+  incomeTaxAmount: '',
+  otherDeductions: '',
+  otherDeductionsLabel: '',
+  notes: '',
+};
+
+/**
+ * Raise a pay stub for an employee.
+ *
+ * Hours, pay rate and gross pre-fill from the employee's approved time for the
+ * selected period. That comes from the read-only payroll-hours endpoint, never
+ * from process-payroll — opening this form must not mark anyone's time entries
+ * as processed as a side effect of looking at the numbers.
+ *
+ * Statutory deductions are typed by the accountant. The system deliberately
+ * does not calculate EI or CPP: the rates change yearly and a wrong guess is
+ * worse than an honest blank.
+ */
+export function PayStubDialog({
+  open,
+  onClose,
+  onCreated,
+  employees,
+  initialEmployeeId,
+  initialPeriodStart,
+  initialPeriodEnd,
+}: PayStubDialogProps) {
+  const [form, setForm] = useState({ ...emptyForm });
+  const [hours, setHours] = useState<PayrollHoursDto | null>(null);
+  const [loadingHours, setLoadingHours] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm({
+      ...emptyForm,
+      employeeId: initialEmployeeId || '',
+      periodStart: initialPeriodStart || emptyForm.periodStart,
+      periodEnd: initialPeriodEnd || emptyForm.periodEnd,
+    });
+    setHours(null);
+    setError(null);
+  }, [open, initialEmployeeId, initialPeriodStart, initialPeriodEnd]);
+
+  const setField = (field: keyof typeof emptyForm, value: string) =>
+    setForm((prev) => ({ ...prev, [field]: value }));
+
+  const loadHours = useCallback(async () => {
+    if (!form.employeeId || !form.periodStart || !form.periodEnd) {
+      setHours(null);
+      return;
+    }
+
+    try {
+      setLoadingHours(true);
+      setError(null);
+      const [result] = await timeClockService.getPayrollHours({
+        employeeId: form.employeeId,
+        startDate: new Date(`${form.periodStart}T00:00:00`).toISOString(),
+        endDate: new Date(`${form.periodEnd}T23:59:59`).toISOString(),
+      });
+      setHours(result || null);
+
+      if (result) {
+        // Pre-fill, never force: the accountant confirms these figures and can
+        // overwrite any of them before the stub is raised.
+        setForm((prev) => ({
+          ...prev,
+          regularHours: result.hours ? String(result.hours) : '',
+          payRate:
+            result.hasCompensation && result.payType === PayType.HOURLY
+              ? String(result.hourlyRate)
+              : prev.payRate,
+          regularAmount: result.grossPay ? String(result.grossPay) : '',
+        }));
+      }
+    } catch (err: any) {
+      setError(err.message || 'Failed to load approved hours');
+    } finally {
+      setLoadingHours(false);
+    }
+  }, [form.employeeId, form.periodStart, form.periodEnd]);
+
+  useEffect(() => {
+    loadHours();
+  }, [loadHours]);
+
+  const grossPay = toNumber(form.regularAmount);
+  const totalWithholding =
+    toNumber(form.eiAmount) +
+    toNumber(form.cppAmount) +
+    toNumber(form.incomeTaxAmount) +
+    toNumber(form.otherDeductions);
+  const netPay = grossPay - totalWithholding;
+
+  const canSave =
+    Boolean(form.employeeId) &&
+    Boolean(form.periodStart) &&
+    Boolean(form.periodEnd) &&
+    Boolean(form.payDate) &&
+    form.regularAmount.trim() !== '' &&
+    netPay >= 0 &&
+    !saving;
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      setError(null);
+      const dto: CreatePayStubDto = {
+        employeeId: form.employeeId,
+        periodStart: form.periodStart,
+        periodEnd: form.periodEnd,
+        payDate: form.payDate,
+        position: form.position || undefined,
+        payRate: form.payRate ? toNumber(form.payRate) : undefined,
+        regularHours: toNumber(form.regularHours),
+        regularAmount: toNumber(form.regularAmount),
+        eiAmount: toNumber(form.eiAmount),
+        cppAmount: toNumber(form.cppAmount),
+        incomeTaxAmount: toNumber(form.incomeTaxAmount),
+        otherDeductions: toNumber(form.otherDeductions),
+        otherDeductionsLabel: form.otherDeductionsLabel || undefined,
+        notes: form.notes || undefined,
+      };
+      const created = await payStubService.create(dto);
+      onCreated(created);
+      onClose();
+    } catch (err: any) {
+      setError(err.message || 'Failed to create the pay stub');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const money = (amount: number) =>
+    new Intl.NumberFormat('en-CA', {
+      style: 'currency',
+      currency: 'CAD',
+    }).format(amount);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ fontWeight: 700 }}>Create Pay Stub</DialogTitle>
+      <DialogContent dividers>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <TextField
+              select
+              fullWidth
+              size="small"
+              label="Employee"
+              value={form.employeeId}
+              onChange={(event) => setField('employeeId', event.target.value)}
+            >
+              {employees.map((employee) => (
+                <MenuItem key={employee.id} value={employee.id}>
+                  {employee.name}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Position"
+              value={form.position}
+              onChange={(event) => setField('position', event.target.value)}
+              placeholder="e.g. Business Manager"
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="date"
+              label="Period Start"
+              value={form.periodStart}
+              onChange={(event) => setField('periodStart', event.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="date"
+              label="Period End"
+              value={form.periodEnd}
+              onChange={(event) => setField('periodEnd', event.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="date"
+              label="Pay Date"
+              value={form.payDate}
+              onChange={(event) => setField('payDate', event.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+          </Grid>
+
+          {form.employeeId && (
+            <Grid size={12}>
+              {loadingHours ? (
+                <Alert severity="info">Loading approved hours…</Alert>
+              ) : hours && !hours.hasCompensation ? (
+                <Alert severity="warning">
+                  This employee has no active compensation record, so no pay
+                  rate could be pre-filled. Enter the rate and gross manually.
+                </Alert>
+              ) : hours && hours.payType === PayType.SALARIED ? (
+                <Alert severity="info">
+                  Salaried employee — gross is prorated from the annual salary
+                  across this period, not derived from hours. Adjust if needed.
+                </Alert>
+              ) : hours && hours.hours === 0 ? (
+                <Alert severity="warning">
+                  No approved hours found for this period. Enter the figures
+                  manually, or approve the time entries first.
+                </Alert>
+              ) : hours ? (
+                <Alert severity="success">
+                  Pre-filled from {hours.entryCount} approved{' '}
+                  {hours.entryCount === 1 ? 'entry' : 'entries'} (
+                  {hours.hours.toFixed(2)} hrs).
+                  {hours.processedHours > 0
+                    ? ` ${hours.processedHours.toFixed(
+                        2
+                      )} hrs already processed for payroll.`
+                    : ''}
+                </Alert>
+              ) : null}
+            </Grid>
+          )}
+
+          <Grid size={12}>
+            <Divider textAlign="left" sx={{ mt: 1 }}>
+              <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                EARNINGS
+              </Typography>
+            </Divider>
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Pay Rate"
+              value={form.payRate}
+              onChange={(event) => setField('payRate', event.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Regular Hours"
+              value={form.regularHours}
+              onChange={(event) => setField('regularHours', event.target.value)}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              required
+              size="small"
+              type="number"
+              label="Gross Pay"
+              value={form.regularAmount}
+              onChange={(event) =>
+                setField('regularAmount', event.target.value)
+              }
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+
+          <Grid size={12}>
+            <Divider textAlign="left" sx={{ mt: 1 }}>
+              <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                WITHHOLDINGS
+              </Typography>
+            </Divider>
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 3 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Employee EI"
+              value={form.eiAmount}
+              onChange={(event) => setField('eiAmount', event.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 3 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Employee CPP/QPP"
+              value={form.cppAmount}
+              onChange={(event) => setField('cppAmount', event.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 3 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Income Tax"
+              value={form.incomeTaxAmount}
+              onChange={(event) =>
+                setField('incomeTaxAmount', event.target.value)
+              }
+              helperText="Omitted from the stub when zero"
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 3 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Other Deduction"
+              value={form.otherDeductions}
+              onChange={(event) =>
+                setField('otherDeductions', event.target.value)
+              }
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+              }}
+            />
+          </Grid>
+          {toNumber(form.otherDeductions) > 0 && (
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Other Deduction Label"
+                value={form.otherDeductionsLabel}
+                onChange={(event) =>
+                  setField('otherDeductionsLabel', event.target.value)
+                }
+                placeholder="e.g. Uniform"
+              />
+            </Grid>
+          )}
+
+          <Grid size={12}>
+            <TextField
+              fullWidth
+              size="small"
+              multiline
+              rows={2}
+              label="Notes (optional)"
+              value={form.notes}
+              onChange={(event) => setField('notes', event.target.value)}
+            />
+          </Grid>
+
+          <Grid size={12}>
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 3,
+                flexWrap: 'wrap',
+                p: 2,
+                borderRadius: 1,
+                background: colors.neutral[100],
+              }}
+            >
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  Gross Pay
+                </Typography>
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  {money(grossPay)}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  Withholding Totals
+                </Typography>
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  {money(totalWithholding)}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  Net Pay
+                </Typography>
+                <Typography
+                  variant="h6"
+                  sx={{
+                    fontWeight: 700,
+                    color: netPay < 0 ? 'error.main' : colors.primary.main,
+                  }}
+                >
+                  {money(netPay)}
+                </Typography>
+              </Box>
+            </Box>
+            {netPay < 0 && (
+              <Alert severity="error" sx={{ mt: 1 }}>
+                Withholdings exceed gross pay — check the amounts.
+              </Alert>
+            )}
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={handleSave} disabled={!canSave}>
+          {saving ? 'Creating…' : 'Create Pay Stub'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default PayStubDialog;

--- a/apps/webApp/src/app/components/pay-stubs/PayStubViewer.tsx
+++ b/apps/webApp/src/app/components/pay-stubs/PayStubViewer.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import { Close, Download, Print } from '@mui/icons-material';
+import { PayStubDto } from '@gt-automotive/data';
+import { payStubService } from '../../requests/pay-stub.requests';
+
+interface PayStubViewerProps {
+  payStub: PayStubDto | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Views a pay stub and prints it.
+ *
+ * Both actions render the same server-generated PDF — there is no second
+ * on-screen template to keep in step with the printed one. The document is
+ * generated on demand and never stored, so what is shown here is rebuilt from
+ * the stub's frozen figures each time it is opened.
+ */
+export function PayStubViewer({ payStub, open, onClose }: PayStubViewerProps) {
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const frameRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    if (!open || !payStub) return;
+
+    let objectUrl: string | null = null;
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const blob = await payStubService.fetchPdfBlob(payStub.id);
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setPdfUrl(objectUrl);
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err.message || 'Failed to load the pay stub');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+      // The blob stays in memory until it is revoked, and a pay stub is not
+      // something to leave lying around longer than the dialog it was opened in.
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      setPdfUrl(null);
+    };
+  }, [open, payStub]);
+
+  const handlePrint = () => {
+    const frame = frameRef.current;
+    if (!frame?.contentWindow) return;
+    frame.contentWindow.focus();
+    frame.contentWindow.print();
+  };
+
+  const handleDownload = () => {
+    if (!pdfUrl || !payStub) return;
+    const link = document.createElement('a');
+    link.href = pdfUrl;
+    link.download = `paystub-${payStub.payDate}-${payStub.employeeName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')}.pdf`;
+    link.click();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            Pay Stub
+          </Typography>
+          {payStub && (
+            <Typography variant="body2" color="text.secondary">
+              {payStub.periodStart} to {payStub.periodEnd} · paid{' '}
+              {payStub.payDate}
+            </Typography>
+          )}
+        </Box>
+        <IconButton onClick={onClose} size="small" aria-label="Close">
+          <Close />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0, minHeight: 480 }}>
+        {error && (
+          <Alert severity="error" sx={{ m: 2 }}>
+            {error}
+          </Alert>
+        )}
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
+        )}
+        {pdfUrl && !loading && (
+          <iframe
+            ref={frameRef}
+            src={pdfUrl}
+            title="Pay stub"
+            style={{ width: '100%', height: '70vh', border: 'none' }}
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+        <Button
+          startIcon={<Download />}
+          onClick={handleDownload}
+          disabled={!pdfUrl}
+        >
+          Download
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<Print />}
+          onClick={handlePrint}
+          disabled={!pdfUrl}
+        >
+          Print
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default PayStubViewer;

--- a/apps/webApp/src/app/components/quotations/QuotationDialog.tsx
+++ b/apps/webApp/src/app/components/quotations/QuotationDialog.tsx
@@ -64,6 +64,9 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
   });
 
   const [items, setItems] = useState<QuoteItem[]>([]);
+  // Index of the item currently loaded into the entry row for editing, or null
+  // when the entry row is adding a new item.
+  const [editingItemIndex, setEditingItemIndex] = useState<number | null>(null);
   const [newItem, setNewItem] = useState<QuoteItem>({
     itemType: 'TIRE',
     description: '',
@@ -172,21 +175,56 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
     }
   };
 
+  const blankItem = () => ({
+    itemType: 'TIRE' as const,
+    description: '',
+    quantity: 1,
+    unitPrice: '' as unknown as number,
+    tireId: undefined,
+  });
+
+  /**
+   * Commit the entry row — appending a new item, or replacing the one being
+   * edited. Line and quote totals are derived from the items array on render,
+   * so replacing a row is enough to keep them in step.
+   */
   const handleAddItem = () => {
-    if (newItem.description && newItem.quantity && newItem.unitPrice) {
+    if (!(newItem.description && newItem.quantity && newItem.unitPrice)) return;
+
+    if (editingItemIndex !== null) {
+      setItems(
+        items.map((item, index) =>
+          index === editingItemIndex ? { ...newItem } : item
+        )
+      );
+      setEditingItemIndex(null);
+    } else {
       setItems([...items, { ...newItem }]);
-      setNewItem({
-        itemType: 'TIRE',
-        description: '',
-        quantity: 1,
-        unitPrice: '' as unknown as number,
-        tireId: undefined,
-      });
     }
+
+    setNewItem(blankItem());
+  };
+
+  /** Load an existing row back into the entry form for editing. */
+  const handleEditItem = (index: number) => {
+    const item = items[index];
+    if (!item) return;
+    setEditingItemIndex(index);
+    setNewItem({ ...item });
+  };
+
+  const handleCancelEditItem = () => {
+    setEditingItemIndex(null);
+    setNewItem(blankItem());
   };
 
   const handleRemoveItem = (index: number) => {
     setItems(items.filter((_, i) => i !== index));
+    // Removing a row shifts every later index, so an in-progress edit would
+    // silently start pointing at the wrong item. Drop it.
+    if (editingItemIndex !== null) {
+      handleCancelEditItem();
+    }
   };
 
   const handleSave = async (shouldPrint = false) => {
@@ -357,6 +395,9 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
             setNewItem={setNewItem}
             onAddItem={handleAddItem}
             onRemoveItem={handleRemoveItem}
+            onEditItem={handleEditItem}
+            onCancelEditItem={handleCancelEditItem}
+            editingItemIndex={editingItemIndex}
             onTireSelect={handleTireSelect}
             onServicesChange={handleServicesChange}
           />

--- a/apps/webApp/src/app/components/quotations/QuotationDialog.tsx
+++ b/apps/webApp/src/app/components/quotations/QuotationDialog.tsx
@@ -17,11 +17,16 @@ import {
   Close as CloseIcon,
   RequestQuote as QuoteIcon,
 } from '@mui/icons-material';
-import { quotationService, QuoteItem } from '../../requests/quotation.requests';
+import {
+  quotationService,
+  Quote,
+  QuoteItem,
+} from '../../requests/quotation.requests';
 import { TireService } from '../../requests/tire.requests';
 import { serviceService } from '../../requests/service.requests';
 import { ServiceDto } from '@gt-automotive/data';
 import QuotationFormContent from './QuotationFormContent';
+import QuotationPrintDialog from './QuotationPrintDialog';
 import { useError } from '../../contexts/ErrorContext';
 import { colors } from '../../theme/colors';
 
@@ -45,6 +50,9 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
   const [saving, setSaving] = useState(false);
   const [tires, setTires] = useState<any[]>([]);
   const [services, setServices] = useState<ServiceDto[]>([]);
+  // The just-saved quote, shown in the print preview dialog. Held here rather
+  // than in the caller so the preview outlives this form closing.
+  const [savedQuote, setSavedQuote] = useState<Quote | null>(null);
 
   const [quoteForm, setQuoteForm] = useState({
     customerName: '',
@@ -64,9 +72,6 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
   });
 
   const [items, setItems] = useState<QuoteItem[]>([]);
-  // Index of the item currently loaded into the entry row for editing, or null
-  // when the entry row is adding a new item.
-  const [editingItemIndex, setEditingItemIndex] = useState<number | null>(null);
   const [newItem, setNewItem] = useState<QuoteItem>({
     itemType: 'TIRE',
     description: '',
@@ -183,48 +188,26 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
     tireId: undefined,
   });
 
-  /**
-   * Commit the entry row — appending a new item, or replacing the one being
-   * edited. Line and quote totals are derived from the items array on render,
-   * so replacing a row is enough to keep them in step.
-   */
   const handleAddItem = () => {
     if (!(newItem.description && newItem.quantity && newItem.unitPrice)) return;
 
-    if (editingItemIndex !== null) {
-      setItems(
-        items.map((item, index) =>
-          index === editingItemIndex ? { ...newItem } : item
-        )
-      );
-      setEditingItemIndex(null);
-    } else {
-      setItems([...items, { ...newItem }]);
-    }
-
+    setItems([...items, { ...newItem }]);
     setNewItem(blankItem());
   };
 
-  /** Load an existing row back into the entry form for editing. */
-  const handleEditItem = (index: number) => {
-    const item = items[index];
-    if (!item) return;
-    setEditingItemIndex(index);
-    setNewItem({ ...item });
-  };
-
-  const handleCancelEditItem = () => {
-    setEditingItemIndex(null);
-    setNewItem(blankItem());
+  /**
+   * Apply an in-row edit. Only the edited fields arrive here; line and quote
+   * totals are derived from the items array on render, so replacing the row is
+   * enough to keep them in step.
+   */
+  const handleUpdateItem = (index: number, changes: Partial<QuoteItem>) => {
+    setItems(
+      items.map((item, i) => (i === index ? { ...item, ...changes } : item))
+    );
   };
 
   const handleRemoveItem = (index: number) => {
     setItems(items.filter((_, i) => i !== index));
-    // Removing a row shifts every later index, so an in-progress edit would
-    // silently start pointing at the wrong item. Drop it.
-    if (editingItemIndex !== null) {
-      handleCancelEditItem();
-    }
   };
 
   const handleSave = async (shouldPrint = false) => {
@@ -267,20 +250,11 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
         });
       }
 
-      // Print the quotation if requested, but don't let print failures affect the save operation
+      // Show the saved quotation in a preview dialog rather than a new browser
+      // tab, so the user stays on the page they were working on and can print
+      // from there if they want to.
       if (shouldPrint) {
-        try {
-          quotationService.printQuote(savedQuotation);
-        } catch (printError) {
-          console.warn(
-            'Print failed, but quotation was saved successfully:',
-            printError
-          );
-          // Show a warning but don't fail the entire operation
-          showError(
-            'Quotation saved successfully, but printing failed. You can print it later from the quotations list.'
-          );
-        }
+        setSavedQuote(savedQuotation);
       }
 
       if (onSuccess) {
@@ -294,171 +268,183 @@ const QuoteDialog: React.FC<QuoteDialogProps> = ({
     }
   };
 
-  const handleSaveAndPrint = async () => {
+  const handleSaveAndPreview = async () => {
     await handleSave(true);
   };
 
   return (
-    <Dialog
-      open={open}
-      disableEscapeKeyDown
-      maxWidth="xl"
-      fullWidth
-      fullScreen={isMobile}
-      PaperProps={{
-        sx: {
-          borderRadius: isMobile ? 0 : 3,
-          ...(isMobile && {
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100vh',
-          }),
-        },
-      }}
-    >
-      <DialogTitle
-        sx={{
-          background: colors.gradients.primary,
-          color: 'white',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          py: { xs: 1.5, sm: 2 },
-          px: { xs: 2, sm: 3 },
-          ...(isMobile && {
-            flexShrink: 0,
-          }),
+    <>
+      <Dialog
+        open={open}
+        disableEscapeKeyDown
+        maxWidth="xl"
+        fullWidth
+        fullScreen={isMobile}
+        PaperProps={{
+          sx: {
+            borderRadius: isMobile ? 0 : 3,
+            ...(isMobile && {
+              display: 'flex',
+              flexDirection: 'column',
+              height: '100vh',
+            }),
+          },
         }}
       >
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}
-        >
-          <QuoteIcon
-            sx={{
-              fontSize: { xs: 24, sm: 28 },
-              display: { xs: 'none', sm: 'block' },
-            }}
-          />
-          <Box>
-            <Typography
-              variant={isMobile ? 'h6' : 'h5'}
-              sx={{ fontWeight: 600 }}
-            >
-              {quoteId ? 'Edit Quote' : 'Create Quote'}
-            </Typography>
-            {!isMobile && (
-              <Typography variant="body2" sx={{ opacity: 0.9 }}>
-                {quoteId
-                  ? 'Modify existing quotation details'
-                  : 'Generate professional quotations for your customers'}
-              </Typography>
-            )}
-          </Box>
-        </Box>
-        <IconButton
-          onClick={onClose}
-          size={isMobile ? 'small' : 'medium'}
+        <DialogTitle
           sx={{
+            background: colors.gradients.primary,
             color: 'white',
-            '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            py: { xs: 1.5, sm: 2 },
+            px: { xs: 2, sm: 3 },
+            ...(isMobile && {
+              flexShrink: 0,
+            }),
           }}
         >
-          <CloseIcon fontSize={isMobile ? 'small' : 'medium'} />
-        </IconButton>
-      </DialogTitle>
-
-      <DialogContent
-        sx={{
-          ...(isMobile && {
-            flex: '1 1 auto',
-            overflowY: 'auto',
-            minHeight: 0,
-            p: 0,
-          }),
-        }}
-      >
-        {loading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
-            <CircularProgress />
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: { xs: 1, sm: 2 },
+            }}
+          >
+            <QuoteIcon
+              sx={{
+                fontSize: { xs: 24, sm: 28 },
+                display: { xs: 'none', sm: 'block' },
+              }}
+            />
+            <Box>
+              <Typography
+                variant={isMobile ? 'h6' : 'h5'}
+                sx={{ fontWeight: 600 }}
+              >
+                {quoteId ? 'Edit Quote' : 'Create Quote'}
+              </Typography>
+              {!isMobile && (
+                <Typography variant="body2" sx={{ opacity: 0.9 }}>
+                  {quoteId
+                    ? 'Modify existing quotation details'
+                    : 'Generate professional quotations for your customers'}
+                </Typography>
+              )}
+            </Box>
           </Box>
-        ) : (
-          <QuotationFormContent
-            tires={tires}
-            services={services}
-            quotationForm={quoteForm}
-            setQuotationForm={setQuoteForm}
-            formData={formData}
-            setFormData={setFormData}
-            items={items}
-            setItems={setItems}
-            newItem={newItem}
-            setNewItem={setNewItem}
-            onAddItem={handleAddItem}
-            onRemoveItem={handleRemoveItem}
-            onEditItem={handleEditItem}
-            onCancelEditItem={handleCancelEditItem}
-            editingItemIndex={editingItemIndex}
-            onTireSelect={handleTireSelect}
-            onServicesChange={handleServicesChange}
-          />
-        )}
-      </DialogContent>
+          <IconButton
+            onClick={onClose}
+            size={isMobile ? 'small' : 'medium'}
+            sx={{
+              color: 'white',
+              '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' },
+            }}
+          >
+            <CloseIcon fontSize={isMobile ? 'small' : 'medium'} />
+          </IconButton>
+        </DialogTitle>
 
-      <DialogActions
-        sx={{
-          p: { xs: 2, sm: 3 },
-          background: colors.background.light,
-          borderTop: `1px solid ${colors.neutral[200]}`,
-          gap: 2,
-          ...(isMobile && {
-            flexShrink: 0,
-            backgroundColor: 'white',
-          }),
-        }}
-      >
-        <Button
-          onClick={onClose}
-          startIcon={<CloseIcon />}
-          variant="outlined"
-          fullWidth={isMobile}
+        <DialogContent
           sx={{
-            borderColor: colors.neutral[400],
-            color: colors.text.secondary,
-            '&:hover': {
-              borderColor: colors.neutral[600],
-              background: colors.neutral[50],
-            },
+            ...(isMobile && {
+              flex: '1 1 auto',
+              overflowY: 'auto',
+              minHeight: 0,
+              p: 0,
+            }),
           }}
         >
-          Cancel
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleSaveAndPrint}
-          disabled={loading || saving}
-          fullWidth={isMobile}
-          startIcon={saving ? <CircularProgress size={20} /> : <PrintIcon />}
+          {loading ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+              <CircularProgress />
+            </Box>
+          ) : (
+            <QuotationFormContent
+              tires={tires}
+              services={services}
+              quotationForm={quoteForm}
+              setQuotationForm={setQuoteForm}
+              formData={formData}
+              setFormData={setFormData}
+              items={items}
+              setItems={setItems}
+              newItem={newItem}
+              setNewItem={setNewItem}
+              onAddItem={handleAddItem}
+              onRemoveItem={handleRemoveItem}
+              onUpdateItem={handleUpdateItem}
+              onTireSelect={handleTireSelect}
+              onServicesChange={handleServicesChange}
+            />
+          )}
+        </DialogContent>
+
+        <DialogActions
           sx={{
-            background: colors.primary.main,
-            '&:hover': {
-              background: colors.primary.dark,
-            },
+            p: { xs: 2, sm: 3 },
+            background: colors.background.light,
+            borderTop: `1px solid ${colors.neutral[200]}`,
+            gap: 2,
+            ...(isMobile && {
+              flexShrink: 0,
+              backgroundColor: 'white',
+            }),
           }}
         >
-          {saving
-            ? quoteId
-              ? 'Updating...'
-              : 'Creating...'
-            : quoteId
-            ? isMobile
-              ? 'Update'
-              : 'Update Quote'
-            : isMobile
-            ? 'Create'
-            : 'Create Quote'}
-        </Button>
-      </DialogActions>
-    </Dialog>
+          <Button
+            onClick={onClose}
+            startIcon={<CloseIcon />}
+            variant="outlined"
+            fullWidth={isMobile}
+            sx={{
+              borderColor: colors.neutral[400],
+              color: colors.text.secondary,
+              '&:hover': {
+                borderColor: colors.neutral[600],
+                background: colors.neutral[50],
+              },
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSaveAndPreview}
+            disabled={loading || saving}
+            fullWidth={isMobile}
+            startIcon={saving ? <CircularProgress size={20} /> : <PrintIcon />}
+            sx={{
+              background: colors.primary.main,
+              '&:hover': {
+                background: colors.primary.dark,
+              },
+            }}
+          >
+            {saving
+              ? quoteId
+                ? 'Updating...'
+                : 'Creating...'
+              : quoteId
+              ? isMobile
+                ? 'Update'
+                : 'Update Quote'
+              : isMobile
+              ? 'Create'
+              : 'Create Quote'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Rendered outside the form dialog so it survives the form closing after
+        a successful save. */}
+      <QuotationPrintDialog
+        quote={savedQuote}
+        open={Boolean(savedQuote)}
+        onClose={() => setSavedQuote(null)}
+      />
+    </>
   );
 };
 

--- a/apps/webApp/src/app/components/quotations/QuotationFormContent.tsx
+++ b/apps/webApp/src/app/components/quotations/QuotationFormContent.tsx
@@ -28,6 +28,7 @@ import {
 import {
   Add as AddIcon,
   Delete as DeleteIcon,
+  Edit as EditIcon,
   Person as PersonIcon,
   ShoppingCart as ShoppingCartIcon,
   AttachMoney as AttachMoneyIcon,
@@ -71,6 +72,11 @@ interface QuotationFormContentProps {
   setNewItem: (item: QuotationItem) => void;
   onAddItem: () => void;
   onRemoveItem: (index: number) => void;
+  /** Load an existing line item back into the entry row for editing. */
+  onEditItem: (index: number) => void;
+  onCancelEditItem: () => void;
+  /** Index of the item being edited, or null when adding a new one. */
+  editingItemIndex: number | null;
   onTireSelect: (tireId: string) => void;
   onServicesChange: () => void;
 }
@@ -88,6 +94,9 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
   setNewItem,
   onAddItem,
   onRemoveItem,
+  onEditItem,
+  onCancelEditItem,
+  editingItemIndex,
   onTireSelect,
   onServicesChange,
 }) => {
@@ -421,12 +430,17 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
               />
             </Grid>
 
+            {/* The same entry row both adds and updates: an item being edited
+                is loaded back into these fields, so the tire and service
+                pickers work on edit exactly as they do on add. */}
             <Grid size={{ xs: 12, md: 2 }}>
               <Button
                 variant="contained"
                 fullWidth
                 onClick={onAddItem}
-                startIcon={<AddIcon />}
+                startIcon={
+                  editingItemIndex !== null ? <EditIcon /> : <AddIcon />
+                }
                 disabled={
                   !newItem.description ||
                   !newItem.quantity ||
@@ -443,8 +457,13 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   },
                 }}
               >
-                Add Item
+                {editingItemIndex !== null ? 'Update Item' : 'Add Item'}
               </Button>
+              {editingItemIndex !== null && (
+                <Button fullWidth size="small" onClick={onCancelEditItem}>
+                  Cancel Edit
+                </Button>
+              )}
             </Grid>
           </Grid>
 
@@ -500,7 +519,15 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                           Number(item.quantity) * Number(item.unitPrice)
                         ).toFixed(2)}
                       </TableCell>
-                      <TableCell align="center">
+                      <TableCell align="center" sx={{ whiteSpace: 'nowrap' }}>
+                        <Tooltip title="Edit Item">
+                          <IconButton
+                            size="small"
+                            onClick={() => onEditItem(index)}
+                          >
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
                         <Tooltip title="Remove Item">
                           <IconButton
                             size="small"

--- a/apps/webApp/src/app/components/quotations/QuotationFormContent.tsx
+++ b/apps/webApp/src/app/components/quotations/QuotationFormContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   TextField,
@@ -29,6 +29,8 @@ import {
   Add as AddIcon,
   Delete as DeleteIcon,
   Edit as EditIcon,
+  Check as CheckIcon,
+  Close as CloseIcon,
   Person as PersonIcon,
   ShoppingCart as ShoppingCartIcon,
   AttachMoney as AttachMoneyIcon,
@@ -45,6 +47,43 @@ import type { QuoteItem as QuotationItem } from '../../requests/quotation.reques
 import ServiceSelect from '../services/ServiceSelect';
 import { PhoneInput } from '../common/PhoneInput';
 import { NumberInput } from '../common';
+
+/** The item type as it is stored on a quotation line item. */
+type ItemTypeValue = QuotationItem['itemType'];
+
+/**
+ * The line item types offered in the pickers, in the order they appear. Shared
+ * by the entry row and the in-row editor so both offer exactly the same set.
+ */
+const ITEM_TYPE_OPTIONS: {
+  value: ItemTypeValue;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    value: 'TIRE',
+    label: 'Tire',
+    icon: <span style={{ fontSize: '18px' }}>🛞</span>,
+  },
+  { value: 'SERVICE', label: 'Service', icon: <BuildIcon fontSize="small" /> },
+  { value: 'PART', label: 'Part', icon: <ExtensionIcon fontSize="small" /> },
+  { value: 'OTHER', label: 'Other', icon: <CategoryIcon fontSize="small" /> },
+  {
+    value: 'LEVY',
+    label: 'Levy',
+    icon: <AccountBalanceIcon fontSize="small" />,
+  },
+];
+
+const renderItemTypeOptions = () =>
+  ITEM_TYPE_OPTIONS.map((option) => (
+    <MenuItem key={option.value} value={option.value}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {option.icon}
+        {option.label}
+      </Box>
+    </MenuItem>
+  ));
 
 interface QuotationFormContentProps {
   tires: any[];
@@ -72,11 +111,8 @@ interface QuotationFormContentProps {
   setNewItem: (item: QuotationItem) => void;
   onAddItem: () => void;
   onRemoveItem: (index: number) => void;
-  /** Load an existing line item back into the entry row for editing. */
-  onEditItem: (index: number) => void;
-  onCancelEditItem: () => void;
-  /** Index of the item being edited, or null when adding a new one. */
-  editingItemIndex: number | null;
+  /** Apply an in-row edit. Only the changed fields are passed. */
+  onUpdateItem: (index: number, changes: Partial<QuotationItem>) => void;
   onTireSelect: (tireId: string) => void;
   onServicesChange: () => void;
 }
@@ -94,14 +130,90 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
   setNewItem,
   onAddItem,
   onRemoveItem,
-  onEditItem,
-  onCancelEditItem,
-  editingItemIndex,
+  onUpdateItem,
   onTireSelect,
   onServicesChange,
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  // In-row editing: the row at `inlineEditIndex` swaps its type, description,
+  // qty and price cells for inputs backed by `inlineDraft`. Nothing reaches the
+  // quote — or its totals — until Save.
+  const [inlineEditIndex, setInlineEditIndex] = useState<number | null>(null);
+  const [inlineDraft, setInlineDraft] = useState<{
+    itemType: ItemTypeValue;
+    description: string;
+    quantity: number | '';
+    unitPrice: number | '';
+  } | null>(null);
+
+  const cancelInlineEdit = () => {
+    setInlineEditIndex(null);
+    setInlineDraft(null);
+  };
+
+  const startInlineEdit = (index: number) => {
+    const item = items[index];
+    if (!item) return;
+    setInlineEditIndex(index);
+    setInlineDraft({
+      itemType: item.itemType,
+      description: item.description ?? '',
+      quantity: Number(item.quantity) || 1,
+      unitPrice: Number(item.unitPrice),
+    });
+  };
+
+  const isInlineDraftValid = () =>
+    Boolean(
+      inlineDraft &&
+        inlineDraft.description.trim() &&
+        Number(inlineDraft.quantity) > 0 &&
+        Number(inlineDraft.unitPrice) > 0
+    );
+
+  const saveInlineEdit = () => {
+    if (inlineEditIndex === null || !inlineDraft || !isInlineDraftValid())
+      return;
+    const item = items[inlineEditIndex];
+    if (!item) return;
+
+    const typeChanged = inlineDraft.itemType !== item.itemType;
+
+    onUpdateItem(inlineEditIndex, {
+      itemType: inlineDraft.itemType,
+      description: inlineDraft.description.trim(),
+      quantity: Number(inlineDraft.quantity),
+      unitPrice: Number(inlineDraft.unitPrice),
+      // A line that is no longer a tire (or no longer that service) must not
+      // keep pointing at one — a stale link would quote against the wrong
+      // record.
+      ...(typeChanged
+        ? { tireId: undefined, tireName: undefined, serviceId: undefined }
+        : {}),
+    } as Partial<QuotationItem>);
+    cancelInlineEdit();
+  };
+
+  const handleInlineKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      saveInlineEdit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelInlineEdit();
+    }
+  };
+
+  /**
+   * Removing a row shifts every later index, so an in-progress edit would
+   * silently start pointing at a different item. Drop it.
+   */
+  const handleRemoveItem = (index: number) => {
+    cancelInlineEdit();
+    onRemoveItem(index);
+  };
 
   const handleServiceChange = (
     serviceId: string,
@@ -288,36 +400,7 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   }}
                   label="Type"
                 >
-                  <MenuItem value="TIRE">
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <span style={{ fontSize: '18px' }}>🛞</span>
-                      Tire
-                    </Box>
-                  </MenuItem>
-                  <MenuItem value="SERVICE">
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <BuildIcon fontSize="small" />
-                      Service
-                    </Box>
-                  </MenuItem>
-                  <MenuItem value="PART">
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <ExtensionIcon fontSize="small" />
-                      Part
-                    </Box>
-                  </MenuItem>
-                  <MenuItem value="OTHER">
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <CategoryIcon fontSize="small" />
-                      Other
-                    </Box>
-                  </MenuItem>
-                  <MenuItem value="LEVY">
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <AccountBalanceIcon fontSize="small" />
-                      Levy
-                    </Box>
-                  </MenuItem>
+                  {renderItemTypeOptions()}
                 </Select>
               </FormControl>
             </Grid>
@@ -430,17 +513,12 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
               />
             </Grid>
 
-            {/* The same entry row both adds and updates: an item being edited
-                is loaded back into these fields, so the tire and service
-                pickers work on edit exactly as they do on add. */}
             <Grid size={{ xs: 12, md: 2 }}>
               <Button
                 variant="contained"
                 fullWidth
                 onClick={onAddItem}
-                startIcon={
-                  editingItemIndex !== null ? <EditIcon /> : <AddIcon />
-                }
+                startIcon={<AddIcon />}
                 disabled={
                   !newItem.description ||
                   !newItem.quantity ||
@@ -457,13 +535,8 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   },
                 }}
               >
-                {editingItemIndex !== null ? 'Update Item' : 'Add Item'}
+                Add Item
               </Button>
-              {editingItemIndex !== null && (
-                <Button fullWidth size="small" onClick={onCancelEditItem}>
-                  Cancel Edit
-                </Button>
-              )}
             </Grid>
           </Grid>
 
@@ -481,65 +554,188 @@ const QuotationFormContent: React.FC<QuotationFormContentProps> = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {items.map((item, index) => (
-                    <TableRow key={index}>
-                      <TableCell>
-                        {item.itemType === 'TIRE' && (
-                          <InventoryIcon fontSize="small" sx={{ mr: 0.5 }} />
-                        )}
-                        {item.itemType === 'SERVICE' && (
-                          <BuildIcon fontSize="small" sx={{ mr: 0.5 }} />
-                        )}
-                        {item.itemType.replace('_', ' ')}
-                      </TableCell>
-                      <TableCell>
-                        {(item as any).tireName && (
-                          <Typography variant="body2" fontWeight="medium">
-                            {(item as any).tireName}
-                          </Typography>
-                        )}
-                        <Typography
-                          variant="body2"
-                          color={
-                            (item as any).tireName
-                              ? 'text.secondary'
-                              : 'inherit'
-                          }
-                        >
-                          {item.description}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="center">{item.quantity}</TableCell>
-                      <TableCell align="right">
-                        ${Number(item.unitPrice).toFixed(2)}
-                      </TableCell>
-                      <TableCell align="right">
-                        $
-                        {(
-                          Number(item.quantity) * Number(item.unitPrice)
-                        ).toFixed(2)}
-                      </TableCell>
-                      <TableCell align="center" sx={{ whiteSpace: 'nowrap' }}>
-                        <Tooltip title="Edit Item">
-                          <IconButton
-                            size="small"
-                            onClick={() => onEditItem(index)}
-                          >
-                            <EditIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title="Remove Item">
-                          <IconButton
-                            size="small"
-                            color="error"
-                            onClick={() => onRemoveItem(index)}
-                          >
-                            <DeleteIcon />
-                          </IconButton>
-                        </Tooltip>
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {items.map((item, index) => {
+                    const isRowEditing = inlineEditIndex === index;
+                    const canSaveRow = isRowEditing && isInlineDraftValid();
+
+                    return (
+                      <TableRow
+                        key={index}
+                        sx={
+                          isRowEditing
+                            ? { background: 'rgba(0, 0, 0, 0.03)' }
+                            : undefined
+                        }
+                      >
+                        <TableCell>
+                          {isRowEditing && inlineDraft ? (
+                            <FormControl size="small" sx={{ minWidth: 150 }}>
+                              <Select
+                                value={inlineDraft.itemType}
+                                onChange={(e) =>
+                                  setInlineDraft({
+                                    ...inlineDraft,
+                                    itemType: e.target.value as ItemTypeValue,
+                                  })
+                                }
+                              >
+                                {renderItemTypeOptions()}
+                              </Select>
+                            </FormControl>
+                          ) : (
+                            <>
+                              {item.itemType === 'TIRE' && (
+                                <InventoryIcon
+                                  fontSize="small"
+                                  sx={{ mr: 0.5 }}
+                                />
+                              )}
+                              {item.itemType === 'SERVICE' && (
+                                <BuildIcon fontSize="small" sx={{ mr: 0.5 }} />
+                              )}
+                              {item.itemType.replace('_', ' ')}
+                            </>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {(item as any).tireName && (
+                            <Typography variant="body2" fontWeight="medium">
+                              {(item as any).tireName}
+                            </Typography>
+                          )}
+                          {isRowEditing && inlineDraft ? (
+                            <TextField
+                              fullWidth
+                              size="small"
+                              autoFocus
+                              value={inlineDraft.description}
+                              onChange={(e) =>
+                                setInlineDraft({
+                                  ...inlineDraft,
+                                  description: e.target.value,
+                                })
+                              }
+                              onKeyDown={handleInlineKeyDown}
+                            />
+                          ) : (
+                            <Typography
+                              variant="body2"
+                              color={
+                                (item as any).tireName
+                                  ? 'text.secondary'
+                                  : 'inherit'
+                              }
+                            >
+                              {item.description}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell align="center">
+                          {isRowEditing && inlineDraft ? (
+                            <NumberInput
+                              size="small"
+                              allowDecimals
+                              decimalPlaces={2}
+                              value={inlineDraft.quantity}
+                              onChange={(v) =>
+                                setInlineDraft({
+                                  ...inlineDraft,
+                                  quantity: v ?? '',
+                                })
+                              }
+                              onKeyDown={handleInlineKeyDown}
+                              min={0}
+                              sx={{ width: 90 }}
+                            />
+                          ) : (
+                            item.quantity
+                          )}
+                        </TableCell>
+                        <TableCell align="right">
+                          {isRowEditing && inlineDraft ? (
+                            <NumberInput
+                              size="small"
+                              allowDecimals
+                              value={inlineDraft.unitPrice}
+                              onChange={(v) =>
+                                setInlineDraft({
+                                  ...inlineDraft,
+                                  unitPrice: v ?? '',
+                                })
+                              }
+                              onKeyDown={handleInlineKeyDown}
+                              min={0}
+                              InputProps={{
+                                startAdornment: (
+                                  <InputAdornment position="start">
+                                    $
+                                  </InputAdornment>
+                                ),
+                              }}
+                              sx={{ width: 140 }}
+                            />
+                          ) : (
+                            `$${Number(item.unitPrice).toFixed(2)}`
+                          )}
+                        </TableCell>
+                        <TableCell align="right">
+                          $
+                          {(isRowEditing && inlineDraft
+                            ? Number(inlineDraft.quantity || 0) *
+                              Number(inlineDraft.unitPrice || 0)
+                            : Number(item.quantity) * Number(item.unitPrice)
+                          ).toFixed(2)}
+                        </TableCell>
+                        <TableCell align="center" sx={{ whiteSpace: 'nowrap' }}>
+                          {isRowEditing ? (
+                            <>
+                              {/* span keeps the tooltip alive while the button
+                                  is disabled */}
+                              <Tooltip title="Save changes">
+                                <span>
+                                  <IconButton
+                                    size="small"
+                                    onClick={saveInlineEdit}
+                                    disabled={!canSaveRow}
+                                  >
+                                    <CheckIcon fontSize="small" />
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
+                              <Tooltip title="Cancel">
+                                <IconButton
+                                  size="small"
+                                  onClick={cancelInlineEdit}
+                                >
+                                  <CloseIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                            </>
+                          ) : (
+                            <>
+                              <Tooltip title="Edit Item">
+                                <IconButton
+                                  size="small"
+                                  onClick={() => startInlineEdit(index)}
+                                >
+                                  <EditIcon fontSize="small" />
+                                </IconButton>
+                              </Tooltip>
+                              <Tooltip title="Remove Item">
+                                <IconButton
+                                  size="small"
+                                  color="error"
+                                  onClick={() => handleRemoveItem(index)}
+                                >
+                                  <DeleteIcon />
+                                </IconButton>
+                              </Tooltip>
+                            </>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
             </TableContainer>

--- a/apps/webApp/src/app/components/quotations/QuotationPrintDialog.tsx
+++ b/apps/webApp/src/app/components/quotations/QuotationPrintDialog.tsx
@@ -1,0 +1,118 @@
+import React, { useRef } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import { Close as CloseIcon, Print as PrintIcon } from '@mui/icons-material';
+import { quotationService, Quote } from '../../requests/quotation.requests';
+import { colors } from '../../theme/colors';
+
+interface QuotationPrintDialogProps {
+  quote: Quote | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Shows the printable quotation without leaving the app.
+ *
+ * The document is the same HTML the printer gets — rendered into an iframe
+ * rather than a popup window, so saving a quote keeps the user on the page they
+ * were working on instead of dropping them into a new browser tab. Printing
+ * targets the frame, so what is on screen is exactly what comes out.
+ */
+export const QuotationPrintDialog: React.FC<QuotationPrintDialogProps> = ({
+  quote,
+  open,
+  onClose,
+}) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const frameRef = useRef<HTMLIFrameElement>(null);
+
+  const handlePrint = () => {
+    const frame = frameRef.current;
+    if (!frame?.contentWindow) return;
+    frame.contentWindow.focus();
+    frame.contentWindow.print();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      fullScreen={isMobile}
+    >
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+        }}
+      >
+        <Box>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            Quotation {quote?.quotationNumber ?? ''}
+          </Typography>
+          {quote?.customerName && (
+            <Typography variant="body2" color="text.secondary">
+              {quote.customerName}
+            </Typography>
+          )}
+        </Box>
+        <IconButton onClick={onClose} size="small" aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers sx={{ p: 0, background: colors.neutral[100] }}>
+        {quote && (
+          <iframe
+            ref={frameRef}
+            title={`Quotation ${quote.quotationNumber ?? ''}`}
+            srcDoc={quotationService.generatePrintHTML(quote)}
+            style={{
+              width: '100%',
+              height: isMobile ? '100%' : '70vh',
+              minHeight: 400,
+              border: 'none',
+              background: 'white',
+            }}
+          />
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ p: 2, gap: 1 }}>
+        <Button onClick={onClose} fullWidth={isMobile}>
+          Close
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<PrintIcon />}
+          onClick={handlePrint}
+          disabled={!quote}
+          fullWidth={isMobile}
+          sx={{
+            background: colors.primary.main,
+            '&:hover': { background: colors.primary.dark },
+          }}
+        >
+          Print
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default QuotationPrintDialog;

--- a/apps/webApp/src/app/layouts/AccountantLayout.tsx
+++ b/apps/webApp/src/app/layouts/AccountantLayout.tsx
@@ -17,11 +17,13 @@ import {
   Divider,
   Chip,
   Tooltip,
-  Collapse
+  Collapse,
 } from '@mui/material';
 import {
   Dashboard,
   Receipt,
+  ReceiptLong,
+  AccessTime,
   Assessment,
   Analytics,
   Logout,
@@ -33,7 +35,7 @@ import {
   ExpandMore,
   ExpandLess,
   BarChart,
-  AccountBalance
+  AccountBalance,
 } from '@mui/icons-material';
 import { useAuth } from '../hooks/useAuth';
 import { colors } from '../theme/colors';
@@ -45,7 +47,9 @@ const drawerCollapsedWidth = 72;
 export function AccountantLayout() {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [drawerCollapsed, setDrawerCollapsed] = React.useState(false);
-  const [expandedSections, setExpandedSections] = React.useState<Record<string, boolean>>({
+  const [expandedSections, setExpandedSections] = React.useState<
+    Record<string, boolean>
+  >({
     financial: true,
     reports: true,
   });
@@ -67,9 +71,9 @@ export function AccountantLayout() {
   };
 
   const handleSectionToggle = (section: string) => {
-    setExpandedSections(prev => ({
+    setExpandedSections((prev) => ({
       ...prev,
-      [section]: !prev[section]
+      [section]: !prev[section],
     }));
   };
 
@@ -77,8 +81,12 @@ export function AccountantLayout() {
     {
       title: 'Overview',
       items: [
-        { text: 'Dashboard', icon: <Dashboard />, path: '/accountant/dashboard' },
-      ]
+        {
+          text: 'Dashboard',
+          icon: <Dashboard />,
+          path: '/accountant/dashboard',
+        },
+      ],
     },
     {
       id: 'financial',
@@ -86,35 +94,79 @@ export function AccountantLayout() {
       icon: <AccountBalance />,
       items: [
         { text: 'Invoices', icon: <Receipt />, path: '/accountant/invoices' },
-        { text: 'Cash Report', icon: <Assessment />, path: '/accountant/cash-report' },
-        { text: 'Purchase & Expense', icon: <ShoppingCart />, path: '/accountant/purchase-invoices' },
-      ]
+        {
+          text: 'Cash Report',
+          icon: <Assessment />,
+          path: '/accountant/cash-report',
+        },
+        {
+          text: 'Purchase & Expense',
+          icon: <ShoppingCart />,
+          path: '/accountant/purchase-invoices',
+        },
+      ],
+    },
+    {
+      id: 'payroll',
+      title: 'Payroll',
+      icon: <ReceiptLong />,
+      items: [
+        {
+          text: 'Employee Hours',
+          icon: <AccessTime />,
+          path: '/accountant/employee-hours',
+        },
+        {
+          text: 'Pay Stubs',
+          icon: <ReceiptLong />,
+          path: '/accountant/pay-stubs',
+        },
+      ],
     },
     {
       id: 'reports',
       title: 'Reports',
       icon: <BarChart />,
       items: [
-        { text: 'Tax Report', icon: <Analytics />, path: '/accountant/reports' },
-        { text: 'Analytics', icon: <Analytics />, path: '/accountant/analytics' },
-      ]
+        {
+          text: 'Tax Report',
+          icon: <Analytics />,
+          path: '/accountant/reports',
+        },
+        {
+          text: 'Analytics',
+          icon: <Analytics />,
+          path: '/accountant/analytics',
+        },
+      ],
     },
   ];
 
   const isActive = (path: string) => {
-    return location.pathname === path || location.pathname.startsWith(path + '/');
+    return (
+      location.pathname === path || location.pathname.startsWith(path + '/')
+    );
   };
 
   const drawer = (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'white' }}>
-      <Toolbar sx={{
-        py: 2,
-        px: drawerCollapsed ? 1 : 2,
-        background: colors.primary.main,
-        borderBottom: `1px solid ${colors.neutral[200]}`,
-        justifyContent: drawerCollapsed ? 'center' : 'flex-start',
-        minHeight: 80,
-      }}>
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'white',
+      }}
+    >
+      <Toolbar
+        sx={{
+          py: 2,
+          px: drawerCollapsed ? 1 : 2,
+          background: colors.primary.main,
+          borderBottom: `1px solid ${colors.neutral[200]}`,
+          justifyContent: drawerCollapsed ? 'center' : 'flex-start',
+          minHeight: 80,
+        }}
+      >
         <Box
           component={Link}
           to="/accountant/dashboard"
@@ -159,10 +211,25 @@ export function AccountantLayout() {
           </Box>
           {!drawerCollapsed && (
             <Box sx={{ whiteSpace: 'nowrap' }}>
-              <Typography variant="h6" sx={{ color: 'white', fontWeight: 700, lineHeight: 1, whiteSpace: 'nowrap' }}>
+              <Typography
+                variant="h6"
+                sx={{
+                  color: 'white',
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 GT Automotives
               </Typography>
-              <Typography variant="caption" sx={{ color: colors.neutral[100], fontWeight: 500, whiteSpace: 'nowrap' }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: colors.neutral[100],
+                  fontWeight: 500,
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 16472991 Canada INC.
               </Typography>
             </Box>
@@ -171,7 +238,14 @@ export function AccountantLayout() {
       </Toolbar>
 
       {/* Collapse Toggle Button - Only on Desktop */}
-      <Box sx={{ display: { xs: 'none', md: 'flex' }, justifyContent: drawerCollapsed ? 'center' : 'flex-end', px: 1, py: 0.5 }}>
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          justifyContent: drawerCollapsed ? 'center' : 'flex-end',
+          px: 1,
+          py: 0.5,
+        }}
+      >
         <IconButton
           onClick={handleDrawerCollapse}
           size="small"
@@ -187,7 +261,14 @@ export function AccountantLayout() {
         </IconButton>
       </Box>
 
-      <List sx={{ flex: 1, py: 1, px: drawerCollapsed ? 0.5 : 1, overflowY: 'auto' }}>
+      <List
+        sx={{
+          flex: 1,
+          py: 1,
+          px: drawerCollapsed ? 0.5 : 1,
+          overflowY: 'auto',
+        }}
+      >
         {menuSections.map((section, sectionIndex) => (
           <React.Fragment key={section.title}>
             {/* Section without expand (Overview) */}
@@ -204,20 +285,30 @@ export function AccountantLayout() {
                         mx: 0.5,
                         mb: 0.5,
                         transition: 'all 0.2s',
-                        backgroundColor: active ? colors.primary.lighter + '20' : 'transparent',
-                        borderLeft: active ? `3px solid ${colors.primary.main}` : '3px solid transparent',
-                        justifyContent: drawerCollapsed ? 'center' : 'flex-start',
+                        backgroundColor: active
+                          ? colors.primary.lighter + '20'
+                          : 'transparent',
+                        borderLeft: active
+                          ? `3px solid ${colors.primary.main}`
+                          : '3px solid transparent',
+                        justifyContent: drawerCollapsed
+                          ? 'center'
+                          : 'flex-start',
                         px: drawerCollapsed ? 0 : 2,
                         '&:hover': {
                           backgroundColor: colors.neutral[100],
                         },
                       }}
                     >
-                      <ListItemIcon sx={{
-                        color: active ? colors.primary.main : colors.neutral[600],
-                        minWidth: drawerCollapsed ? 0 : 40,
-                        justifyContent: 'center',
-                      }}>
+                      <ListItemIcon
+                        sx={{
+                          color: active
+                            ? colors.primary.main
+                            : colors.neutral[600],
+                          minWidth: drawerCollapsed ? 0 : 40,
+                          justifyContent: 'center',
+                        }}
+                      >
                         {item.icon}
                       </ListItemIcon>
                       {!drawerCollapsed && (
@@ -226,7 +317,9 @@ export function AccountantLayout() {
                           primaryTypographyProps={{
                             fontSize: '0.95rem',
                             fontWeight: active ? 600 : 400,
-                            color: active ? colors.primary.main : colors.text.primary,
+                            color: active
+                              ? colors.primary.main
+                              : colors.text.primary,
                           }}
                         />
                       )}
@@ -245,7 +338,13 @@ export function AccountantLayout() {
                     </ListItem>
                   );
                 })}
-                <Divider sx={{ my: 1.5, mx: drawerCollapsed ? 1 : 0, borderColor: colors.neutral[200] }} />
+                <Divider
+                  sx={{
+                    my: 1.5,
+                    mx: drawerCollapsed ? 1 : 0,
+                    borderColor: colors.neutral[200],
+                  }}
+                />
               </>
             )}
 
@@ -268,11 +367,13 @@ export function AccountantLayout() {
                         },
                       }}
                     >
-                      <ListItemIcon sx={{
-                        color: colors.neutral[700],
-                        minWidth: 0,
-                        justifyContent: 'center',
-                      }}>
+                      <ListItemIcon
+                        sx={{
+                          color: colors.neutral[700],
+                          minWidth: 0,
+                          justifyContent: 'center',
+                        }}
+                      >
                         {section.icon}
                       </ListItemIcon>
                     </ListItemButton>
@@ -294,10 +395,12 @@ export function AccountantLayout() {
                       },
                     }}
                   >
-                    <ListItemIcon sx={{
-                      color: colors.primary.main,
-                      minWidth: 40,
-                    }}>
+                    <ListItemIcon
+                      sx={{
+                        color: colors.primary.main,
+                        minWidth: 40,
+                      }}
+                    >
                       {section.icon}
                     </ListItemIcon>
                     <ListItemText
@@ -311,15 +414,23 @@ export function AccountantLayout() {
                       }}
                     />
                     {expandedSections[section.id] ? (
-                      <ExpandLess sx={{ color: colors.primary.main, fontSize: '1.2rem' }} />
+                      <ExpandLess
+                        sx={{ color: colors.primary.main, fontSize: '1.2rem' }}
+                      />
                     ) : (
-                      <ExpandMore sx={{ color: colors.primary.main, fontSize: '1.2rem' }} />
+                      <ExpandMore
+                        sx={{ color: colors.primary.main, fontSize: '1.2rem' }}
+                      />
                     )}
                   </ListItemButton>
                 )}
 
                 {/* Section items - always show when collapsed, conditionally when expanded */}
-                <Collapse in={drawerCollapsed || expandedSections[section.id]} timeout="auto" unmountOnExit>
+                <Collapse
+                  in={drawerCollapsed || expandedSections[section.id]}
+                  timeout="auto"
+                  unmountOnExit
+                >
                   <List component="div" disablePadding>
                     {section.items.map((item) => {
                       const active = isActive(item.path);
@@ -333,19 +444,29 @@ export function AccountantLayout() {
                             mb: 0.5,
                             pl: drawerCollapsed ? 0 : 4,
                             transition: 'all 0.2s',
-                            backgroundColor: active ? colors.primary.lighter + '20' : 'transparent',
-                            borderLeft: active ? `3px solid ${colors.primary.main}` : '3px solid transparent',
-                            justifyContent: drawerCollapsed ? 'center' : 'flex-start',
+                            backgroundColor: active
+                              ? colors.primary.lighter + '20'
+                              : 'transparent',
+                            borderLeft: active
+                              ? `3px solid ${colors.primary.main}`
+                              : '3px solid transparent',
+                            justifyContent: drawerCollapsed
+                              ? 'center'
+                              : 'flex-start',
                             '&:hover': {
                               backgroundColor: colors.neutral[100],
                             },
                           }}
                         >
-                          <ListItemIcon sx={{
-                            color: active ? colors.primary.main : colors.neutral[600],
-                            minWidth: drawerCollapsed ? 0 : 40,
-                            justifyContent: 'center',
-                          }}>
+                          <ListItemIcon
+                            sx={{
+                              color: active
+                                ? colors.primary.main
+                                : colors.neutral[600],
+                              minWidth: drawerCollapsed ? 0 : 40,
+                              justifyContent: 'center',
+                            }}
+                          >
                             {item.icon}
                           </ListItemIcon>
                           {!drawerCollapsed && (
@@ -354,7 +475,9 @@ export function AccountantLayout() {
                               primaryTypographyProps={{
                                 fontSize: '0.9rem',
                                 fontWeight: active ? 600 : 400,
-                                color: active ? colors.primary.main : colors.text.primary,
+                                color: active
+                                  ? colors.primary.main
+                                  : colors.text.primary,
                               }}
                             />
                           )}
@@ -377,7 +500,13 @@ export function AccountantLayout() {
                 </Collapse>
 
                 {sectionIndex < menuSections.length - 1 && (
-                  <Divider sx={{ my: 1.5, mx: drawerCollapsed ? 1 : 0, borderColor: colors.neutral[200] }} />
+                  <Divider
+                    sx={{
+                      my: 1.5,
+                      mx: drawerCollapsed ? 1 : 0,
+                      borderColor: colors.neutral[200],
+                    }}
+                  />
                 )}
               </>
             )}
@@ -432,7 +561,10 @@ export function AccountantLayout() {
       <Box
         component="nav"
         sx={{
-          width: { sm: drawerCollapsed ? drawerCollapsedWidth : drawerWidth, md: drawerCollapsed ? drawerCollapsedWidth : drawerWidth },
+          width: {
+            sm: drawerCollapsed ? drawerCollapsedWidth : drawerWidth,
+            md: drawerCollapsed ? drawerCollapsedWidth : drawerWidth,
+          },
           flexShrink: { sm: 0 },
           transition: 'width 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
         }}
@@ -482,10 +614,15 @@ export function AccountantLayout() {
           flexGrow: 1,
           display: 'flex',
           flexDirection: 'column',
-          width: { md: `calc(100% - ${drawerCollapsed ? drawerCollapsedWidth : drawerWidth}px)` },
+          width: {
+            md: `calc(100% - ${
+              drawerCollapsed ? drawerCollapsedWidth : drawerWidth
+            }px)`,
+          },
           height: '100vh',
           overflow: 'hidden',
-          transition: 'width 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms, margin 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
+          transition:
+            'width 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms, margin 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
         }}
       >
         <AppBar

--- a/apps/webApp/src/app/layouts/AdminLayout.tsx
+++ b/apps/webApp/src/app/layouts/AdminLayout.tsx
@@ -196,6 +196,12 @@ export function AdminLayout() {
           path: '/admin/tire-commissions',
         },
         { text: 'Payroll', icon: <AttachMoney />, path: '/admin/payroll' },
+        {
+          text: 'Employee Hours',
+          icon: <AccessTime />,
+          path: '/admin/employee-hours',
+        },
+        { text: 'Pay Stubs', icon: <Receipt />, path: '/admin/pay-stubs' },
         { text: 'Payments', icon: <Payment />, path: '/admin/payments' },
         {
           text: 'Payout Rules',

--- a/apps/webApp/src/app/layouts/StaffLayout.tsx
+++ b/apps/webApp/src/app/layouts/StaffLayout.tsx
@@ -17,13 +17,14 @@ import {
   Divider,
   Chip,
   Tooltip,
-  Collapse
+  Collapse,
 } from '@mui/material';
 import {
   Dashboard,
   People,
   Inventory,
   Receipt,
+  ReceiptLong,
   CalendarMonth,
   Assessment,
   Settings,
@@ -58,7 +59,9 @@ const drawerCollapsedWidth = 72;
 export function StaffLayout() {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const [drawerCollapsed, setDrawerCollapsed] = React.useState(false);
-  const [expandedSections, setExpandedSections] = React.useState<Record<string, boolean>>({
+  const [expandedSections, setExpandedSections] = React.useState<
+    Record<string, boolean>
+  >({
     work: true,
     business: true,
     scheduling: true,
@@ -86,9 +89,9 @@ export function StaffLayout() {
   };
 
   const handleSectionToggle = (section: string) => {
-    setExpandedSections(prev => ({
+    setExpandedSections((prev) => ({
       ...prev,
-      [section]: !prev[section]
+      [section]: !prev[section],
     }));
   };
 
@@ -97,7 +100,7 @@ export function StaffLayout() {
       title: 'Overview',
       items: [
         { text: 'Dashboard', icon: <Dashboard />, path: '/staff/dashboard' },
-      ]
+      ],
     },
     {
       id: 'work',
@@ -107,9 +110,18 @@ export function StaffLayout() {
         { text: 'My Jobs', icon: <Work />, path: '/staff/jobs' },
         { text: 'Time Clock', icon: <AccessTime />, path: '/staff/time-clock' },
         { text: 'My Earnings', icon: <AttachMoney />, path: '/staff/earnings' },
-        { text: 'My Commission', icon: <TireRepair />, path: '/staff/commission' },
+        {
+          text: 'My Pay Stubs',
+          icon: <ReceiptLong />,
+          path: '/staff/pay-stubs',
+        },
+        {
+          text: 'My Commission',
+          icon: <TireRepair />,
+          path: '/staff/commission',
+        },
         { text: 'Reports', icon: <Assessment />, path: '/staff/reports' },
-      ]
+      ],
     },
     {
       id: 'business',
@@ -118,52 +130,92 @@ export function StaffLayout() {
       items: [
         { text: 'Customers', icon: <People />, path: '/staff/customers' },
         { text: 'Vehicles', icon: <DirectionsCar />, path: '/staff/vehicles' },
-        { text: 'Inspections', icon: <AssignmentTurnedIn />, path: '/staff/inspections' },
-        { text: 'Repair Orders', icon: <CarRepair />, path: '/staff/repair-orders' },
+        {
+          text: 'Inspections',
+          icon: <AssignmentTurnedIn />,
+          path: '/staff/inspections',
+        },
+        {
+          text: 'Repair Orders',
+          icon: <CarRepair />,
+          path: '/staff/repair-orders',
+        },
         { text: 'Inventory', icon: <Inventory />, path: '/staff/inventory' },
         { text: 'Invoices', icon: <Receipt />, path: '/staff/invoices' },
-        { text: 'Quotations', icon: <Description />, path: '/staff/quotations' },
-      ]
+        {
+          text: 'Quotations',
+          icon: <Description />,
+          path: '/staff/quotations',
+        },
+      ],
     },
     {
       id: 'scheduling',
       title: 'Scheduling',
       icon: <Event />,
       items: [
-        { text: 'Appointments', icon: <CalendarMonth />, path: '/staff/appointments' },
-        { text: 'My Availability', icon: <EventAvailable />, path: '/staff/availability' },
-      ]
+        {
+          text: 'Appointments',
+          icon: <CalendarMonth />,
+          path: '/staff/appointments',
+        },
+        {
+          text: 'My Availability',
+          icon: <EventAvailable />,
+          path: '/staff/availability',
+        },
+      ],
     },
     {
       title: 'System',
       items: [
         { text: 'Settings', icon: <Settings />, path: '/staff/settings' },
-      ]
+      ],
     },
     {
       title: 'Quick Links',
-      items: [
-        { text: 'Pricing', icon: <LocalOffer />, path: '/pricing' },
-      ]
+      items: [{ text: 'Pricing', icon: <LocalOffer />, path: '/pricing' }],
     },
   ];
 
   const isActive = (path: string) => {
-    return location.pathname === path || location.pathname.startsWith(path + '/');
+    return (
+      location.pathname === path || location.pathname.startsWith(path + '/')
+    );
   };
 
   const drawer = (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', background: 'white' }}>
-      <Toolbar sx={{
-        py: 2,
-        px: drawerCollapsed ? 1 : 2,
-        background: colors.primary.main,
-        borderBottom: `1px solid ${colors.neutral[200]}`,
-        justifyContent: drawerCollapsed ? 'center' : 'flex-start',
-        minHeight: 80,
-      }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: drawerCollapsed ? 0 : 1.5, width: '100%', justifyContent: drawerCollapsed ? 'center' : 'flex-start' }}>
-          <Link to="/staff/dashboard" style={{ textDecoration: 'none', display: 'flex' }}>
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'white',
+      }}
+    >
+      <Toolbar
+        sx={{
+          py: 2,
+          px: drawerCollapsed ? 1 : 2,
+          background: colors.primary.main,
+          borderBottom: `1px solid ${colors.neutral[200]}`,
+          justifyContent: drawerCollapsed ? 'center' : 'flex-start',
+          minHeight: 80,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: drawerCollapsed ? 0 : 1.5,
+            width: '100%',
+            justifyContent: drawerCollapsed ? 'center' : 'flex-start',
+          }}
+        >
+          <Link
+            to="/staff/dashboard"
+            style={{ textDecoration: 'none', display: 'flex' }}
+          >
             <Box
               sx={{
                 width: 42,
@@ -181,7 +233,7 @@ export function StaffLayout() {
                 cursor: 'pointer',
                 '&:hover': {
                   transform: 'scale(1.05)',
-                }
+                },
               }}
             >
               <img
@@ -197,10 +249,25 @@ export function StaffLayout() {
           </Link>
           {!drawerCollapsed && (
             <Box sx={{ whiteSpace: 'nowrap' }}>
-              <Typography variant="h6" sx={{ color: 'white', fontWeight: 700, lineHeight: 1, whiteSpace: 'nowrap' }}>
+              <Typography
+                variant="h6"
+                sx={{
+                  color: 'white',
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 GT Automotives
               </Typography>
-              <Typography variant="caption" sx={{ color: colors.neutral[100], fontWeight: 500, whiteSpace: 'nowrap' }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: colors.neutral[100],
+                  fontWeight: 500,
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 16472991 Canada INC.
               </Typography>
             </Box>
@@ -209,7 +276,14 @@ export function StaffLayout() {
       </Toolbar>
 
       {/* Collapse Toggle Button - Only on Desktop */}
-      <Box sx={{ display: { xs: 'none', md: 'flex' }, justifyContent: drawerCollapsed ? 'center' : 'flex-end', px: 1, py: 0.5 }}>
+      <Box
+        sx={{
+          display: { xs: 'none', md: 'flex' },
+          justifyContent: drawerCollapsed ? 'center' : 'flex-end',
+          px: 1,
+          py: 0.5,
+        }}
+      >
         <IconButton
           onClick={handleDrawerCollapse}
           size="small"
@@ -225,7 +299,14 @@ export function StaffLayout() {
         </IconButton>
       </Box>
 
-      <List sx={{ flex: 1, py: 1, px: drawerCollapsed ? 0.5 : 1, overflowY: 'auto' }}>
+      <List
+        sx={{
+          flex: 1,
+          py: 1,
+          px: drawerCollapsed ? 0.5 : 1,
+          overflowY: 'auto',
+        }}
+      >
         {menuSections.map((section, sectionIndex) => (
           <React.Fragment key={section.title}>
             {/* Section without expand (Overview/System) */}
@@ -242,20 +323,30 @@ export function StaffLayout() {
                         mx: 0.5,
                         mb: 0.5,
                         transition: 'all 0.2s',
-                        backgroundColor: active ? colors.primary.lighter + '20' : 'transparent',
-                        borderLeft: active ? `3px solid ${colors.primary.main}` : '3px solid transparent',
-                        justifyContent: drawerCollapsed ? 'center' : 'flex-start',
+                        backgroundColor: active
+                          ? colors.primary.lighter + '20'
+                          : 'transparent',
+                        borderLeft: active
+                          ? `3px solid ${colors.primary.main}`
+                          : '3px solid transparent',
+                        justifyContent: drawerCollapsed
+                          ? 'center'
+                          : 'flex-start',
                         px: drawerCollapsed ? 0 : 2,
                         '&:hover': {
                           backgroundColor: colors.neutral[100],
                         },
                       }}
                     >
-                      <ListItemIcon sx={{
-                        color: active ? colors.primary.main : colors.neutral[600],
-                        minWidth: drawerCollapsed ? 0 : 40,
-                        justifyContent: 'center',
-                      }}>
+                      <ListItemIcon
+                        sx={{
+                          color: active
+                            ? colors.primary.main
+                            : colors.neutral[600],
+                          minWidth: drawerCollapsed ? 0 : 40,
+                          justifyContent: 'center',
+                        }}
+                      >
                         {item.icon}
                       </ListItemIcon>
                       {!drawerCollapsed && (
@@ -264,7 +355,9 @@ export function StaffLayout() {
                           primaryTypographyProps={{
                             fontSize: '0.95rem',
                             fontWeight: active ? 600 : 400,
-                            color: active ? colors.primary.main : colors.text.primary,
+                            color: active
+                              ? colors.primary.main
+                              : colors.text.primary,
                           }}
                         />
                       )}
@@ -283,7 +376,13 @@ export function StaffLayout() {
                     </ListItem>
                   );
                 })}
-                <Divider sx={{ my: 1.5, mx: drawerCollapsed ? 1 : 0, borderColor: colors.neutral[200] }} />
+                <Divider
+                  sx={{
+                    my: 1.5,
+                    mx: drawerCollapsed ? 1 : 0,
+                    borderColor: colors.neutral[200],
+                  }}
+                />
               </>
             )}
 
@@ -306,11 +405,13 @@ export function StaffLayout() {
                         },
                       }}
                     >
-                      <ListItemIcon sx={{
-                        color: colors.neutral[700],
-                        minWidth: 0,
-                        justifyContent: 'center',
-                      }}>
+                      <ListItemIcon
+                        sx={{
+                          color: colors.neutral[700],
+                          minWidth: 0,
+                          justifyContent: 'center',
+                        }}
+                      >
                         {section.icon}
                       </ListItemIcon>
                     </ListItemButton>
@@ -332,10 +433,12 @@ export function StaffLayout() {
                       },
                     }}
                   >
-                    <ListItemIcon sx={{
-                      color: colors.primary.main,
-                      minWidth: 40,
-                    }}>
+                    <ListItemIcon
+                      sx={{
+                        color: colors.primary.main,
+                        minWidth: 40,
+                      }}
+                    >
                       {section.icon}
                     </ListItemIcon>
                     <ListItemText
@@ -349,15 +452,23 @@ export function StaffLayout() {
                       }}
                     />
                     {expandedSections[section.id] ? (
-                      <ExpandLess sx={{ color: colors.primary.main, fontSize: '1.2rem' }} />
+                      <ExpandLess
+                        sx={{ color: colors.primary.main, fontSize: '1.2rem' }}
+                      />
                     ) : (
-                      <ExpandMore sx={{ color: colors.primary.main, fontSize: '1.2rem' }} />
+                      <ExpandMore
+                        sx={{ color: colors.primary.main, fontSize: '1.2rem' }}
+                      />
                     )}
                   </ListItemButton>
                 )}
 
                 {/* Section items - always show when collapsed, conditionally when expanded */}
-                <Collapse in={drawerCollapsed || expandedSections[section.id]} timeout="auto" unmountOnExit>
+                <Collapse
+                  in={drawerCollapsed || expandedSections[section.id]}
+                  timeout="auto"
+                  unmountOnExit
+                >
                   <List component="div" disablePadding>
                     {section.items.map((item) => {
                       const active = isActive(item.path);
@@ -371,19 +482,29 @@ export function StaffLayout() {
                             mb: 0.5,
                             pl: drawerCollapsed ? 0 : 4,
                             transition: 'all 0.2s',
-                            backgroundColor: active ? colors.primary.lighter + '20' : 'transparent',
-                            borderLeft: active ? `3px solid ${colors.primary.main}` : '3px solid transparent',
-                            justifyContent: drawerCollapsed ? 'center' : 'flex-start',
+                            backgroundColor: active
+                              ? colors.primary.lighter + '20'
+                              : 'transparent',
+                            borderLeft: active
+                              ? `3px solid ${colors.primary.main}`
+                              : '3px solid transparent',
+                            justifyContent: drawerCollapsed
+                              ? 'center'
+                              : 'flex-start',
                             '&:hover': {
                               backgroundColor: colors.neutral[100],
                             },
                           }}
                         >
-                          <ListItemIcon sx={{
-                            color: active ? colors.primary.main : colors.neutral[600],
-                            minWidth: drawerCollapsed ? 0 : 40,
-                            justifyContent: 'center',
-                          }}>
+                          <ListItemIcon
+                            sx={{
+                              color: active
+                                ? colors.primary.main
+                                : colors.neutral[600],
+                              minWidth: drawerCollapsed ? 0 : 40,
+                              justifyContent: 'center',
+                            }}
+                          >
                             {item.icon}
                           </ListItemIcon>
                           {!drawerCollapsed && (
@@ -392,7 +513,9 @@ export function StaffLayout() {
                               primaryTypographyProps={{
                                 fontSize: '0.9rem',
                                 fontWeight: active ? 600 : 400,
-                                color: active ? colors.primary.main : colors.text.primary,
+                                color: active
+                                  ? colors.primary.main
+                                  : colors.text.primary,
                               }}
                             />
                           )}
@@ -415,7 +538,13 @@ export function StaffLayout() {
                 </Collapse>
 
                 {sectionIndex < menuSections.length - 1 && (
-                  <Divider sx={{ my: 1.5, mx: drawerCollapsed ? 1 : 0, borderColor: colors.neutral[200] }} />
+                  <Divider
+                    sx={{
+                      my: 1.5,
+                      mx: drawerCollapsed ? 1 : 0,
+                      borderColor: colors.neutral[200],
+                    }}
+                  />
                 )}
               </>
             )}
@@ -470,7 +599,10 @@ export function StaffLayout() {
       <Box
         component="nav"
         sx={{
-          width: { sm: drawerCollapsed ? drawerCollapsedWidth : drawerWidth, md: drawerCollapsed ? drawerCollapsedWidth : drawerWidth },
+          width: {
+            sm: drawerCollapsed ? drawerCollapsedWidth : drawerWidth,
+            md: drawerCollapsed ? drawerCollapsedWidth : drawerWidth,
+          },
           flexShrink: { sm: 0 },
           transition: 'width 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
         }}
@@ -520,10 +652,15 @@ export function StaffLayout() {
           flexGrow: 1,
           display: 'flex',
           flexDirection: 'column',
-          width: { md: `calc(100% - ${drawerCollapsed ? drawerCollapsedWidth : drawerWidth}px)` },
+          width: {
+            md: `calc(100% - ${
+              drawerCollapsed ? drawerCollapsedWidth : drawerWidth
+            }px)`,
+          },
           height: '100vh',
           overflow: 'hidden',
-          transition: 'width 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms, margin 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
+          transition:
+            'width 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms, margin 225ms cubic-bezier(0.4, 0, 0.6, 1) 0ms',
         }}
       >
         <AppBar
@@ -557,7 +694,10 @@ export function StaffLayout() {
                 flexGrow: 1,
               }}
             >
-              <Link to="/staff/dashboard" style={{ textDecoration: 'none', display: 'flex' }}>
+              <Link
+                to="/staff/dashboard"
+                style={{ textDecoration: 'none', display: 'flex' }}
+              >
                 <Box
                   sx={{
                     width: 36,
@@ -573,7 +713,7 @@ export function StaffLayout() {
                     cursor: 'pointer',
                     '&:hover': {
                       transform: 'scale(1.05)',
-                    }
+                    },
                   }}
                 >
                   <img

--- a/apps/webApp/src/app/pages/accountant/EmployeeHours.tsx
+++ b/apps/webApp/src/app/pages/accountant/EmployeeHours.tsx
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Description,
+  Warning,
+} from '@mui/icons-material';
+import {
+  addMonths,
+  endOfMonth,
+  format,
+  isSameMonth,
+  startOfMonth,
+  subMonths,
+} from 'date-fns';
+import { PayrollHoursDto, PayType } from '@gt-automotive/data';
+import { timeClockService } from '../../requests/time-clock.requests';
+import { colors } from '../../theme/colors';
+
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(amount);
+
+const employeeName = (row: PayrollHoursDto) =>
+  [row.employee?.firstName, row.employee?.lastName].filter(Boolean).join(' ') ||
+  row.employee?.email ||
+  'Unknown employee';
+
+/**
+ * Read-only view of approved hours per employee for a pay period.
+ *
+ * The accountant reviews these figures and raises pay stubs from them;
+ * approving, adjusting and processing time entries stays with admin/foreman, so
+ * nothing on this page mutates. In particular the figures come from the
+ * read-only payroll-hours endpoint, never from process-payroll, which would
+ * stamp the entries as processed as a side effect of looking at them.
+ */
+export function EmployeeHours() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  // This page is mounted under both /accountant and /admin, so links stay
+  // within whichever section the user is actually in.
+  const basePath = `/${location.pathname.split('/')[1]}`;
+  const [viewMonth, setViewMonth] = useState(() => startOfMonth(new Date()));
+  const [rows, setRows] = useState<PayrollHoursDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const monthStart = startOfMonth(viewMonth).toISOString();
+  const monthEnd = endOfMonth(viewMonth).toISOString();
+  const monthLabel = format(viewMonth, 'MMMM yyyy');
+  const isCurrentMonth = isSameMonth(viewMonth, new Date());
+
+  const loadHours = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await timeClockService.getPayrollHours({
+        startDate: monthStart,
+        endDate: monthEnd,
+      });
+      setRows(data);
+    } catch (err: any) {
+      setError(err.message || 'Failed to load employee hours');
+    } finally {
+      setLoading(false);
+    }
+  }, [monthStart, monthEnd]);
+
+  useEffect(() => {
+    loadHours();
+  }, [loadHours]);
+
+  const totals = rows.reduce(
+    (acc, row) => ({
+      hours: acc.hours + row.hours,
+      grossPay: acc.grossPay + row.grossPay,
+    }),
+    { hours: 0, grossPay: 0 }
+  );
+
+  const withHours = rows.filter((row) => row.hours > 0 || row.grossPay > 0);
+
+  return (
+    <Box sx={{ px: { xs: 1, sm: 2, md: 3 } }}>
+      <Box sx={{ mb: 3 }}>
+        <Typography
+          variant="h4"
+          sx={{
+            fontWeight: 700,
+            color: colors.primary.main,
+            fontSize: { xs: '1.5rem', sm: '2rem' },
+          }}
+        >
+          Employee Hours
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Approved hours for the period. Use these to raise pay stubs — viewing
+          them does not process payroll.
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          mb: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <IconButton
+          size="small"
+          aria-label="Previous month"
+          onClick={() => setViewMonth(startOfMonth(subMonths(viewMonth, 1)))}
+          disabled={loading}
+        >
+          <ChevronLeft fontSize="small" />
+        </IconButton>
+        <Typography
+          variant="h6"
+          sx={{ fontWeight: 700, minWidth: 170, textAlign: 'center' }}
+        >
+          {monthLabel}
+        </Typography>
+        <IconButton
+          size="small"
+          aria-label="Next month"
+          onClick={() => setViewMonth(startOfMonth(addMonths(viewMonth, 1)))}
+          disabled={loading || isCurrentMonth}
+        >
+          <ChevronRight fontSize="small" />
+        </IconButton>
+        {!isCurrentMonth && (
+          <Button
+            size="small"
+            onClick={() => setViewMonth(startOfMonth(new Date()))}
+            disabled={loading}
+          >
+            This Month
+          </Button>
+        )}
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : withHours.length === 0 ? (
+        <Card elevation={0} sx={{ border: `1px solid ${colors.neutral[200]}` }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              No approved hours for {monthLabel}. Hours appear here once they
+              have been approved in the time clock.
+            </Typography>
+          </CardContent>
+        </Card>
+      ) : (
+        <TableContainer component={Paper} elevation={0} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Employee</TableCell>
+                <TableCell align="right">Approved Hours</TableCell>
+                <TableCell align="right">Already Processed</TableCell>
+                <TableCell align="right">Pay Rate</TableCell>
+                <TableCell align="right">Gross Pay</TableCell>
+                <TableCell align="center">Pay Stub</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {withHours.map((row) => (
+                <TableRow key={row.employeeId} hover>
+                  <TableCell>
+                    <Typography variant="body2" fontWeight={600}>
+                      {employeeName(row)}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {row.entryCount}{' '}
+                      {row.entryCount === 1 ? 'entry' : 'entries'}
+                    </Typography>
+                  </TableCell>
+                  <TableCell align="right">{row.hours.toFixed(2)}</TableCell>
+                  <TableCell align="right">
+                    {row.processedHours > 0 ? (
+                      <Chip
+                        size="small"
+                        color="success"
+                        label={`${row.processedHours.toFixed(2)} hrs`}
+                      />
+                    ) : (
+                      '—'
+                    )}
+                  </TableCell>
+                  <TableCell align="right">
+                    {!row.hasCompensation ? (
+                      <Tooltip title="No active compensation record for this employee">
+                        <Chip
+                          size="small"
+                          color="warning"
+                          icon={<Warning />}
+                          label="Not set"
+                        />
+                      </Tooltip>
+                    ) : row.payType === PayType.SALARIED ? (
+                      'Salaried'
+                    ) : (
+                      `${formatCurrency(row.hourlyRate)}/hr`
+                    )}
+                  </TableCell>
+                  <TableCell align="right">
+                    {row.hasCompensation ? (
+                      <Typography variant="body2" fontWeight={600}>
+                        {formatCurrency(row.grossPay)}
+                      </Typography>
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">
+                        Needs a pay rate
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell align="center">
+                    <Tooltip title="Create a pay stub for this period">
+                      <Button
+                        size="small"
+                        startIcon={<Description />}
+                        onClick={() =>
+                          navigate(
+                            `${basePath}/pay-stubs?employeeId=${
+                              row.employeeId
+                            }&start=${format(
+                              startOfMonth(viewMonth),
+                              'yyyy-MM-dd'
+                            )}&end=${format(
+                              endOfMonth(viewMonth),
+                              'yyyy-MM-dd'
+                            )}`
+                          )
+                        }
+                      >
+                        Create
+                      </Button>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+              <TableRow>
+                <TableCell sx={{ fontWeight: 700 }}>Total</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 700 }}>
+                  {totals.hours.toFixed(2)}
+                </TableCell>
+                <TableCell />
+                <TableCell />
+                <TableCell align="right" sx={{ fontWeight: 700 }}>
+                  {formatCurrency(totals.grossPay)}
+                </TableCell>
+                <TableCell />
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+}
+
+export default EmployeeHours;

--- a/apps/webApp/src/app/pages/accountant/PayStubs.tsx
+++ b/apps/webApp/src/app/pages/accountant/PayStubs.tsx
@@ -18,7 +18,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { Add, Visibility } from '@mui/icons-material';
+import { Add, Edit, Visibility } from '@mui/icons-material';
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import { PayrollHoursDto, PayStubDto } from '@gt-automotive/data';
 import { payStubService } from '../../requests/pay-stub.requests';
@@ -51,6 +51,8 @@ export function PayStubs() {
   const [filterEmployeeId, setFilterEmployeeId] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [viewing, setViewing] = useState<PayStubDto | null>(null);
+  // The stub being corrected, or null when the dialog is raising a new one.
+  const [editing, setEditing] = useState<PayStubDto | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -97,6 +99,7 @@ export function PayStubs() {
 
   const closeDialog = () => {
     setDialogOpen(false);
+    setEditing(null);
     // Drop the deep-link params so reopening the page does not immediately
     // reopen the dialog.
     if (prefillEmployeeId || prefillStart || prefillEnd) {
@@ -219,6 +222,16 @@ export function PayStubs() {
                     >
                       View
                     </Button>
+                    <Button
+                      size="small"
+                      startIcon={<Edit />}
+                      onClick={() => {
+                        setEditing(stub);
+                        setDialogOpen(true);
+                      }}
+                    >
+                      Edit
+                    </Button>
                   </TableCell>
                 </TableRow>
               ))}
@@ -230,9 +243,16 @@ export function PayStubs() {
       <PayStubDialog
         open={dialogOpen}
         onClose={closeDialog}
-        onCreated={(created) => {
-          setPayStubs((prev) => [created, ...prev]);
-          setViewing(created);
+        payStub={editing}
+        onCreated={(saved) => {
+          // An amendment rewrites year-to-date on later stubs too, so the list
+          // is reloaded rather than patched in place.
+          if (editing) {
+            loadData();
+          } else {
+            setPayStubs((prev) => [saved, ...prev]);
+          }
+          setViewing(saved);
         }}
         employees={employeeOptions}
         initialEmployeeId={prefillEmployeeId}

--- a/apps/webApp/src/app/pages/accountant/PayStubs.tsx
+++ b/apps/webApp/src/app/pages/accountant/PayStubs.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  MenuItem,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Add, Visibility } from '@mui/icons-material';
+import { endOfMonth, format, startOfMonth } from 'date-fns';
+import { PayrollHoursDto, PayStubDto } from '@gt-automotive/data';
+import { payStubService } from '../../requests/pay-stub.requests';
+import { timeClockService } from '../../requests/time-clock.requests';
+import { PayStubDialog } from '../../components/pay-stubs/PayStubDialog';
+import { PayStubViewer } from '../../components/pay-stubs/PayStubViewer';
+import { colors } from '../../theme/colors';
+
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(amount);
+
+const displayName = (row: PayrollHoursDto) =>
+  [row.employee?.firstName, row.employee?.lastName].filter(Boolean).join(' ') ||
+  row.employee?.email ||
+  'Unknown employee';
+
+/**
+ * Accountant view of issued pay stubs, and where new ones are raised.
+ *
+ * Deep-linkable from the Employee Hours page: `?employeeId=&start=&end=` opens
+ * the create dialog pre-scoped to that employee and period.
+ */
+export function PayStubs() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [payStubs, setPayStubs] = useState<PayStubDto[]>([]);
+  const [employees, setEmployees] = useState<PayrollHoursDto[]>([]);
+  const [filterEmployeeId, setFilterEmployeeId] = useState('');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [viewing, setViewing] = useState<PayStubDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const prefillEmployeeId = searchParams.get('employeeId') || undefined;
+  const prefillStart = searchParams.get('start') || undefined;
+  const prefillEnd = searchParams.get('end') || undefined;
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      // The payroll-hours endpoint doubles as the employee roster here: it is
+      // already scoped to payroll-eligible staff and carries their names, so
+      // the accountant does not also need access to the full user list.
+      const [stubs, roster] = await Promise.all([
+        payStubService.findAll(filterEmployeeId || undefined),
+        timeClockService.getPayrollHours({
+          startDate: startOfMonth(new Date()).toISOString(),
+          endDate: endOfMonth(new Date()).toISOString(),
+        }),
+      ]);
+      setPayStubs(stubs);
+      setEmployees(roster);
+    } catch (err: any) {
+      setError(err.message || 'Failed to load pay stubs');
+    } finally {
+      setLoading(false);
+    }
+  }, [filterEmployeeId]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (prefillEmployeeId) setDialogOpen(true);
+  }, [prefillEmployeeId]);
+
+  const employeeOptions = useMemo(
+    () =>
+      employees.map((row) => ({ id: row.employeeId, name: displayName(row) })),
+    [employees]
+  );
+
+  const closeDialog = () => {
+    setDialogOpen(false);
+    // Drop the deep-link params so reopening the page does not immediately
+    // reopen the dialog.
+    if (prefillEmployeeId || prefillStart || prefillEnd) {
+      setSearchParams({}, { replace: true });
+    }
+  };
+
+  return (
+    <Box sx={{ px: { xs: 1, sm: 2, md: 3 } }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 2,
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          mb: 3,
+        }}
+      >
+        <Box>
+          <Typography
+            variant="h4"
+            sx={{
+              fontWeight: 700,
+              color: colors.primary.main,
+              fontSize: { xs: '1.5rem', sm: '2rem' },
+            }}
+          >
+            Pay Stubs
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Issued pay stubs. Employees can view and print their own from their
+            profile.
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
+          <TextField
+            select
+            size="small"
+            label="Employee"
+            value={filterEmployeeId}
+            onChange={(event) => setFilterEmployeeId(event.target.value)}
+            sx={{ minWidth: 200 }}
+          >
+            <MenuItem value="">All Employees</MenuItem>
+            {employeeOptions.map((employee) => (
+              <MenuItem key={employee.id} value={employee.id}>
+                {employee.name}
+              </MenuItem>
+            ))}
+          </TextField>
+          <Button
+            variant="contained"
+            startIcon={<Add />}
+            onClick={() => setDialogOpen(true)}
+          >
+            Create Pay Stub
+          </Button>
+        </Box>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : payStubs.length === 0 ? (
+        <Card elevation={0} sx={{ border: `1px solid ${colors.neutral[200]}` }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              No pay stubs yet. Create one to get started.
+            </Typography>
+          </CardContent>
+        </Card>
+      ) : (
+        <TableContainer component={Paper} elevation={0} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Employee</TableCell>
+                <TableCell>Pay Cycle</TableCell>
+                <TableCell>Pay Date</TableCell>
+                <TableCell align="right">Hours</TableCell>
+                <TableCell align="right">Gross</TableCell>
+                <TableCell align="right">Withholding</TableCell>
+                <TableCell align="right">Net Pay</TableCell>
+                <TableCell align="center">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {payStubs.map((stub) => (
+                <TableRow key={stub.id} hover>
+                  <TableCell>{stub.employeeName}</TableCell>
+                  <TableCell>
+                    {stub.periodStart} — {stub.periodEnd}
+                  </TableCell>
+                  <TableCell>{stub.payDate}</TableCell>
+                  <TableCell align="right">
+                    {stub.regularHours.toFixed(2)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(stub.grossPay)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(stub.totalWithholding)}
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700 }}>
+                    {formatCurrency(stub.netPay)}
+                  </TableCell>
+                  <TableCell align="center">
+                    <Button
+                      size="small"
+                      startIcon={<Visibility />}
+                      onClick={() => setViewing(stub)}
+                    >
+                      View
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <PayStubDialog
+        open={dialogOpen}
+        onClose={closeDialog}
+        onCreated={(created) => {
+          setPayStubs((prev) => [created, ...prev]);
+          setViewing(created);
+        }}
+        employees={employeeOptions}
+        initialEmployeeId={prefillEmployeeId}
+        initialPeriodStart={
+          prefillStart || format(startOfMonth(new Date()), 'yyyy-MM-dd')
+        }
+        initialPeriodEnd={
+          prefillEnd || format(endOfMonth(new Date()), 'yyyy-MM-dd')
+        }
+      />
+
+      <PayStubViewer
+        payStub={viewing}
+        open={Boolean(viewing)}
+        onClose={() => setViewing(null)}
+      />
+    </Box>
+  );
+}
+
+export default PayStubs;

--- a/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Card,
   CardContent,
+  Divider,
   Chip,
   CircularProgress,
   Dialog,
@@ -147,6 +148,9 @@ export function TimeClockManagement() {
   const [selectedEmployeeId, setSelectedEmployeeId] = useState('');
   const [payType, setPayType] = useState<PayType>(PayType.HOURLY);
   const [hourlyRate, setHourlyRate] = useState('');
+  // Job title for this employee's pay stubs. Kept with pay because it is set
+  // by the same person at the same moment, and it is what a stub prints.
+  const [position, setPosition] = useState('');
   const [annualSalary, setAnnualSalary] = useState('');
   const [bonusAmount, setBonusAmount] = useState('');
   const [bonusReason, setBonusReason] = useState('');
@@ -242,6 +246,7 @@ export function TimeClockManagement() {
         );
         if (compensation) {
           setPayType(compensation.payType);
+          setPosition(compensation.position || '');
           setHourlyRate(compensation.hourlyRate?.toString() || '');
           setAnnualSalary(compensation.annualSalary?.toString() || '');
         } else {
@@ -376,6 +381,7 @@ export function TimeClockManagement() {
     if (!selectedEmployeeId) return;
     const payload: UpsertEmployeeCompensationDto = {
       payType,
+      position: position.trim() || undefined,
       hourlyRate: payType === PayType.HOURLY ? Number(hourlyRate) : undefined,
       annualSalary:
         payType === PayType.SALARIED ? Number(annualSalary) : undefined,
@@ -1453,8 +1459,14 @@ export function TimeClockManagement() {
             <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
               Compensation & Bonus
             </Typography>
-            <Grid container spacing={2}>
-              <Grid size={{ xs: 12, md: 4 }}>
+            {/* Two jobs share this card and one employee selector: setting how
+                someone is paid from now on, and paying a one-off bonus now.
+                They are kept as labelled groups so the standing arrangement is
+                not confused with a single payment. Rows add to 12 columns, and
+                the buttons match the 56px input height so each group reads as
+                one control strip. */}
+            <Grid container spacing={2} alignItems="flex-start">
+              <Grid size={{ xs: 12, md: 6 }}>
                 <TextField
                   select
                   fullWidth
@@ -1463,6 +1475,7 @@ export function TimeClockManagement() {
                   onChange={(event) =>
                     setSelectedEmployeeId(event.target.value)
                   }
+                  helperText="Applies to both compensation and bonus below"
                 >
                   {users.map((user) => (
                     <MenuItem key={user.id} value={user.id}>
@@ -1471,6 +1484,15 @@ export function TimeClockManagement() {
                   ))}
                 </TextField>
               </Grid>
+
+              <Grid size={12}>
+                <Divider textAlign="left">
+                  <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                    HOW THIS EMPLOYEE IS PAID
+                  </Typography>
+                </Divider>
+              </Grid>
+
               <Grid size={{ xs: 12, md: 3 }}>
                 <TextField
                   select
@@ -1502,6 +1524,16 @@ export function TimeClockManagement() {
                   }}
                 />
               </Grid>
+              <Grid size={{ xs: 12, md: 4 }}>
+                <TextField
+                  fullWidth
+                  label="Position"
+                  value={position}
+                  onChange={(event) => setPosition(event.target.value)}
+                  placeholder="e.g. Tire Technician"
+                  helperText="Optional — printed on this employee's pay stubs"
+                />
+              </Grid>
               <Grid size={{ xs: 12, md: 2 }}>
                 <Button
                   fullWidth
@@ -1509,10 +1541,20 @@ export function TimeClockManagement() {
                   startIcon={<Save />}
                   onClick={saveCompensation}
                   disabled={saving || !selectedEmployeeId}
+                  sx={{ height: 56 }}
                 >
                   Save
                 </Button>
               </Grid>
+
+              <Grid size={12}>
+                <Divider textAlign="left" sx={{ mt: 1 }}>
+                  <Typography variant="caption" sx={{ fontWeight: 700 }}>
+                    ONE-OFF BONUS
+                  </Typography>
+                </Divider>
+              </Grid>
+
               <Grid size={{ xs: 12, md: 3 }}>
                 <NumberInput
                   fullWidth
@@ -1545,8 +1587,9 @@ export function TimeClockManagement() {
                     !bonusAmount ||
                     !bonusReason
                   }
+                  sx={{ height: 56 }}
                 >
-                  Bonus
+                  Add Bonus
                 </Button>
               </Grid>
             </Grid>

--- a/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
@@ -54,9 +54,11 @@ import {
 } from '@mui/icons-material';
 import {
   addMonths,
+  endOfDay,
   endOfMonth,
   format,
   isSameMonth,
+  startOfDay,
   startOfMonth,
   subMonths,
 } from 'date-fns';
@@ -87,6 +89,7 @@ const formatCurrency = (amount: number) =>
     currency: 'CAD',
   }).format(amount);
 const formatStatus = (status: TimeEntryStatus) => {
+  if (status === TimeEntryStatus.PROCESSED) return 'Paid';
   if (status === TimeEntryStatus.OPEN) return 'Clocked In';
   if (status === TimeEntryStatus.ON_BREAK) return 'On Break';
   if (status === TimeEntryStatus.CLOCKED_OUT) return 'Clocked Out';
@@ -102,6 +105,7 @@ const getStatusColor = (
   | 'warning'
   | 'info'
   | 'error' => {
+  if (status === TimeEntryStatus.PROCESSED) return 'primary'; // paid out — final
   if (status === TimeEntryStatus.APPROVED) return 'success'; // green
   if (status === TimeEntryStatus.OPEN) return 'info'; // blue - actively clocked in
   if (status === TimeEntryStatus.ON_BREAK) return 'warning'; // amber
@@ -186,10 +190,58 @@ export function TimeClockManagement() {
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 
-  const monthStart = startOfMonth(viewMonth).toISOString();
-  const monthEnd = endOfMonth(viewMonth).toISOString();
   const monthLabel = format(viewMonth, 'MMMM yyyy');
   const isCurrentMonth = isSameMonth(viewMonth, new Date());
+
+  /**
+   * A From/To date is a request for that data, not merely a refinement of what
+   * is already on screen — so the fetch follows the dates rather than staying
+   * pinned to the month being browsed. Without this the pickers could only ever
+   * narrow within the current month, which read as them being disabled for
+   * every earlier one.
+   *
+   * Half-typed dates are ignored: a `type="date"` input reports 0002-01-01
+   * while the year is still being keyed, and that would ask the server for two
+   * millennia of time entries.
+   */
+  const parseFilterDate = (value: string) => {
+    if (!value) return undefined;
+    const parsed = new Date(`${value}T00:00:00`);
+    if (Number.isNaN(parsed.getTime()) || parsed.getFullYear() < 2000) {
+      return undefined;
+    }
+    return parsed;
+  };
+
+  const filterStart = parseFilterDate(filterStartDate);
+  const filterEnd = parseFilterDate(filterEndDate);
+
+  // One date on its own still has to produce a range that contains it, so the
+  // open end stretches to cover both it and the month being browsed. Setting
+  // only a From never yields an empty window, and neither does only a To.
+  const rangeStart = filterStart
+    ? startOfDay(filterStart)
+    : filterEnd && filterEnd < viewMonth
+    ? startOfMonth(filterEnd)
+    : startOfMonth(viewMonth);
+  const rangeEnd = filterEnd
+    ? endOfDay(filterEnd)
+    : filterStart && filterStart > endOfMonth(viewMonth)
+    ? endOfMonth(filterStart)
+    : endOfMonth(viewMonth);
+
+  const monthStart = rangeStart.toISOString();
+  const monthEnd = rangeEnd.toISOString();
+
+  // The heading tracks what is actually loaded, so a range reaching outside the
+  // browsed month is not shown under that month's name.
+  const rangeLabel =
+    filterStart || filterEnd
+      ? `${format(rangeStart, 'MMM d, yyyy')} – ${format(
+          rangeEnd,
+          'MMM d, yyyy'
+        )}`
+      : monthLabel;
 
   const loadData = async (options?: { silent?: boolean }) => {
     try {
@@ -226,7 +278,7 @@ export function TimeClockManagement() {
   useEffect(() => {
     loadData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewMonth]);
+  }, [viewMonth, monthStart, monthEnd]);
 
   // A From/To filter left over from the previous month would exclude every
   // entry in the newly loaded one, so reset the date refinement on month change.
@@ -1019,7 +1071,7 @@ export function TimeClockManagement() {
                   variant="h6"
                   sx={{ fontWeight: 700, minWidth: 190, textAlign: 'center' }}
                 >
-                  Time Entries · {monthLabel}
+                  Time Entries · {rangeLabel}
                 </Typography>
                 <IconButton
                   size="small"
@@ -1100,11 +1152,7 @@ export function TimeClockManagement() {
               value={filterStartDate}
               onChange={(event) => setFilterStartDate(event.target.value)}
               InputLabelProps={{ shrink: true }}
-              inputProps={{
-                min: format(startOfMonth(viewMonth), 'yyyy-MM-dd'),
-                max:
-                  filterEndDate || format(endOfMonth(viewMonth), 'yyyy-MM-dd'),
-              }}
+              inputProps={{ max: filterEndDate || undefined }}
               sx={{ minWidth: { sm: 150 }, flex: { xs: 1, sm: 'none' } }}
             />
             <TextField
@@ -1114,12 +1162,7 @@ export function TimeClockManagement() {
               value={filterEndDate}
               onChange={(event) => setFilterEndDate(event.target.value)}
               InputLabelProps={{ shrink: true }}
-              inputProps={{
-                min:
-                  filterStartDate ||
-                  format(startOfMonth(viewMonth), 'yyyy-MM-dd'),
-                max: format(endOfMonth(viewMonth), 'yyyy-MM-dd'),
-              }}
+              inputProps={{ min: filterStartDate || undefined }}
               sx={{ minWidth: { sm: 150 }, flex: { xs: 1, sm: 'none' } }}
             />
             {hasEntryFilters && (
@@ -1232,7 +1275,9 @@ export function TimeClockManagement() {
                     startIcon={<Edit />}
                     onClick={() => openEditEntry(entry)}
                     disabled={
-                      saving || entry.status === TimeEntryStatus.APPROVED
+                      saving ||
+                      entry.status === TimeEntryStatus.APPROVED ||
+                      Boolean(entry.payrollProcessedAt)
                     }
                   >
                     Edit
@@ -1248,7 +1293,8 @@ export function TimeClockManagement() {
                     Delete
                   </Button>
                   {entry.clockOutAt &&
-                    entry.status !== TimeEntryStatus.APPROVED && (
+                    entry.status !== TimeEntryStatus.APPROVED &&
+                    !entry.payrollProcessedAt && (
                       <Button
                         size="small"
                         variant="contained"

--- a/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
@@ -33,6 +33,8 @@ import {
   AccessTime,
   Add,
   CheckCircle,
+  ChevronLeft,
+  ChevronRight,
   Coffee,
   Delete,
   Edit,
@@ -49,7 +51,14 @@ import {
   Undo,
   WorkspacePremium,
 } from '@mui/icons-material';
-import { format, startOfMonth, endOfMonth } from 'date-fns';
+import {
+  addMonths,
+  endOfMonth,
+  format,
+  isSameMonth,
+  startOfMonth,
+  subMonths,
+} from 'date-fns';
 import {
   CreateTimeEntryDto,
   PayType,
@@ -164,10 +173,19 @@ export function TimeClockManagement() {
   );
   const [filterStartDate, setFilterStartDate] = useState('');
   const [filterEndDate, setFilterEndDate] = useState('');
+  // The month whose entries are loaded. Entries are fetched per month, so
+  // changing this refetches — the From/To filters below only refine what has
+  // already been loaded and cannot reach outside the viewed month.
+  const [viewMonth, setViewMonth] = useState(() => startOfMonth(new Date()));
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+
+  const monthStart = startOfMonth(viewMonth).toISOString();
+  const monthEnd = endOfMonth(viewMonth).toISOString();
+  const monthLabel = format(viewMonth, 'MMMM yyyy');
+  const isCurrentMonth = isSameMonth(viewMonth, new Date());
 
   const loadData = async (options?: { silent?: boolean }) => {
     try {
@@ -177,8 +195,8 @@ export function TimeClockManagement() {
         userService.getUsers(),
         timeClockService.getCurrentEntries(),
         timeClockService.getEntries({
-          startDate: startOfMonth(new Date()).toISOString(),
-          endDate: endOfMonth(new Date()).toISOString(),
+          startDate: monthStart,
+          endDate: monthEnd,
         }),
       ]);
       const myCurrent = await timeClockService.getMyCurrent();
@@ -203,7 +221,16 @@ export function TimeClockManagement() {
 
   useEffect(() => {
     loadData();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewMonth]);
+
+  // A From/To filter left over from the previous month would exclude every
+  // entry in the newly loaded one, so reset the date refinement on month change.
+  const goToMonth = (month: Date) => {
+    setFilterStartDate('');
+    setFilterEndDate('');
+    setViewMonth(startOfMonth(month));
+  };
 
   useEffect(() => {
     if (!selectedEmployeeId) return;
@@ -234,9 +261,6 @@ export function TimeClockManagement() {
   const currentEntryByEmployeeId = new Map(
     currentEntries.map((entry) => [entry.employeeId, entry])
   );
-  const monthStart = startOfMonth(new Date()).toISOString();
-  const monthEnd = endOfMonth(new Date()).toISOString();
-  const monthLabel = format(new Date(), 'MMMM yyyy');
   const selectedReadyEntries = entries.filter(
     (entry) =>
       entry.employeeId === selectedEmployeeId &&
@@ -261,7 +285,7 @@ export function TimeClockManagement() {
       ? selectedReadyHours * Number(hourlyRate || 0)
       : 0;
 
-  // Dashboard aggregate stats across all employees for the current month
+  // Dashboard aggregate stats across all employees for the viewed month
   const totalReadyHours = useMemo(
     () =>
       entries
@@ -311,7 +335,9 @@ export function TimeClockManagement() {
       color: colors.semantic.info,
     },
     {
-      label: 'Processed This Month',
+      label: isCurrentMonth
+        ? 'Processed This Month'
+        : `Processed · ${monthLabel}`,
       value: `${totalProcessedHours.toFixed(1)} hrs`,
       icon: <CheckCircle />,
       color: colors.semantic.success,
@@ -662,11 +688,7 @@ export function TimeClockManagement() {
           }}
         >
           <Tab icon={<AccessTime />} iconPosition="start" label="Dashboard" />
-          <Tab
-            icon={<Payment />}
-            iconPosition="start"
-            label="This Month's Entries"
-          />
+          <Tab icon={<Payment />} iconPosition="start" label="Time Entries" />
           {/* Compensation & Bonus is hidden for foreman. */}
           {user?.role?.name !== 'FOREMAN' && (
             <Tab
@@ -957,7 +979,7 @@ export function TimeClockManagement() {
         </Card>
       </TabPanel>
 
-      {/* This Month's Entries tab */}
+      {/* Time Entries tab — scoped to the month selected above the table. */}
       <TabPanel value={activeTab} index={1}>
         <Box
           sx={{
@@ -978,9 +1000,39 @@ export function TimeClockManagement() {
             }}
           >
             <Box>
-              <Typography variant="h6" sx={{ fontWeight: 700 }}>
-                Time Entries · {monthLabel}
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <IconButton
+                  size="small"
+                  aria-label="Previous month"
+                  onClick={() => goToMonth(subMonths(viewMonth, 1))}
+                  disabled={loading}
+                >
+                  <ChevronLeft fontSize="small" />
+                </IconButton>
+                <Typography
+                  variant="h6"
+                  sx={{ fontWeight: 700, minWidth: 190, textAlign: 'center' }}
+                >
+                  Time Entries · {monthLabel}
+                </Typography>
+                <IconButton
+                  size="small"
+                  aria-label="Next month"
+                  onClick={() => goToMonth(addMonths(viewMonth, 1))}
+                  disabled={loading || isCurrentMonth}
+                >
+                  <ChevronRight fontSize="small" />
+                </IconButton>
+                {!isCurrentMonth && (
+                  <Button
+                    size="small"
+                    onClick={() => goToMonth(new Date())}
+                    disabled={loading}
+                  >
+                    This Month
+                  </Button>
+                )}
+              </Box>
               <Typography variant="body2" color="text.secondary">
                 Showing {filteredEntries.length} of {entries.length} entries
               </Typography>
@@ -1043,9 +1095,9 @@ export function TimeClockManagement() {
               onChange={(event) => setFilterStartDate(event.target.value)}
               InputLabelProps={{ shrink: true }}
               inputProps={{
-                min: format(startOfMonth(new Date()), 'yyyy-MM-dd'),
+                min: format(startOfMonth(viewMonth), 'yyyy-MM-dd'),
                 max:
-                  filterEndDate || format(endOfMonth(new Date()), 'yyyy-MM-dd'),
+                  filterEndDate || format(endOfMonth(viewMonth), 'yyyy-MM-dd'),
               }}
               sx={{ minWidth: { sm: 150 }, flex: { xs: 1, sm: 'none' } }}
             />
@@ -1059,8 +1111,8 @@ export function TimeClockManagement() {
               inputProps={{
                 min:
                   filterStartDate ||
-                  format(startOfMonth(new Date()), 'yyyy-MM-dd'),
-                max: format(endOfMonth(new Date()), 'yyyy-MM-dd'),
+                  format(startOfMonth(viewMonth), 'yyyy-MM-dd'),
+                max: format(endOfMonth(viewMonth), 'yyyy-MM-dd'),
               }}
               sx={{ minWidth: { sm: 150 }, flex: { xs: 1, sm: 'none' } }}
             />
@@ -1377,7 +1429,15 @@ export function TimeClockManagement() {
               <ListItemIcon>
                 <Delete fontSize="small" color="error" />
               </ListItemIcon>
-              <ListItemText>Delete</ListItemText>
+              <ListItemText
+                secondary={
+                  actionEntry.payrollProcessedAt
+                    ? 'Already processed for payroll'
+                    : undefined
+                }
+              >
+                Delete
+              </ListItemText>
             </MenuItem>,
           ]}
         </Menu>
@@ -1533,7 +1593,7 @@ export function TimeClockManagement() {
                       color="text.secondary"
                       sx={{ display: 'block' }}
                     >
-                      Processed This Month
+                      Processed · {monthLabel}
                     </Typography>
                     <Typography variant="h6" sx={{ fontWeight: 700 }}>
                       {selectedProcessedHours.toFixed(2)} hrs

--- a/apps/webApp/src/app/pages/quotations/QuotationList.tsx
+++ b/apps/webApp/src/app/pages/quotations/QuotationList.tsx
@@ -28,6 +28,7 @@ import {
   Stack,
   Divider,
   Collapse,
+  Link,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -44,6 +45,7 @@ import {
 } from '@mui/icons-material';
 import { quotationService, Quote } from '../../requests/quotation.requests';
 import QuoteDialog from '../../components/quotations/QuotationDialog';
+import QuotationPrintDialog from '../../components/quotations/QuotationPrintDialog';
 import EmailPromptDialog from '../../components/common/EmailPromptDialog';
 import { useAuth } from '../../hooks/useAuth';
 import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
@@ -73,6 +75,10 @@ const QuoteList: React.FC = () => {
   const [quotationForEmail, setQuotationForEmail] = useState<Quote | null>(
     null
   );
+  // Quotation shown in the print preview, opened by clicking its number. The
+  // list rows carry no line items, so the full quote is fetched first.
+  const [previewQuote, setPreviewQuote] = useState<Quote | null>(null);
+  const [previewLoadingId, setPreviewLoadingId] = useState<string | null>(null);
 
   useEffect(() => {
     loadQuotations();
@@ -131,6 +137,20 @@ const QuoteList: React.FC = () => {
       } catch (error) {
         showApiError(error, 'Failed to delete quotation');
       }
+    }
+  };
+
+  /** Open the printable quotation in a dialog, without leaving the list. */
+  const handleOpenPreview = async (quotation: Quote) => {
+    if (previewLoadingId) return;
+    try {
+      setPreviewLoadingId(quotation.id);
+      const fullQuotation = await quotationService.getQuote(quotation.id);
+      setPreviewQuote(fullQuotation);
+    } catch (error) {
+      showApiError(error, 'Failed to open quotation');
+    } finally {
+      setPreviewLoadingId(null);
     }
   };
 
@@ -431,13 +451,23 @@ const QuoteList: React.FC = () => {
                         }}
                       >
                         <Box sx={{ flex: 1 }}>
-                          <Typography
-                            variant="h6"
-                            fontWeight="bold"
-                            gutterBottom
+                          <Link
+                            component="button"
+                            type="button"
+                            onClick={() => handleOpenPreview(quotation)}
+                            underline="hover"
+                            sx={{
+                              display: 'block',
+                              textAlign: 'left',
+                              mb: 0.5,
+                              fontFamily: 'inherit',
+                              fontSize: '1.25rem',
+                              fontWeight: 'bold',
+                              cursor: 'pointer',
+                            }}
                           >
                             {quotation.quotationNumber}
-                          </Typography>
+                          </Link>
                           <Chip
                             label={getStatusLabel(quotation.status)}
                             color={getStatusColor(quotation.status)}
@@ -584,7 +614,22 @@ const QuoteList: React.FC = () => {
                   .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                   .map((quotation) => (
                     <TableRow key={quotation.id} hover>
-                      <TableCell>{quotation.quotationNumber}</TableCell>
+                      <TableCell>
+                        <Link
+                          component="button"
+                          type="button"
+                          onClick={() => handleOpenPreview(quotation)}
+                          underline="hover"
+                          sx={{
+                            fontFamily: 'inherit',
+                            fontSize: 'inherit',
+                            fontWeight: 600,
+                            cursor: 'pointer',
+                          }}
+                        >
+                          {quotation.quotationNumber}
+                        </Link>
+                      </TableCell>
                       <TableCell>{formatDate(quotation.createdAt)}</TableCell>
                       <TableCell>
                         {quotation.businessName && (
@@ -646,6 +691,12 @@ const QuoteList: React.FC = () => {
         }}
         onSuccess={loadQuotations}
         quoteId={editingQuotationId}
+      />
+
+      <QuotationPrintDialog
+        quote={previewQuote}
+        open={Boolean(previewQuote)}
+        onClose={() => setPreviewQuote(null)}
       />
 
       <Menu

--- a/apps/webApp/src/app/pages/staff/MyPayStubs.tsx
+++ b/apps/webApp/src/app/pages/staff/MyPayStubs.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { Visibility } from '@mui/icons-material';
+import { PayStubDto } from '@gt-automotive/data';
+import { payStubService } from '../../requests/pay-stub.requests';
+import { PayStubViewer } from '../../components/pay-stubs/PayStubViewer';
+import { colors } from '../../theme/colors';
+
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(amount);
+
+/**
+ * The signed-in employee's own pay stubs.
+ *
+ * Backed by `GET /api/pay-stubs/mine`, which can only ever return the caller's
+ * own records — an employee never sees a colleague's pay.
+ */
+export function MyPayStubs() {
+  const [payStubs, setPayStubs] = useState<PayStubDto[]>([]);
+  const [viewing, setViewing] = useState<PayStubDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setPayStubs(await payStubService.findMine());
+      } catch (err: any) {
+        setError(err.message || 'Failed to load your pay stubs');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <Box sx={{ px: { xs: 1, sm: 2, md: 3 } }}>
+      <Box sx={{ mb: 3 }}>
+        <Typography
+          variant="h4"
+          sx={{
+            fontWeight: 700,
+            color: colors.primary.main,
+            fontSize: { xs: '1.5rem', sm: '2rem' },
+          }}
+        >
+          My Pay Stubs
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          View and print your pay stubs.
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : payStubs.length === 0 ? (
+        <Card elevation={0} sx={{ border: `1px solid ${colors.neutral[200]}` }}>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              You don't have any pay stubs yet. They appear here once payroll
+              issues them.
+            </Typography>
+          </CardContent>
+        </Card>
+      ) : (
+        <TableContainer component={Paper} elevation={0} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Pay Cycle</TableCell>
+                <TableCell>Pay Date</TableCell>
+                <TableCell align="right">Hours</TableCell>
+                <TableCell align="right">Gross</TableCell>
+                <TableCell align="right">Withholding</TableCell>
+                <TableCell align="right">Net Pay</TableCell>
+                <TableCell align="center">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {payStubs.map((stub) => (
+                <TableRow key={stub.id} hover>
+                  <TableCell>
+                    {stub.periodStart} — {stub.periodEnd}
+                  </TableCell>
+                  <TableCell>{stub.payDate}</TableCell>
+                  <TableCell align="right">
+                    {stub.regularHours.toFixed(2)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(stub.grossPay)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(stub.totalWithholding)}
+                  </TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700 }}>
+                    {formatCurrency(stub.netPay)}
+                  </TableCell>
+                  <TableCell align="center">
+                    <Button
+                      size="small"
+                      startIcon={<Visibility />}
+                      onClick={() => setViewing(stub)}
+                    >
+                      View
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      <PayStubViewer
+        payStub={viewing}
+        open={Boolean(viewing)}
+        onClose={() => setViewing(null)}
+      />
+    </Box>
+  );
+}
+
+export default MyPayStubs;

--- a/apps/webApp/src/app/providers/ServicesProvider.tsx
+++ b/apps/webApp/src/app/providers/ServicesProvider.tsx
@@ -10,13 +10,16 @@ import { setClerkTokenGetter as setPaymentTokenGetter } from '../requests/paymen
 import { setClerkTokenGetter as setTireSaleTokenGetter } from '../requests/tire-sale.requests';
 import { setClerkTokenGetter as setTireTokenGetter } from '../requests/tire.requests';
 import { setClerkTokenGetter as setTimeClockTokenGetter } from '../requests/time-clock.requests';
+import { setClerkTokenGetter as setPayStubTokenGetter } from '../requests/pay-stub.requests';
 
 // Check if Clerk is configured - use direct import.meta.env access for consistency
 // @ts-ignore
 const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY || '';
 const useAuth = publishableKey ? useClerkAuth : useMockAuth;
 
-export const ServicesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const ServicesProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const { getToken } = useAuth();
 
   useEffect(() => {
@@ -31,6 +34,7 @@ export const ServicesProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       setTireSaleTokenGetter(getToken);
       setTireTokenGetter(getToken);
       setTimeClockTokenGetter(getToken);
+      setPayStubTokenGetter(getToken);
     }
   }, [getToken]);
 

--- a/apps/webApp/src/app/requests/pay-stub.requests.ts
+++ b/apps/webApp/src/app/requests/pay-stub.requests.ts
@@ -1,4 +1,10 @@
-import { CreatePayStubDto, PayStubDto } from '@gt-automotive/data';
+import {
+  CreatePayStubDto,
+  PayStubDeductionEstimateDto,
+  PayStubDeductionEstimateRequestDto,
+  PayStubDto,
+  UpdatePayStubDto,
+} from '@gt-automotive/data';
 
 // @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
@@ -48,6 +54,30 @@ class PayStubService {
 
     const text = await response.text();
     return text ? JSON.parse(text) : (null as T);
+  }
+
+  /**
+   * What the CRA formulas say should be withheld for a given gross. Only ever
+   * a suggestion — the accountant confirms or overrides it before saving.
+   */
+  estimateDeductions(
+    dto: PayStubDeductionEstimateRequestDto
+  ): Promise<PayStubDeductionEstimateDto> {
+    return this.makeRequest<PayStubDeductionEstimateDto>(
+      `${this.baseUrl}/deduction-estimate`,
+      { method: 'POST', body: JSON.stringify(dto) }
+    );
+  }
+
+  /**
+   * Correct an issued stub. Send only the fields that are wrong; the server
+   * recomputes the totals and rewrites the year-to-date chain.
+   */
+  update(id: string, dto: UpdatePayStubDto): Promise<PayStubDto> {
+    return this.makeRequest<PayStubDto>(`${this.baseUrl}/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(dto),
+    });
   }
 
   create(dto: CreatePayStubDto): Promise<PayStubDto> {

--- a/apps/webApp/src/app/requests/pay-stub.requests.ts
+++ b/apps/webApp/src/app/requests/pay-stub.requests.ts
@@ -1,0 +1,105 @@
+import { CreatePayStubDto, PayStubDto } from '@gt-automotive/data';
+
+// @ts-ignore - TypeScript doesn't recognize import.meta.env properly in some contexts
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+let clerkTokenGetter: (() => Promise<string | null>) | null = null;
+
+export function setClerkTokenGetter(getter: () => Promise<string | null>) {
+  clerkTokenGetter = getter;
+}
+
+class PayStubService {
+  private baseUrl = `${API_BASE_URL}/api/pay-stubs`;
+
+  private async getToken() {
+    return clerkTokenGetter
+      ? await clerkTokenGetter()
+      : localStorage.getItem('authToken');
+  }
+
+  private async makeRequest<T>(
+    url: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const token = await this.getToken();
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token && { Authorization: `Bearer ${token}` }),
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response
+        .json()
+        .catch(() => ({ message: 'Unknown error' }));
+      throw new Error(
+        errorData.message || `HTTP error! status: ${response.status}`
+      );
+    }
+
+    if (response.status === 204) {
+      return null as T;
+    }
+
+    const text = await response.text();
+    return text ? JSON.parse(text) : (null as T);
+  }
+
+  create(dto: CreatePayStubDto): Promise<PayStubDto> {
+    return this.makeRequest<PayStubDto>(this.baseUrl, {
+      method: 'POST',
+      body: JSON.stringify(dto),
+    });
+  }
+
+  findAll(employeeId?: string): Promise<PayStubDto[]> {
+    const query = employeeId
+      ? `?employeeId=${encodeURIComponent(employeeId)}`
+      : '';
+    return this.makeRequest<PayStubDto[]>(`${this.baseUrl}${query}`);
+  }
+
+  /** The signed-in employee's own pay stubs. */
+  findMine(): Promise<PayStubDto[]> {
+    return this.makeRequest<PayStubDto[]>(`${this.baseUrl}/mine`);
+  }
+
+  findOne(id: string): Promise<PayStubDto> {
+    return this.makeRequest<PayStubDto>(`${this.baseUrl}/${id}`);
+  }
+
+  /**
+   * Fetch the rendered stub as a PDF blob.
+   *
+   * Goes through fetch rather than pointing an <iframe> straight at the URL,
+   * because the endpoint needs an Authorization header — a bare URL would be
+   * unauthenticated, and pay stubs must never be reachable without a token.
+   * The caller is responsible for revoking the object URL it creates.
+   */
+  async fetchPdfBlob(id: string): Promise<Blob> {
+    const token = await this.getToken();
+    const response = await fetch(`${this.baseUrl}/${id}/pdf`, {
+      headers: {
+        ...(token && { Authorization: `Bearer ${token}` }),
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response
+        .json()
+        .catch(() => ({ message: 'Unable to generate the pay stub PDF' }));
+      throw new Error(
+        errorData.message || `HTTP error! status: ${response.status}`
+      );
+    }
+
+    return response.blob();
+  }
+}
+
+export const payStubService = new PayStubService();

--- a/apps/webApp/src/app/requests/time-clock.requests.ts
+++ b/apps/webApp/src/app/requests/time-clock.requests.ts
@@ -5,6 +5,7 @@ import {
   CreateTimeEntryDto,
   EmployeeCompensationDto,
   PayrollAdjustmentDto,
+  PayrollHoursDto,
   ProcessPayrollDto,
   PayrollSummaryDto,
   StartBreakDto,
@@ -237,9 +238,25 @@ class TimeClockService {
     );
   }
 
-  processPayroll(
-    dto: ProcessPayrollDto
-  ): Promise<{
+  /**
+   * Approved hours and gross pay per employee over a period. Read-only —
+   * unlike processPayroll() below, calling this never stamps time entries, so
+   * it is safe to call whenever a form needs the numbers.
+   *
+   * Returns one row per payroll employee, or a single row when `employeeId` is
+   * supplied.
+   */
+  getPayrollHours(filters: {
+    startDate: string;
+    endDate: string;
+    employeeId?: string;
+  }): Promise<PayrollHoursDto[]> {
+    return this.makeRequest<PayrollHoursDto[]>(
+      `${this.baseUrl}/payroll-hours${this.toQuery(filters)}`
+    );
+  }
+
+  processPayroll(dto: ProcessPayrollDto): Promise<{
     employeeId: string;
     processedEntries: number;
     processedHours: number;

--- a/libs/data/src/index.ts
+++ b/libs/data/src/index.ts
@@ -30,6 +30,7 @@ export * from './lib/sales-report.dto';
 export * from './lib/tax-report.dto';
 export * from './lib/tire-sale.dto';
 export * from './lib/repair-order.dto';
+export * from './lib/pay-stub.dto';
 
 // Export utility functions
 export * from './lib/utils/index';

--- a/libs/data/src/lib/pay-stub.dto.ts
+++ b/libs/data/src/lib/pay-stub.dto.ts
@@ -1,0 +1,144 @@
+import {
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { PayType } from './prisma-enums';
+import { EmployeeSummaryDto } from './time-clock.dto';
+
+/**
+ * What the accountant fills in to raise a pay stub.
+ *
+ * Only the inputs are accepted here. Every derived figure — regular amount,
+ * gross, total withholding, net, and all the year-to-date columns — is computed
+ * server-side and never taken from the client, so the arithmetic on a printed
+ * stub is always internally consistent.
+ *
+ * Statutory deductions are entered, not calculated: EI and CPP rates are
+ * year-specific and getting them wrong has real consequences, so the system
+ * stores what the accountant supplies rather than guessing.
+ */
+export class CreatePayStubDto {
+  @IsString()
+  employeeId!: string;
+
+  /** Pay period start, as a calendar date (YYYY-MM-DD). */
+  @IsDateString()
+  periodStart!: string;
+
+  /** Pay period end, as a calendar date (YYYY-MM-DD). */
+  @IsDateString()
+  periodEnd!: string;
+
+  /** The date the employee is paid, as a calendar date (YYYY-MM-DD). */
+  @IsDateString()
+  payDate!: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  payRate?: number;
+
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  regularHours!: number;
+
+  /**
+   * Gross earnings for the period. Sent explicitly rather than derived from
+   * hours × rate so the accountant can correct it — a salaried employee has no
+   * meaningful hourly product, and hourly pay may include agreed adjustments.
+   */
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  regularAmount!: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  eiAmount?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  cppAmount?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  incomeTaxAmount?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  otherDeductions?: number;
+
+  @IsOptional()
+  @IsString()
+  otherDeductionsLabel?: string;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}
+
+/**
+ * A pay stub as issued. Every printed figure is stored, so re-rendering the
+ * document later reproduces the same numbers no matter what has changed in
+ * payroll since.
+ */
+export interface PayStubDto {
+  id: string;
+  employeeId: string;
+  employee?: EmployeeSummaryDto;
+
+  periodStart: string;
+  periodEnd: string;
+  payDate: string;
+
+  companyName: string;
+  companyAddress?: string;
+  employeeName: string;
+  position?: string;
+  payRate?: number;
+  payType: PayType;
+
+  regularHours: number;
+  regularAmount: number;
+  grossPay: number;
+
+  eiAmount: number;
+  cppAmount: number;
+  incomeTaxAmount: number;
+  otherDeductions: number;
+  otherDeductionsLabel?: string;
+  totalWithholding: number;
+  netPay: number;
+
+  ytdHours: number;
+  ytdRegularAmount: number;
+  ytdGrossPay: number;
+  ytdEiAmount: number;
+  ytdCppAmount: number;
+  ytdIncomeTaxAmount: number;
+  ytdOtherDeductions: number;
+  ytdWithholding: number;
+  ytdNetPay: number;
+
+  notes?: string;
+  generatedBy: string;
+  createdAt: string;
+}

--- a/libs/data/src/lib/pay-stub.dto.ts
+++ b/libs/data/src/lib/pay-stub.dto.ts
@@ -1,11 +1,13 @@
 import {
   IsDateString,
+  IsIn,
   IsNumber,
   IsOptional,
   IsString,
   Min,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { OmitType, PartialType } from './utils/mapped-types';
 import { PayType } from './prisma-enums';
 import { EmployeeSummaryDto } from './time-clock.dto';
 
@@ -17,9 +19,11 @@ import { EmployeeSummaryDto } from './time-clock.dto';
  * server-side and never taken from the client, so the arithmetic on a printed
  * stub is always internally consistent.
  *
- * Statutory deductions are entered, not calculated: EI and CPP rates are
- * year-specific and getting them wrong has real consequences, so the system
- * stores what the accountant supplies rather than guessing.
+ * Statutory deductions are still supplied here rather than recomputed on save.
+ * They are suggested by the deduction estimate endpoint using the CRA formulas
+ * for the pay date's year, but the accountant can type over any of them, and
+ * what they confirm is what gets stored — a stub must record what was actually
+ * withheld, not what a formula thinks should have been.
  */
 export class CreatePayStubDto {
   @IsString()
@@ -96,6 +100,90 @@ export class CreatePayStubDto {
 }
 
 /**
+ * Correct a stub that has already been issued.
+ *
+ * Every input is optional — send only what is wrong. The employee is not
+ * among them: a stub belongs to one person's year-to-date record, and moving
+ * it to another would corrupt both. Re-raise it against the right employee
+ * instead.
+ *
+ * Editing an earlier stub shifts the running totals on every later one, so the
+ * server rewrites that employee's year-to-date chain rather than leaving the
+ * later documents disagreeing with this one.
+ */
+export class UpdatePayStubDto extends PartialType(
+  OmitType(CreatePayStubDto, ['employeeId'] as const)
+) {}
+
+/** Pay frequencies the deduction calculator supports, as periods per year. */
+export const PAY_PERIODS_PER_YEAR = [52, 26, 24, 12] as const;
+export type PayPeriodsPerYear = (typeof PAY_PERIODS_PER_YEAR)[number];
+
+/**
+ * Ask what CPP, EI and income tax should come off a given gross.
+ *
+ * The employee and pay date are needed as well as the amount: contributions
+ * stop at annual maximums, so the answer depends on what has already been
+ * withheld from this employee earlier in the same year.
+ */
+export class PayStubDeductionEstimateRequestDto {
+  @IsString()
+  employeeId!: string;
+
+  /** Determines the tax year, and therefore which rate table applies. */
+  @IsDateString()
+  payDate!: string;
+
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  grossPay!: number;
+
+  /**
+   * Pay periods in the year. Sent explicitly because the CRA formulas
+   * annualize the period's pay, so the frequency changes every figure and
+   * cannot be safely guessed from the dates alone.
+   */
+  @IsNumber()
+  @IsIn([...PAY_PERIODS_PER_YEAR])
+  @Type(() => Number)
+  payPeriodsPerYear!: PayPeriodsPerYear;
+}
+
+/**
+ * Suggested statutory deductions, with enough context for the accountant to
+ * judge whether to accept them.
+ */
+export interface PayStubDeductionEstimateDto {
+  /** False when no CRA rate table is held for the pay date's year. */
+  supported: boolean;
+  taxYear: number;
+  province: string;
+  payPeriodsPerYear: number;
+
+  ei: number;
+  cpp: number;
+  /** The CPP2 slice of `cpp`, non-zero only above the year's YMPE. */
+  cpp2: number;
+  incomeTax: number;
+  federalTax: number;
+  provincialTax: number;
+  annualTaxableIncome: number;
+
+  /** This period's contribution was clipped by the annual maximum. */
+  cppMaxedOut: boolean;
+  eiMaxedOut: boolean;
+
+  /** Year-to-date figures the estimate was based on. */
+  ytdGrossPay: number;
+  ytdCpp: number;
+  ytdEi: number;
+
+  /** Plain-language caveats to show alongside the suggested figures. */
+  assumptions: string[];
+}
+
+/**
  * A pay stub as issued. Every printed figure is stored, so re-rendering the
  * document later reproduces the same numbers no matter what has changed in
  * payroll since.
@@ -111,6 +199,11 @@ export interface PayStubDto {
 
   companyName: string;
   companyAddress?: string;
+  /** Company details as they stood when the stub was raised. */
+  companyBusinessType?: string;
+  companyRegistrationNumber?: string;
+  companyPhone?: string;
+  companyEmail?: string;
   employeeName: string;
   position?: string;
   payRate?: number;

--- a/libs/data/src/lib/prisma-enums.ts
+++ b/libs/data/src/lib/prisma-enums.ts
@@ -17,6 +17,7 @@ export const TimeEntryStatus = {
   APPROVED: 'APPROVED',
   ADJUSTED: 'ADJUSTED',
   VOIDED: 'VOIDED',
+  PROCESSED: 'PROCESSED',
 } as const;
 export type TimeEntryStatus = (typeof TimeEntryStatus)[keyof typeof TimeEntryStatus];
 

--- a/libs/data/src/lib/time-clock.dto.ts
+++ b/libs/data/src/lib/time-clock.dto.ts
@@ -249,3 +249,31 @@ export interface PayrollSummaryDto {
     grossPay: number;
   };
 }
+
+/**
+ * Approved hours and gross pay for one employee over a period, as returned by
+ * the read-only `GET /api/time-clock/payroll-hours` endpoint. This is what the
+ * pay stub form pre-fills from — reading it never marks entries as processed.
+ *
+ * `hours` counts every approved entry in the period, whether or not payroll has
+ * already been processed for it, so a stub raised after payroll runs still
+ * reports the period correctly. `processedHours` is the subset already stamped,
+ * exposed so the UI can say so rather than silently conflating the two.
+ */
+export interface PayrollHoursDto {
+  employeeId: string;
+  employee: EmployeeSummaryDto;
+  startDate: string;
+  endDate: string;
+  entryCount: number;
+  hours: number;
+  processedHours: number;
+  /** Absent when the employee has no active compensation record. */
+  payType?: PayType;
+  hasCompensation: boolean;
+  /** Zero for salaried employees — read `salaryPay` instead. */
+  hourlyRate: number;
+  /** Annual salary prorated across the period; zero for hourly employees. */
+  salaryPay: number;
+  grossPay: number;
+}

--- a/libs/data/src/lib/time-clock.dto.ts
+++ b/libs/data/src/lib/time-clock.dto.ts
@@ -27,6 +27,14 @@ export class UpsertEmployeeCompensationDto {
   @IsEnum(PayType)
   payType!: PayType;
 
+  /**
+   * Job title as it should read on this employee's pay stubs. Optional — the
+   * stub omits the line when there is none.
+   */
+  @IsOptional()
+  @IsString()
+  position?: string;
+
   @IsOptional()
   @IsNumber()
   @Type(() => Number)
@@ -163,6 +171,8 @@ export interface EmployeeSummaryDto {
 export interface EmployeeCompensationDto {
   id: string;
   employeeId: string;
+  /** Job title for pay stubs, e.g. "Tire Technician". */
+  position?: string;
   payType: PayType;
   hourlyRate?: number;
   annualSalary?: number;
@@ -271,6 +281,8 @@ export interface PayrollHoursDto {
   /** Absent when the employee has no active compensation record. */
   payType?: PayType;
   hasCompensation: boolean;
+  /** Job title from the compensation record, for the pay stub. */
+  position?: string;
   /** Zero for salaried employees — read `salaryPay` instead. */
   hourlyRate: number;
   /** Annual salary prorated across the period; zero for hourly employees. */

--- a/libs/database/src/lib/prisma/migrations/20260806172332_add_pay_stubs/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260806172332_add_pay_stubs/migration.sql
@@ -1,0 +1,51 @@
+-- CreateTable
+CREATE TABLE "public"."PayStub" (
+    "id" TEXT NOT NULL,
+    "employeeId" TEXT NOT NULL,
+    "periodStart" TIMESTAMP(3) NOT NULL,
+    "periodEnd" TIMESTAMP(3) NOT NULL,
+    "payDate" TIMESTAMP(3) NOT NULL,
+    "companyName" TEXT NOT NULL,
+    "companyAddress" TEXT,
+    "employeeName" TEXT NOT NULL,
+    "position" TEXT,
+    "payRate" DECIMAL(10,2),
+    "payType" "public"."PayType" NOT NULL DEFAULT 'HOURLY',
+    "regularHours" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "regularAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "grossPay" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "eiAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "cppAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "incomeTaxAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "otherDeductions" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "otherDeductionsLabel" TEXT,
+    "totalWithholding" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "netPay" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdHours" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdRegularAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdGrossPay" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdEiAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdCppAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdIncomeTaxAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdOtherDeductions" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdWithholding" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "ytdNetPay" DECIMAL(10,2) NOT NULL DEFAULT 0,
+    "notes" TEXT,
+    "generatedBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PayStub_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PayStub_employeeId_idx" ON "public"."PayStub"("employeeId");
+
+-- CreateIndex
+CREATE INDEX "PayStub_employeeId_payDate_idx" ON "public"."PayStub"("employeeId", "payDate");
+
+-- CreateIndex
+CREATE INDEX "PayStub_payDate_idx" ON "public"."PayStub"("payDate");
+
+-- AddForeignKey
+ALTER TABLE "public"."PayStub" ADD CONSTRAINT "PayStub_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/libs/database/src/lib/prisma/migrations/20260806204225_add_pay_stub_company_details/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260806204225_add_pay_stub_company_details/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "public"."PayStub" ADD COLUMN     "companyBusinessType" TEXT,
+ADD COLUMN     "companyEmail" TEXT,
+ADD COLUMN     "companyPhone" TEXT,
+ADD COLUMN     "companyRegistrationNumber" TEXT;

--- a/libs/database/src/lib/prisma/migrations/20260806204934_backfill_pay_stub_company_details/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260806204934_backfill_pay_stub_company_details/migration.sql
@@ -1,0 +1,31 @@
+-- Backfill company details onto pay stubs raised before those columns existed.
+--
+-- The stub freezes its company header at issue time so a reprint reproduces the
+-- document as issued. Stubs created before the columns were added have nothing
+-- frozen, so their header prints a bare name and address. This stamps the
+-- default company's current details onto exactly those rows.
+--
+-- Two guards keep it from rewriting history it shouldn't:
+--   - only rows where all four columns are NULL, i.e. never populated, so a
+--     stub that recorded its own details is never overwritten;
+--   - only rows whose stored company name still matches the default company,
+--     so a stub issued under a different company is left alone.
+--
+-- Safe to run on a database with no such rows: it updates nothing.
+UPDATE "public"."PayStub" AS ps
+SET "companyBusinessType"       = c."businessType",
+    "companyRegistrationNumber" = c."registrationNumber",
+    "companyPhone"              = c."phone",
+    "companyEmail"              = c."email"
+FROM (
+  SELECT "name", "businessType", "registrationNumber", "phone", "email"
+  FROM "public"."Company"
+  WHERE "isDefault" = true
+  ORDER BY "createdAt" ASC
+  LIMIT 1
+) AS c
+WHERE ps."companyName" = c."name"
+  AND ps."companyBusinessType" IS NULL
+  AND ps."companyRegistrationNumber" IS NULL
+  AND ps."companyPhone" IS NULL
+  AND ps."companyEmail" IS NULL;

--- a/libs/database/src/lib/prisma/migrations/20260806210904_add_employee_compensation_position/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260806210904_add_employee_compensation_position/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."EmployeeCompensation" ADD COLUMN     "position" TEXT;

--- a/libs/database/src/lib/prisma/migrations/20260806213458_add_processed_time_entry_status/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260806213458_add_processed_time_entry_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "public"."TimeEntryStatus" ADD VALUE 'PROCESSED';

--- a/libs/database/src/lib/prisma/migrations/20260806213519_backfill_processed_time_entry_status/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260806213519_backfill_processed_time_entry_status/migration.sql
@@ -1,0 +1,16 @@
+-- Move entries already paid out through payroll onto the PROCESSED status.
+--
+-- Processing previously only stamped payrollProcessedAt and left the status at
+-- APPROVED, so a paid entry was indistinguishable from one merely waiting to be
+-- paid. Everything with that stamp is, by definition, processed.
+--
+-- Separate from the migration that adds the enum value: PostgreSQL will not let
+-- a new enum value be used in the same transaction that declares it.
+--
+-- VOIDED entries are left alone. A voided entry that was somehow processed is a
+-- discrepancy worth seeing, not one to paper over by relabelling it as paid.
+UPDATE "public"."TimeEntry"
+SET "status" = 'PROCESSED'
+WHERE "payrollProcessedAt" IS NOT NULL
+  AND "status" <> 'VOIDED'
+  AND "status" <> 'PROCESSED';

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -969,6 +969,10 @@ enum TimeEntryStatus {
   APPROVED
   ADJUSTED
   VOIDED
+  // Paid out through a payroll run. Terminal: a processed entry is the
+  // evidence behind money that has already left the business, so it is never
+  // edited, voided, deleted or unapproved afterwards.
+  PROCESSED
 }
 
 enum TimeEntrySource {

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -773,8 +773,12 @@ model Payment {
 }
 
 model EmployeeCompensation {
-  id                  String    @id @default(cuid())
-  employeeId          String
+  id         String @id @default(cuid())
+  employeeId String
+  // Job title as it should read on a pay stub ("Tire Technician"), which the
+  // permission role (STAFF, ACCOUNTANT) does not capture. Optional: an employee
+  // can be paid without one, and the stub simply omits the line.
+  position            String?
   payType             PayType
   hourlyRate          Decimal?  @db.Decimal(10, 2)
   annualSalary        Decimal?  @db.Decimal(10, 2)
@@ -895,10 +899,20 @@ model PayStub {
   periodEnd   DateTime
   payDate     DateTime
 
-  // Header and identity, as printed.
-  companyName    String
-  companyAddress String?
-  employeeName   String
+  // Header and identity, as printed. The company details are copied from the
+  // Company record when the stub is raised rather than joined at render time,
+  // for the same reason the figures are: reprinting a stub years later must
+  // reproduce the document as issued, even if the business has since changed
+  // its address, phone or registered name. Nullable because stubs raised
+  // before these columns existed have no value to show, and inventing one on
+  // an old wage statement would be worse than omitting the line.
+  companyName               String
+  companyAddress            String?
+  companyBusinessType       String?
+  companyRegistrationNumber String?
+  companyPhone              String?
+  companyEmail              String?
+  employeeName              String
   position       String?
   payRate        Decimal? @db.Decimal(10, 2)
   payType        PayType  @default(HOURLY)

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -39,6 +39,7 @@ model User {
   roEmployees          ROEmployee[]           // Repair orders assigned to this employee
   roServices           ROService[]            @relation("ROServiceCompletedBy") // Service items completed by this user
   roMedia              ROMedia[]              // Photos uploaded by this user
+  payStubs             PayStub[]              // Pay stubs issued to this employee
 }
 
 model Role {
@@ -867,6 +868,79 @@ model PayrollPeriod {
 
   @@unique([startDate, endDate, type])
   @@index([startDate, endDate])
+}
+
+/// A pay stub issued to an employee for one pay period.
+///
+/// No PDF is stored — the document is rendered on demand from this row. That
+/// only works if the row is a complete, frozen record of what was issued, so
+/// every figure and label that appears on the printed stub is a column here:
+/// the employee's name, position, pay rate and the company header are
+/// snapshotted at generation rather than joined live. Editing a time entry,
+/// changing an hourly rate or renaming the company must never alter a stub
+/// that has already been handed to someone.
+///
+/// YTD columns are likewise frozen. They are computed once, at generation, by
+/// summing this employee's earlier stubs in the same calendar year — not
+/// recomputed at render time, which would make an old stub change whenever a
+/// later one was issued or voided.
+model PayStub {
+  id         String @id @default(cuid())
+  employeeId String
+
+  // Period this stub covers. periodStart/periodEnd are calendar dates stored at
+  // midnight UTC (see toBusinessCalendarDate) so the printed pay cycle reads the
+  // same on any device, regardless of the server's timezone.
+  periodStart DateTime
+  periodEnd   DateTime
+  payDate     DateTime
+
+  // Header and identity, as printed.
+  companyName    String
+  companyAddress String?
+  employeeName   String
+  position       String?
+  payRate        Decimal? @db.Decimal(10, 2)
+  payType        PayType  @default(HOURLY)
+
+  // Current-period earnings.
+  regularHours  Decimal @default(0) @db.Decimal(10, 2)
+  regularAmount Decimal @default(0) @db.Decimal(10, 2)
+  grossPay      Decimal @default(0) @db.Decimal(10, 2)
+
+  // Current-period withholdings. Income tax and "other" default to zero and are
+  // omitted from the printed stub when zero — the business's current stubs
+  // withhold EI and CPP only, but the columns exist so adding tax later is a
+  // form change, not a migration.
+  eiAmount             Decimal @default(0) @db.Decimal(10, 2)
+  cppAmount            Decimal @default(0) @db.Decimal(10, 2)
+  incomeTaxAmount      Decimal @default(0) @db.Decimal(10, 2)
+  otherDeductions      Decimal @default(0) @db.Decimal(10, 2)
+  otherDeductionsLabel String?
+  totalWithholding     Decimal @default(0) @db.Decimal(10, 2)
+  netPay               Decimal @default(0) @db.Decimal(10, 2)
+
+  // Year-to-date totals through and including this stub.
+  ytdHours           Decimal @default(0) @db.Decimal(10, 2)
+  ytdRegularAmount   Decimal @default(0) @db.Decimal(10, 2)
+  ytdGrossPay        Decimal @default(0) @db.Decimal(10, 2)
+  ytdEiAmount        Decimal @default(0) @db.Decimal(10, 2)
+  ytdCppAmount       Decimal @default(0) @db.Decimal(10, 2)
+  ytdIncomeTaxAmount Decimal @default(0) @db.Decimal(10, 2)
+  ytdOtherDeductions Decimal @default(0) @db.Decimal(10, 2)
+  ytdWithholding     Decimal @default(0) @db.Decimal(10, 2)
+  ytdNetPay          Decimal @default(0) @db.Decimal(10, 2)
+
+  notes       String?
+  generatedBy String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  employee User @relation(fields: [employeeId], references: [id])
+
+  @@index([employeeId])
+  @@index([employeeId, payDate])
+  @@index([payDate])
 }
 
 enum PayType {

--- a/server/src/app/app.module.ts
+++ b/server/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { BookingRequestsModule } from '../booking-requests/booking-requests.modu
 import { TireSalesModule } from '../tire-sales/tire-sales.module';
 import { PayoutRulesModule } from '../payout-rules/payout-rules.module';
 import { TimeClockModule } from '../time-clock/time-clock.module';
+import { PayStubsModule } from '../pay-stubs/pay-stubs.module';
 import { InspectionsModule } from '../inspections/inspections.module';
 import { RepairOrdersModule } from '../repair-orders/repair-orders.module';
 import { CarfaxModule } from '../carfax/carfax.module';
@@ -69,6 +70,7 @@ import { RoleGuard } from '../auth/guards/role.guard';
     TireSalesModule,
     PayoutRulesModule,
     TimeClockModule,
+    PayStubsModule,
     InspectionsModule,
     RepairOrdersModule,
     CarfaxModule,

--- a/server/src/pay-stubs/canadian-payroll.spec.ts
+++ b/server/src/pay-stubs/canadian-payroll.spec.ts
@@ -1,7 +1,6 @@
 import {
   calculateDeductions,
   getPayrollRates,
-  inferPayPeriodsPerYear,
   payPeriodLabel,
 } from './canadian-payroll';
 
@@ -226,28 +225,7 @@ describe('canadian payroll deductions', () => {
     });
   });
 
-  describe('pay period inference', () => {
-    const infer = (start: string, end: string) =>
-      inferPayPeriodsPerYear(new Date(start), new Date(end));
-
-    it('reads a week as weekly', () => {
-      expect(infer('2026-01-05', '2026-01-11')).toBe(52);
-    });
-
-    it('reads a fortnight as biweekly', () => {
-      expect(infer('2026-01-05', '2026-01-18')).toBe(26);
-    });
-
-    it('reads a half month as semi-monthly', () => {
-      expect(infer('2026-01-01', '2026-01-15')).toBe(24);
-      expect(infer('2026-01-16', '2026-01-31')).toBe(24);
-    });
-
-    it('reads a calendar month as monthly', () => {
-      expect(infer('2026-01-01', '2026-01-31')).toBe(12);
-      expect(infer('2026-02-01', '2026-02-28')).toBe(12);
-    });
-
+  describe('pay frequency labels', () => {
     it('labels each frequency', () => {
       expect(payPeriodLabel(52)).toBe('Weekly');
       expect(payPeriodLabel(26)).toBe('Biweekly');

--- a/server/src/pay-stubs/canadian-payroll.spec.ts
+++ b/server/src/pay-stubs/canadian-payroll.spec.ts
@@ -1,0 +1,258 @@
+import {
+  calculateDeductions,
+  getPayrollRates,
+  inferPayPeriodsPerYear,
+  payPeriodLabel,
+} from './canadian-payroll';
+
+/**
+ * These lock the calculator to the CRA's published 2026 figures (T4127, 122nd
+ * edition). Where the guide shows its own arithmetic, the expected values below
+ * are the guide's, not this implementation's — so a wrong refactor fails
+ * against the CRA rather than against itself.
+ */
+describe('canadian payroll deductions', () => {
+  const base = {
+    payPeriodsPerYear: 52,
+    ytdCpp: 0,
+    ytdEi: 0,
+    ytdGrossPay: 0,
+    province: 'BC' as const,
+    taxYear: 2026,
+  };
+
+  describe('rate tables', () => {
+    it('has the 2026 CRA figures for BC', () => {
+      const rates = getPayrollRates('BC', 2026);
+      expect(rates?.cpp.ympe).toBe(74600);
+      expect(rates?.cpp.yampe).toBe(85000);
+      expect(rates?.cpp.employeeRate).toBe(0.0595);
+      expect(rates?.cpp.maxEmployeeContribution).toBe(4230.45);
+      expect(rates?.cpp.maxCpp2Contribution).toBe(416);
+      expect(rates?.ei.employeeRate).toBe(0.0163);
+      expect(rates?.ei.maxInsurableEarnings).toBe(68900);
+      expect(rates?.ei.maxAnnualPremium).toBe(1123.07);
+      expect(rates?.federal.lowestRate).toBe(0.14);
+      expect(rates?.federal.basicPersonalAmount.max).toBe(16452);
+      expect(rates?.provincial.basicPersonalAmount).toBe(13216);
+    });
+
+    it('refuses to guess a year it has no table for', () => {
+      expect(getPayrollRates('BC', 2027)).toBeUndefined();
+      expect(
+        calculateDeductions({ ...base, grossPay: 1000, taxYear: 2027 })
+      ).toBeUndefined();
+    });
+  });
+
+  describe('CPP (T4127 factor C)', () => {
+    // T4127 worked example: C = 0.0595 × ($3,500 − ($3,500/52)) = $204.25.
+    it('matches the CRA worked example for weekly pensionable income of $3,500', () => {
+      const result = calculateDeductions({ ...base, grossPay: 3500 });
+      expect(result?.cpp).toBe(204.25);
+    });
+
+    // Second T4127 worked example: 0.0595 × ($3,600 − $67.30) = $210.20.
+    it('matches the CRA worked example for weekly pensionable income of $3,600', () => {
+      const result = calculateDeductions({ ...base, grossPay: 3600 });
+      expect(result?.cpp).toBe(210.2);
+    });
+
+    it('applies the per-period basic exemption', () => {
+      // $1,000 weekly: 0.0595 × (1000 − 67.30) = $55.50, as in the guide.
+      expect(calculateDeductions({ ...base, grossPay: 1000 })?.cpp).toBe(55.5);
+    });
+
+    it('stops at the annual maximum once reached', () => {
+      const result = calculateDeductions({
+        ...base,
+        grossPay: 2000,
+        ytdCpp: 4200,
+        ytdGrossPay: 70000,
+      });
+      // Only $30.45 of room left in the $4,230.45 annual maximum.
+      expect(result?.cpp).toBe(30.45);
+      expect(result?.cppMaxedOut).toBe(true);
+    });
+
+    it('charges CPP2 on earnings above the YMPE', () => {
+      const result = calculateDeductions({
+        ...base,
+        grossPay: 2000,
+        ytdCpp: 4230.45,
+        ytdGrossPay: 75000,
+      });
+      // All $2,000 sits above the $74,600 ceiling, so CPP2 takes 4% of it.
+      expect(result?.cpp2).toBe(80);
+      // The recorded YTD is a single figure, so the $16 of CPP2 implied by
+      // $75,000 of earnings is carved out of it, leaving $16 of base room.
+      expect(result?.cpp).toBe(96);
+    });
+
+    it('caps CPP2 at its own annual maximum', () => {
+      const result = calculateDeductions({
+        ...base,
+        grossPay: 5000,
+        ytdCpp: 4630.45,
+        ytdGrossPay: 84000,
+      });
+      // $84,000 of earnings implies $376 of CPP2 already taken, so only $40 of
+      // the $416 maximum is left — less than 4% of the $1,000 of band remaining.
+      expect(result?.cpp2).toBe(40);
+    });
+  });
+
+  describe('EI (T4127 Chapter 7)', () => {
+    it('is the employee rate on the period’s earnings', () => {
+      expect(calculateDeductions({ ...base, grossPay: 1000 })?.ei).toBe(16.3);
+    });
+
+    it('takes only the remainder of the annual maximum in the final period', () => {
+      const result = calculateDeductions({
+        ...base,
+        grossPay: 1000,
+        ytdEi: 1113.07,
+      });
+      expect(result?.ei).toBe(10);
+      expect(result?.eiMaxedOut).toBe(true);
+    });
+
+    it('never exceeds the annual maximum', () => {
+      const result = calculateDeductions({
+        ...base,
+        grossPay: 1000,
+        ytdEi: 1123.07,
+      });
+      expect(result?.ei).toBe(0);
+    });
+  });
+
+  describe('income tax', () => {
+    it('splits a full year of federal and BC tax across the pay periods', () => {
+      const result = calculateDeductions({ ...base, grossPay: 1000 });
+
+      // Annualized: 52 × ($1,000 − $9.33 enhanced CPP) = $51,514.84.
+      expect(result?.annualTaxableIncome).toBeCloseTo(51514.84, 2);
+      expect(result?.federalTax).toBeCloseTo(81.61, 2);
+      expect(result?.provincialTax).toBeCloseTo(34.69, 2);
+      expect(result?.incomeTax).toBeCloseTo(116.3, 2);
+    });
+
+    it('reports a breakdown that adds up to the total withheld', () => {
+      for (const grossPay of [850, 1000, 1234.56, 2500, 4000]) {
+        const result = calculateDeductions({ ...base, grossPay });
+        expect(
+          (result?.federalTax ?? 0) + (result?.provincialTax ?? 0)
+        ).toBeCloseTo(result?.incomeTax ?? 0, 10);
+      }
+    });
+
+    it('deducts no tax when annual income is under the personal amounts', () => {
+      // $300 weekly is $15,600 a year — below both basic personal amounts.
+      const result = calculateDeductions({ ...base, grossPay: 300 });
+      expect(result?.incomeTax).toBe(0);
+    });
+
+    it('applies the BC tax reduction inside its phase-out band', () => {
+      // $600 weekly annualizes to ~$30,900 — inside the factor-S band, so BC
+      // tax is cut by $575 − 3.56% of the excess over $25,570 (a $384 credit
+      // on $801 of BC tax, leaving $8.01 a week).
+      const reduced = calculateDeductions({ ...base, grossPay: 600 });
+      expect(reduced?.provincialTax).toBeCloseTo(8.01, 2);
+
+      // Past the $41,722 cut-off the credit is gone: BC tax is then the plain
+      // bracket calculation less the personal-amount credits.
+      const above = calculateDeductions({ ...base, grossPay: 830 });
+      expect(above?.annualTaxableIncome).toBeGreaterThan(41722);
+      expect(above?.provincialTax).toBeCloseTo(26.15, 2);
+    });
+
+    it('reaches the higher federal brackets on large salaries', () => {
+      const monthly = calculateDeductions({
+        ...base,
+        payPeriodsPerYear: 12,
+        grossPay: 20000,
+      });
+      expect(monthly?.annualTaxableIncome).toBeGreaterThan(200000);
+      // Well into the 29% federal bracket, so the average rate is high.
+      expect((monthly?.incomeTax ?? 0) / 20000).toBeGreaterThan(0.3);
+    });
+
+    it('tapers the federal basic personal amount on high incomes', () => {
+      const rates = getPayrollRates('BC', 2026);
+      const low = calculateDeductions({
+        ...base,
+        payPeriodsPerYear: 12,
+        grossPay: 15000,
+      });
+      const high = calculateDeductions({
+        ...base,
+        payPeriodsPerYear: 12,
+        grossPay: 25000,
+      });
+      // Both above the phase-out start; the higher earner gets the smaller BPA,
+      // so the extra tax exceeds the plain bracket difference.
+      expect(rates?.federal.basicPersonalAmount.min).toBe(14829);
+      expect(high?.incomeTax ?? 0).toBeGreaterThan(low?.incomeTax ?? 0);
+    });
+  });
+
+  describe('guards', () => {
+    it('returns zeros for a zero gross', () => {
+      const result = calculateDeductions({ ...base, grossPay: 0 });
+      expect(result).toEqual({
+        ei: 0,
+        cpp: 0,
+        cpp2: 0,
+        incomeTax: 0,
+        federalTax: 0,
+        provincialTax: 0,
+        annualTaxableIncome: 0,
+        cppMaxedOut: false,
+        eiMaxedOut: false,
+      });
+    });
+
+    it('never returns a negative deduction', () => {
+      const result = calculateDeductions({
+        ...base,
+        grossPay: 50,
+        ytdCpp: 4230.45,
+        ytdEi: 1123.07,
+      });
+      expect(result?.cpp).toBe(0);
+      expect(result?.ei).toBe(0);
+      expect(result?.incomeTax).toBe(0);
+    });
+  });
+
+  describe('pay period inference', () => {
+    const infer = (start: string, end: string) =>
+      inferPayPeriodsPerYear(new Date(start), new Date(end));
+
+    it('reads a week as weekly', () => {
+      expect(infer('2026-01-05', '2026-01-11')).toBe(52);
+    });
+
+    it('reads a fortnight as biweekly', () => {
+      expect(infer('2026-01-05', '2026-01-18')).toBe(26);
+    });
+
+    it('reads a half month as semi-monthly', () => {
+      expect(infer('2026-01-01', '2026-01-15')).toBe(24);
+      expect(infer('2026-01-16', '2026-01-31')).toBe(24);
+    });
+
+    it('reads a calendar month as monthly', () => {
+      expect(infer('2026-01-01', '2026-01-31')).toBe(12);
+      expect(infer('2026-02-01', '2026-02-28')).toBe(12);
+    });
+
+    it('labels each frequency', () => {
+      expect(payPeriodLabel(52)).toBe('Weekly');
+      expect(payPeriodLabel(26)).toBe('Biweekly');
+      expect(payPeriodLabel(24)).toBe('Semi-monthly');
+      expect(payPeriodLabel(12)).toBe('Monthly');
+    });
+  });
+});

--- a/server/src/pay-stubs/canadian-payroll.ts
+++ b/server/src/pay-stubs/canadian-payroll.ts
@@ -1,0 +1,447 @@
+/**
+ * Statutory payroll deductions for a pay period — CPP, EI and income tax.
+ *
+ * This implements the CRA's own withholding formulas (T4127 Payroll Deductions
+ * Formulas, 122nd edition, effective January 1 2026), not an approximation of
+ * them. The published tables (T4032) are generated from these same formulas, so
+ * the figures here should agree with them to the cent.
+ *
+ * Two deliberate limits, both surfaced to the accountant rather than hidden:
+ *
+ *  - Rates are stored per tax year and nothing is extrapolated. Payroll rates
+ *    change every January, and a plausible-looking figure computed from last
+ *    year's numbers is worse than a blank box, because nobody checks a filled
+ *    field. A year with no table returns `supported: false`.
+ *  - The employee's TD1 claim amounts are not on file, so the basic personal
+ *    amounts are assumed (claim code 1). An employee claiming dependants or
+ *    tuition is over-deducted, which the accountant fixes by typing over the
+ *    suggested tax.
+ *
+ * Everything here is pure arithmetic: no dates, no I/O, no database.
+ */
+
+/** Provinces this calculator has rate tables for. The shop operates in BC. */
+export type SupportedProvince = 'BC';
+
+export interface PayrollRates {
+  year: number;
+  cpp: {
+    /** Year's Maximum Pensionable Earnings. */
+    ympe: number;
+    /** Year's Additional Maximum Pensionable Earnings (the CPP2 ceiling). */
+    yampe: number;
+    basicExemption: number;
+    /** Employee rate on earnings up to the YMPE (base + first additional). */
+    employeeRate: number;
+    /** The base portion of the employee rate — the only part that is a tax credit. */
+    baseRate: number;
+    maxEmployeeContribution: number;
+    maxBaseContribution: number;
+    cpp2Rate: number;
+    maxCpp2Contribution: number;
+  };
+  ei: {
+    maxInsurableEarnings: number;
+    employeeRate: number;
+    maxAnnualPremium: number;
+  };
+  federal: {
+    /** Ascending bracket floors with their rate (R) and constant (K). */
+    brackets: { floor: number; rate: number; constant: number }[];
+    lowestRate: number;
+    canadaEmploymentAmount: number;
+    /** The income-tested federal basic personal amount (BPAF). */
+    basicPersonalAmount: {
+      max: number;
+      min: number;
+      phaseOutStart: number;
+      phaseOutEnd: number;
+    };
+  };
+  provincial: {
+    /** Ascending bracket floors with their rate (V) and constant (KP). */
+    brackets: { floor: number; rate: number; constant: number }[];
+    lowestRate: number;
+    basicPersonalAmount: number;
+    /** BC tax reduction (factor S). */
+    taxReduction: {
+      max: number;
+      phaseOutStart: number;
+      phaseOutEnd: number;
+      rate: number;
+    };
+  };
+}
+
+/**
+ * 2026 rates — CRA T4127 (122nd edition, January 1 2026), Chapter 8.
+ *
+ * To add a year: copy this block, replace every figure from the new edition of
+ * T4127 (Tables 8.1-8.7 plus the BPAF and provincial factor-S formulas) and
+ * register it below. Do not index or extrapolate the old numbers.
+ */
+const RATES_BC_2026: PayrollRates = {
+  year: 2026,
+  cpp: {
+    ympe: 74600,
+    yampe: 85000,
+    basicExemption: 3500,
+    employeeRate: 0.0595,
+    baseRate: 0.0495,
+    maxEmployeeContribution: 4230.45,
+    maxBaseContribution: 3519.45,
+    cpp2Rate: 0.04,
+    maxCpp2Contribution: 416,
+  },
+  ei: {
+    maxInsurableEarnings: 68900,
+    employeeRate: 0.0163,
+    maxAnnualPremium: 1123.07,
+  },
+  federal: {
+    brackets: [
+      { floor: 0, rate: 0.14, constant: 0 },
+      { floor: 58523, rate: 0.205, constant: 3804 },
+      { floor: 117045, rate: 0.26, constant: 10241 },
+      { floor: 181440, rate: 0.29, constant: 15685 },
+      { floor: 258482, rate: 0.33, constant: 26024 },
+    ],
+    lowestRate: 0.14,
+    canadaEmploymentAmount: 1501,
+    basicPersonalAmount: {
+      max: 16452,
+      min: 14829,
+      phaseOutStart: 181440,
+      phaseOutEnd: 258482,
+    },
+  },
+  provincial: {
+    brackets: [
+      { floor: 0, rate: 0.0506, constant: 0 },
+      { floor: 50363, rate: 0.077, constant: 1330 },
+      { floor: 100728, rate: 0.105, constant: 4150 },
+      { floor: 115648, rate: 0.1229, constant: 6220 },
+      { floor: 140430, rate: 0.147, constant: 9604 },
+      { floor: 190405, rate: 0.168, constant: 13603 },
+      { floor: 265545, rate: 0.205, constant: 23428 },
+    ],
+    lowestRate: 0.0506,
+    basicPersonalAmount: 13216,
+    taxReduction: {
+      max: 575,
+      phaseOutStart: 25570,
+      phaseOutEnd: 41722,
+      rate: 0.0356,
+    },
+  },
+};
+
+const RATE_TABLES: Record<string, PayrollRates> = {
+  'BC:2026': RATES_BC_2026,
+};
+
+export const getPayrollRates = (
+  province: SupportedProvince,
+  year: number
+): PayrollRates | undefined => RATE_TABLES[`${province}:${year}`];
+
+/** The tax years that have a rate table, oldest first. */
+export const supportedTaxYears = (province: SupportedProvince): number[] =>
+  Object.values(RATE_TABLES)
+    .filter((rates) => RATE_TABLES[`${province}:${rates.year}`] === rates)
+    .map((rates) => rates.year)
+    .sort((a, b) => a - b);
+
+export interface DeductionInput {
+  /** Gross pay for this period (factor I). */
+  grossPay: number;
+  /** Pay periods in the year (factor P) — 52, 26, 24 or 12. */
+  payPeriodsPerYear: number;
+  /** CPP already withheld this year, base + first + second additional. */
+  ytdCpp: number;
+  /** EI already withheld this year (factor D1). */
+  ytdEi: number;
+  /** Gross pay already paid this year, used for the CPP2 ceiling. */
+  ytdGrossPay: number;
+  province: SupportedProvince;
+  taxYear: number;
+}
+
+export interface DeductionEstimate {
+  ei: number;
+  /** Total CPP for the period: base + first additional + CPP2. */
+  cpp: number;
+  /** The CPP2 slice of `cpp`, non-zero only above the YMPE. */
+  cpp2: number;
+  incomeTax: number;
+  federalTax: number;
+  provincialTax: number;
+  /** Annualized taxable income (factor A) the tax was derived from. */
+  annualTaxableIncome: number;
+  /** True once this period's CPP or EI hits the annual maximum. */
+  cppMaxedOut: boolean;
+  eiMaxedOut: boolean;
+}
+
+/** CRA rounding: half up to the cent. */
+const round2 = (value: number) =>
+  Math.round((value + Number.EPSILON) * 100) / 100;
+
+/** CRA truncation, used for the per-period CPP basic exemption. */
+const truncate2 = (value: number) => Math.floor(value * 100) / 100;
+
+const atLeastZero = (value: number) => (value > 0 ? value : 0);
+
+const bracketFor = (
+  brackets: { floor: number; rate: number; constant: number }[],
+  income: number
+) => {
+  let match = brackets[0];
+  for (const bracket of brackets) {
+    if (income >= bracket.floor) match = bracket;
+  }
+  return match;
+};
+
+/**
+ * The pay periods per year implied by a period's length.
+ *
+ * The CRA formulas need the employer's actual pay frequency, which the system
+ * does not record, so it is inferred from the period the accountant selected by
+ * picking the frequency whose nominal length is closest. Weekly, biweekly,
+ * semi-monthly and monthly are the only ones offered; anything unusual lands on
+ * the nearest of those and is shown to the accountant so a wrong guess is
+ * visible rather than silent.
+ */
+export const inferPayPeriodsPerYear = (
+  periodStart: Date,
+  periodEnd: Date
+): number => {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const days =
+    Math.round((periodEnd.getTime() - periodStart.getTime()) / msPerDay) + 1;
+  if (!Number.isFinite(days) || days <= 0) return 26;
+
+  const candidates = [52, 26, 24, 12];
+  return candidates.reduce((best, candidate) =>
+    Math.abs(365 / candidate - days) < Math.abs(365 / best - days)
+      ? candidate
+      : best
+  );
+};
+
+/** Human label for a pay frequency, for the accountant to sanity check. */
+export const payPeriodLabel = (payPeriodsPerYear: number): string =>
+  ({
+    52: 'Weekly',
+    26: 'Biweekly',
+    24: 'Semi-monthly',
+    12: 'Monthly',
+  }[payPeriodsPerYear] ?? `${payPeriodsPerYear} pay periods per year`);
+
+/**
+ * EI premium for the period (T4127 Chapter 7).
+ *
+ * EI = lesser of (annual maximum − withheld so far) and (rate × insurable
+ * earnings), so the last premium of the year is the exact remainder.
+ */
+const calculateEi = (input: DeductionInput, rates: PayrollRates) => {
+  const remaining = atLeastZero(rates.ei.maxAnnualPremium - input.ytdEi);
+  const premium = round2(rates.ei.employeeRate * input.grossPay);
+  const ei = round2(Math.min(remaining, premium));
+  return { ei, maxedOut: ei < premium };
+};
+
+/**
+ * CPP contributions for the period (T4127 Chapter 6, factors C and C2).
+ *
+ * The stored YTD figure is a single combined number, so the CPP2 already
+ * withheld is reconstructed from year-to-date earnings — CPP2 only applies
+ * above the YMPE, so for anyone under that ceiling this is exactly zero and the
+ * whole YTD amount is base + first additional, as it should be.
+ */
+const calculateCpp = (input: DeductionInput, rates: PayrollRates) => {
+  const { cpp } = rates;
+  const periodExemption = truncate2(
+    cpp.basicExemption / input.payPeriodsPerYear
+  );
+
+  const ytdCpp2 = round2(
+    cpp.cpp2Rate *
+      atLeastZero(Math.min(input.ytdGrossPay, cpp.yampe) - cpp.ympe)
+  );
+  const ytdBaseCpp = atLeastZero(input.ytdCpp - ytdCpp2);
+
+  // C — base + first additional, on earnings up to the YMPE.
+  const contributory = atLeastZero(input.grossPay - periodExemption);
+  const uncapped = round2(cpp.employeeRate * contributory);
+  const roomLeft = atLeastZero(cpp.maxEmployeeContribution - ytdBaseCpp);
+  const c = round2(Math.min(roomLeft, uncapped));
+
+  // C2 — 4% of the slice of earnings between the YMPE and the YAMPE.
+  const ceiling = Math.max(input.ytdGrossPay, cpp.ympe);
+  const cpp2Earnings = atLeastZero(
+    Math.min(input.ytdGrossPay + input.grossPay, cpp.yampe) - ceiling
+  );
+  const cpp2Room = atLeastZero(cpp.maxCpp2Contribution - ytdCpp2);
+  const c2 = round2(Math.min(cpp2Room, round2(cpp.cpp2Rate * cpp2Earnings)));
+
+  return {
+    c,
+    c2,
+    total: round2(c + c2),
+    maxedOut: c < uncapped,
+  };
+};
+
+/**
+ * The federal basic personal amount (BPAF), which tapers away over the top two
+ * brackets.
+ */
+const basicPersonalAmount = (annualIncome: number, rates: PayrollRates) => {
+  const bpa = rates.federal.basicPersonalAmount;
+  if (annualIncome <= bpa.phaseOutStart) return bpa.max;
+  if (annualIncome >= bpa.phaseOutEnd) return bpa.min;
+  const taper =
+    ((annualIncome - bpa.phaseOutStart) * (bpa.max - bpa.min)) /
+    (bpa.phaseOutEnd - bpa.phaseOutStart);
+  return round2(bpa.max - taper);
+};
+
+/**
+ * The BC tax reduction (factor S) — a credit for low incomes that tapers to
+ * nothing, and can never exceed the provincial tax itself.
+ */
+const bcTaxReduction = (
+  annualIncome: number,
+  provincialTaxBeforeReduction: number,
+  rates: PayrollRates
+) => {
+  const reduction = rates.provincial.taxReduction;
+  if (annualIncome > reduction.phaseOutEnd) return 0;
+  const available =
+    annualIncome <= reduction.phaseOutStart
+      ? reduction.max
+      : reduction.max -
+        (annualIncome - reduction.phaseOutStart) * reduction.rate;
+  return atLeastZero(Math.min(provincialTaxBeforeReduction, available));
+};
+
+/**
+ * Income tax for the period (T4127 Chapter 5).
+ *
+ * The method is: annualize this period's pay, work out a whole year's federal
+ * and provincial tax on it, then divide back down by the number of pay periods.
+ * That is why a raise mid-year changes the tax on every later stub — each
+ * period is taxed as though the employee earned at that rate all year.
+ */
+const calculateIncomeTax = (
+  input: DeductionInput,
+  rates: PayrollRates,
+  cpp: { c: number; c2: number },
+  ei: number
+) => {
+  const p = input.payPeriodsPerYear;
+
+  // F5 — the enhanced portion of CPP (first additional + CPP2) is deducted
+  // from income, unlike the base portion which is a credit further down.
+  const f5 = round2(
+    cpp.c *
+      ((rates.cpp.employeeRate - rates.cpp.baseRate) / rates.cpp.employeeRate) +
+      cpp.c2
+  );
+
+  // A — annual taxable income.
+  const a = atLeastZero(round2(p * (input.grossPay - f5)));
+
+  // K2 — the CPP (base portion only) and EI credits, each capped at the
+  // year's maximum so a part-year employee is not over-credited.
+  const annualBaseCpp = Math.min(
+    p * cpp.c * (rates.cpp.baseRate / rates.cpp.employeeRate),
+    rates.cpp.maxBaseContribution
+  );
+  const annualEi = Math.min(p * ei, rates.ei.maxAnnualPremium);
+
+  // Federal.
+  const federalBracket = bracketFor(rates.federal.brackets, a);
+  const k1 = rates.federal.lowestRate * basicPersonalAmount(a, rates);
+  const k2 =
+    rates.federal.lowestRate * annualBaseCpp +
+    rates.federal.lowestRate * annualEi;
+  const k4 =
+    rates.federal.lowestRate *
+    Math.min(a, rates.federal.canadaEmploymentAmount);
+  const federalTax = atLeastZero(
+    federalBracket.rate * a - federalBracket.constant - k1 - k2 - k4
+  );
+
+  // Provincial.
+  const provincialBracket = bracketFor(rates.provincial.brackets, a);
+  const k1p =
+    rates.provincial.lowestRate * rates.provincial.basicPersonalAmount;
+  const k2p =
+    rates.provincial.lowestRate * annualBaseCpp +
+    rates.provincial.lowestRate * annualEi;
+  const provincialBeforeReduction = atLeastZero(
+    provincialBracket.rate * a - provincialBracket.constant - k1p - k2p
+  );
+  const provincialTax = atLeastZero(
+    provincialBeforeReduction -
+      bcTaxReduction(a, provincialBeforeReduction, rates)
+  );
+
+  // The CRA rounds the combined deduction, not each half, so that is the
+  // authoritative figure. The breakdown is then made to add up to it exactly —
+  // an accountant checking the split should not find it a cent out.
+  const periodTax = round2((federalTax + provincialTax) / p);
+  const periodFederal = round2(federalTax / p);
+
+  return {
+    annualTaxableIncome: a,
+    federalTax: periodFederal,
+    provincialTax: round2(periodTax - periodFederal),
+    incomeTax: periodTax,
+  };
+};
+
+/**
+ * Suggested statutory deductions for one pay period.
+ *
+ * Returns undefined when there is no rate table for the tax year — the caller
+ * must then leave the fields blank rather than fall back to another year.
+ */
+export const calculateDeductions = (
+  input: DeductionInput
+): DeductionEstimate | undefined => {
+  const rates = getPayrollRates(input.province, input.taxYear);
+  if (!rates) return undefined;
+  if (!(input.grossPay > 0)) {
+    return {
+      ei: 0,
+      cpp: 0,
+      cpp2: 0,
+      incomeTax: 0,
+      federalTax: 0,
+      provincialTax: 0,
+      annualTaxableIncome: 0,
+      cppMaxedOut: false,
+      eiMaxedOut: false,
+    };
+  }
+
+  const ei = calculateEi(input, rates);
+  const cpp = calculateCpp(input, rates);
+  const tax = calculateIncomeTax(input, rates, cpp, ei.ei);
+
+  return {
+    ei: ei.ei,
+    cpp: cpp.total,
+    cpp2: cpp.c2,
+    incomeTax: tax.incomeTax,
+    federalTax: tax.federalTax,
+    provincialTax: tax.provincialTax,
+    annualTaxableIncome: tax.annualTaxableIncome,
+    cppMaxedOut: cpp.maxedOut,
+    eiMaxedOut: ei.maxedOut,
+  };
+};

--- a/server/src/pay-stubs/canadian-payroll.ts
+++ b/server/src/pay-stubs/canadian-payroll.ts
@@ -145,13 +145,6 @@ export const getPayrollRates = (
   year: number
 ): PayrollRates | undefined => RATE_TABLES[`${province}:${year}`];
 
-/** The tax years that have a rate table, oldest first. */
-export const supportedTaxYears = (province: SupportedProvince): number[] =>
-  Object.values(RATE_TABLES)
-    .filter((rates) => RATE_TABLES[`${province}:${rates.year}`] === rates)
-    .map((rates) => rates.year)
-    .sort((a, b) => a - b);
-
 export interface DeductionInput {
   /** Gross pay for this period (factor I). */
   grossPay: number;
@@ -201,33 +194,6 @@ const bracketFor = (
     if (income >= bracket.floor) match = bracket;
   }
   return match;
-};
-
-/**
- * The pay periods per year implied by a period's length.
- *
- * The CRA formulas need the employer's actual pay frequency, which the system
- * does not record, so it is inferred from the period the accountant selected by
- * picking the frequency whose nominal length is closest. Weekly, biweekly,
- * semi-monthly and monthly are the only ones offered; anything unusual lands on
- * the nearest of those and is shown to the accountant so a wrong guess is
- * visible rather than silent.
- */
-export const inferPayPeriodsPerYear = (
-  periodStart: Date,
-  periodEnd: Date
-): number => {
-  const msPerDay = 24 * 60 * 60 * 1000;
-  const days =
-    Math.round((periodEnd.getTime() - periodStart.getTime()) / msPerDay) + 1;
-  if (!Number.isFinite(days) || days <= 0) return 26;
-
-  const candidates = [52, 26, 24, 12];
-  return candidates.reduce((best, candidate) =>
-    Math.abs(365 / candidate - days) < Math.abs(365 / best - days)
-      ? candidate
-      : best
-  );
 };
 
 /** Human label for a pay frequency, for the accountant to sanity check. */

--- a/server/src/pay-stubs/pay-stubs.controller.ts
+++ b/server/src/pay-stubs/pay-stubs.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { CreatePayStubDto } from '@gt-automotive/data';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RoleGuard } from '../auth/guards/role.guard';
+import { PayStubsService } from './pay-stubs.service';
+
+@Controller('pay-stubs')
+@UseGuards(RoleGuard)
+export class PayStubsController {
+  constructor(private readonly payStubsService: PayStubsService) {}
+
+  /** Raise a pay stub. Accountants and admins only. */
+  @Post()
+  @Roles('ADMIN', 'ACCOUNTANT')
+  create(@Body() dto: CreatePayStubDto, @CurrentUser() user: any) {
+    return this.payStubsService.create(dto, user.id);
+  }
+
+  /** Every pay stub, optionally filtered to one employee. Payroll roles only. */
+  @Get()
+  @Roles('ADMIN', 'ACCOUNTANT')
+  findAll(@CurrentUser() user: any, @Query('employeeId') employeeId?: string) {
+    return this.payStubsService.findAll(user, employeeId);
+  }
+
+  /**
+   * The signed-in employee's own pay stubs. Open to every payroll-eligible
+   * role because it can only ever return the caller's own records.
+   */
+  @Get('mine')
+  @Roles('ADMIN', 'ACCOUNTANT', 'FOREMAN', 'SUPERVISOR', 'STAFF')
+  findMine(@CurrentUser() user: any) {
+    return this.payStubsService.findForEmployee(user.id, user);
+  }
+
+  @Get('employees/:employeeId')
+  @Roles('ADMIN', 'ACCOUNTANT', 'FOREMAN', 'SUPERVISOR', 'STAFF')
+  findForEmployee(
+    @Param('employeeId') employeeId: string,
+    @CurrentUser() user: any
+  ) {
+    return this.payStubsService.findForEmployee(employeeId, user);
+  }
+
+  @Get(':id')
+  @Roles('ADMIN', 'ACCOUNTANT', 'FOREMAN', 'SUPERVISOR', 'STAFF')
+  findOne(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.payStubsService.findOne(id, user);
+  }
+
+  /**
+   * The stub as a PDF, rendered on demand. This is the only place the document
+   * is produced — the on-screen view and the print action both display this
+   * response, so there is a single template and nothing to drift.
+   *
+   * The service re-checks ownership, so an employee cannot fetch a colleague's
+   * stub by guessing an id.
+   */
+  @Get(':id/pdf')
+  @Roles('ADMIN', 'ACCOUNTANT', 'FOREMAN', 'SUPERVISOR', 'STAFF')
+  async getPdf(
+    @Param('id') id: string,
+    @CurrentUser() user: any,
+    @Res() res: Response
+  ) {
+    const [pdf, filename] = await Promise.all([
+      this.payStubsService.generatePdf(id, user),
+      this.payStubsService.getPdfFilename(id, user),
+    ]);
+
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
+    res.setHeader('Content-Length', pdf.length);
+    // Pay data must not sit in a shared or browser cache.
+    res.setHeader('Cache-Control', 'private, no-store');
+    res.end(pdf);
+  }
+}

--- a/server/src/pay-stubs/pay-stubs.controller.ts
+++ b/server/src/pay-stubs/pay-stubs.controller.ts
@@ -3,13 +3,18 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Res,
   UseGuards,
 } from '@nestjs/common';
 import type { Response } from 'express';
-import { CreatePayStubDto } from '@gt-automotive/data';
+import {
+  CreatePayStubDto,
+  PayStubDeductionEstimateRequestDto,
+  UpdatePayStubDto,
+} from '@gt-automotive/data';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RoleGuard } from '../auth/guards/role.guard';
@@ -25,6 +30,33 @@ export class PayStubsController {
   @Roles('ADMIN', 'ACCOUNTANT')
   create(@Body() dto: CreatePayStubDto, @CurrentUser() user: any) {
     return this.payStubsService.create(dto, user.id);
+  }
+
+  /**
+   * Correct an issued stub. Accountants and admins only — the same people who
+   * raise them. The amendment is audited with the figures before and after.
+   */
+  @Patch(':id')
+  @Roles('ADMIN', 'ACCOUNTANT')
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdatePayStubDto,
+    @CurrentUser() user: any
+  ) {
+    return this.payStubsService.update(id, dto, user.id);
+  }
+
+  /**
+   * Suggested CPP, EI and income tax for a gross the accountant is about to
+   * enter. Read-only: nothing is stored, and the caller is free to ignore it.
+   *
+   * A POST because it needs a body and depends on the employee's year-to-date
+   * withholding, which is not something to put in a cacheable URL.
+   */
+  @Post('deduction-estimate')
+  @Roles('ADMIN', 'ACCOUNTANT')
+  estimateDeductions(@Body() dto: PayStubDeductionEstimateRequestDto) {
+    return this.payStubsService.estimateDeductions(dto);
   }
 
   /** Every pay stub, optionally filtered to one employee. Payroll roles only. */

--- a/server/src/pay-stubs/pay-stubs.module.ts
+++ b/server/src/pay-stubs/pay-stubs.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from '@gt-automotive/database';
+import { AuditRepository } from '../audit/repositories/audit.repository';
+import { PdfModule } from '../pdf/pdf.module';
+import { PayStubsController } from './pay-stubs.controller';
+import { PayStubsService } from './pay-stubs.service';
+
+@Module({
+  imports: [PdfModule],
+  controllers: [PayStubsController],
+  providers: [PayStubsService, PrismaService, AuditRepository],
+  exports: [PayStubsService],
+})
+export class PayStubsModule {}

--- a/server/src/pay-stubs/pay-stubs.service.spec.ts
+++ b/server/src/pay-stubs/pay-stubs.service.spec.ts
@@ -1,0 +1,234 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { PayStubsService } from './pay-stubs.service';
+
+/**
+ * Unit tests for PayStubsService.
+ *
+ * The two things worth guarding here are the ones a pay record cannot get
+ * wrong: the derived totals must be computed server-side rather than trusted
+ * from the client, and year-to-date must accumulate across the calendar year.
+ */
+describe('PayStubsService', () => {
+  let service: PayStubsService;
+  let prisma: any;
+  let pdfService: any;
+  let auditRepository: any;
+
+  const employee = {
+    id: 'emp-1',
+    firstName: 'Rohit',
+    lastName: 'Toora',
+    email: 'rohit@example.com',
+    role: { name: 'STAFF' },
+  };
+
+  const accountant = { id: 'acc-1', role: { name: 'ACCOUNTANT' } };
+
+  const baseDto = {
+    employeeId: 'emp-1',
+    periodStart: '2026-01-05',
+    periodEnd: '2026-01-31',
+    payDate: '2026-01-31',
+    position: 'Business Manager',
+    payRate: 24,
+    regularHours: 128,
+    regularAmount: 3072,
+    eiAmount: 50.08,
+    cppAmount: 166.96,
+  };
+
+  beforeEach(() => {
+    prisma = {
+      user: { findUnique: jest.fn().mockResolvedValue(employee) },
+      company: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'co-1',
+          name: 'GT Automotive',
+          address: '2983 Nicole Ave, Prince George, BC',
+          isDefault: true,
+        }),
+      },
+      employeeCompensation: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValue({ payType: 'HOURLY', hourlyRate: 24 }),
+      },
+      payStub: {
+        create: jest.fn((args: any) => ({
+          id: 'stub-1',
+          createdAt: new Date('2026-01-31T00:00:00.000Z'),
+          employee,
+          ...args.data,
+        })),
+        findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn(),
+      },
+    };
+    pdfService = {
+      generatePayStubHtml: jest.fn().mockReturnValue('<html></html>'),
+      generatePdfFromHtml: jest.fn().mockResolvedValue(Buffer.from('pdf')),
+    };
+    auditRepository = { create: jest.fn() };
+
+    service = new PayStubsService(prisma, pdfService, auditRepository);
+  });
+
+  describe('create', () => {
+    it('derives withholding total and net pay rather than trusting the client', async () => {
+      const result = await service.create(baseDto as any, accountant.id);
+
+      expect(result.grossPay).toBe(3072);
+      expect(result.totalWithholding).toBe(217.04);
+      expect(result.netPay).toBe(2854.96);
+    });
+
+    it('snapshots the company header and employee name onto the stub', async () => {
+      const result = await service.create(baseDto as any, accountant.id);
+
+      expect(result.companyName).toBe('GT Automotive');
+      expect(result.companyAddress).toBe('2983 Nicole Ave, Prince George, BC');
+      expect(result.employeeName).toBe('Rohit Toora');
+      expect(result.position).toBe('Business Manager');
+    });
+
+    it('accumulates year-to-date across earlier stubs in the same year', async () => {
+      // January's stub already exists; February's must carry the running total.
+      prisma.payStub.findMany.mockResolvedValue([
+        {
+          regularHours: 128,
+          regularAmount: 3072,
+          grossPay: 3072,
+          eiAmount: 50.08,
+          cppAmount: 166.96,
+          incomeTaxAmount: 0,
+          otherDeductions: 0,
+          totalWithholding: 217.04,
+          netPay: 2854.96,
+        },
+      ]);
+
+      const result = await service.create(
+        {
+          ...baseDto,
+          periodStart: '2026-02-01',
+          periodEnd: '2026-02-28',
+          payDate: '2026-02-28',
+        } as any,
+        accountant.id
+      );
+
+      expect(result.ytdHours).toBe(256);
+      expect(result.ytdGrossPay).toBe(6144);
+      expect(result.ytdEiAmount).toBe(100.16);
+      expect(result.ytdCppAmount).toBe(333.92);
+      expect(result.ytdWithholding).toBe(434.08);
+      expect(result.ytdNetPay).toBe(5709.92);
+    });
+
+    it('scopes the year-to-date query to the pay date calendar year', async () => {
+      await service.create(baseDto as any, accountant.id);
+
+      expect(prisma.payStub.findMany).toHaveBeenCalledWith({
+        where: {
+          employeeId: 'emp-1',
+          payDate: {
+            gte: new Date(Date.UTC(2026, 0, 1)),
+            lt: new Date(Date.UTC(2027, 0, 1)),
+          },
+        },
+      });
+    });
+
+    it('rejects a stub whose withholdings exceed gross pay', async () => {
+      await expect(
+        service.create({ ...baseDto, eiAmount: 4000 } as any, accountant.id)
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects a period that ends before it starts', async () => {
+      await expect(
+        service.create(
+          {
+            ...baseDto,
+            periodStart: '2026-01-31',
+            periodEnd: '2026-01-05',
+          } as any,
+          accountant.id
+        )
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects creation when no default company is configured', async () => {
+      prisma.company.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create(baseDto as any, accountant.id)
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('writes an audit record', async () => {
+      await service.create(baseDto as any, accountant.id);
+
+      expect(auditRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'CREATE_PAY_STUB',
+          resource: 'PayStub',
+        })
+      );
+    });
+  });
+
+  describe('access control', () => {
+    it('lets an employee read their own stubs', async () => {
+      await expect(
+        service.findForEmployee('emp-1', {
+          id: 'emp-1',
+          role: { name: 'STAFF' },
+        })
+      ).resolves.toEqual([]);
+    });
+
+    it("refuses an employee another person's stubs", async () => {
+      await expect(
+        service.findForEmployee('emp-2', {
+          id: 'emp-1',
+          role: { name: 'STAFF' },
+        })
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('refuses a supervisor another person’s stubs — pay is not a supervision concern', async () => {
+      await expect(
+        service.findForEmployee('emp-2', {
+          id: 'sup-1',
+          role: { name: 'SUPERVISOR' },
+        })
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('lets an accountant read anyone’s stubs', async () => {
+      await expect(
+        service.findForEmployee('emp-2', accountant)
+      ).resolves.toEqual([]);
+    });
+
+    it('refuses a non-payroll role the full list', async () => {
+      await expect(
+        service.findAll({ id: 'emp-1', role: { name: 'STAFF' } })
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('refuses a PDF for a stub belonging to someone else', async () => {
+      prisma.payStub.findUnique.mockResolvedValue({
+        id: 'stub-1',
+        employeeId: 'emp-2',
+        employee,
+      });
+
+      await expect(
+        service.generatePdf('stub-1', { id: 'emp-1', role: { name: 'STAFF' } })
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(pdfService.generatePdfFromHtml).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/pay-stubs/pay-stubs.service.spec.ts
+++ b/server/src/pay-stubs/pay-stubs.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { PayStubsService } from './pay-stubs.service';
 
 /**
@@ -49,9 +53,11 @@ describe('PayStubsService', () => {
         }),
       },
       employeeCompensation: {
-        findFirst: jest
-          .fn()
-          .mockResolvedValue({ payType: 'HOURLY', hourlyRate: 24 }),
+        findFirst: jest.fn().mockResolvedValue({
+          payType: 'HOURLY',
+          hourlyRate: 24,
+          position: 'Tire Technician',
+        }),
       },
       payStub: {
         create: jest.fn((args: any) => ({
@@ -89,6 +95,27 @@ describe('PayStubsService', () => {
       expect(result.companyAddress).toBe('2983 Nicole Ave, Prince George, BC');
       expect(result.employeeName).toBe('Rohit Toora');
       expect(result.position).toBe('Business Manager');
+    });
+
+    it('takes the job title from the compensation record when none is sent', async () => {
+      const { position, ...withoutPosition } = baseDto;
+
+      const result = await service.create(
+        withoutPosition as any,
+        accountant.id
+      );
+
+      expect(result.position).toBe('Tire Technician');
+    });
+
+    it('prefers an explicit job title over the compensation record', async () => {
+      // A stub can be raised for a role someone held only for that period.
+      const result = await service.create(
+        { ...baseDto, position: 'Shop Foreman' } as any,
+        accountant.id
+      );
+
+      expect(result.position).toBe('Shop Foreman');
     });
 
     it('accumulates year-to-date across earlier stubs in the same year', async () => {
@@ -229,6 +256,176 @@ describe('PayStubsService', () => {
         service.generatePdf('stub-1', { id: 'emp-1', role: { name: 'STAFF' } })
       ).rejects.toBeInstanceOf(ForbiddenException);
       expect(pdfService.generatePdfFromHtml).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    /** A stub as stored: Decimal-ish numbers and real Dates, like Prisma returns. */
+    const storedStub = (overrides: any = {}) => ({
+      id: 'stub-1',
+      employeeId: 'emp-1',
+      periodStart: new Date(Date.UTC(2026, 0, 5)),
+      periodEnd: new Date(Date.UTC(2026, 0, 31)),
+      payDate: new Date(Date.UTC(2026, 0, 31)),
+      createdAt: new Date(Date.UTC(2026, 0, 31)),
+      companyName: 'GT Automotive',
+      employeeName: 'Rohit Toora',
+      position: 'Business Manager',
+      payRate: 24,
+      payType: 'HOURLY',
+      regularHours: 128,
+      regularAmount: 3072,
+      grossPay: 3072,
+      eiAmount: 50.08,
+      cppAmount: 166.96,
+      incomeTaxAmount: 0,
+      otherDeductions: 0,
+      totalWithholding: 217.04,
+      netPay: 2854.96,
+      ytdHours: 128,
+      ytdRegularAmount: 3072,
+      ytdGrossPay: 3072,
+      ytdEiAmount: 50.08,
+      ytdCppAmount: 166.96,
+      ytdIncomeTaxAmount: 0,
+      ytdOtherDeductions: 0,
+      ytdWithholding: 217.04,
+      ytdNetPay: 2854.96,
+      employee,
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      prisma.payStub.update = jest.fn(({ where, data }: any) => ({
+        ...storedStub(),
+        id: where.id,
+        ...data,
+      }));
+    });
+
+    it('recomputes the totals rather than trusting the client', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(storedStub());
+      prisma.payStub.findMany.mockResolvedValue([]);
+
+      await service.update('stub-1', { regularAmount: 3500 } as any, 'acc-1');
+
+      const [[{ data }]] = prisma.payStub.update.mock.calls;
+      expect(data.grossPay).toBe(3500);
+      expect(data.totalWithholding).toBe(217.04);
+      expect(data.netPay).toBe(3282.96);
+    });
+
+    it('leaves untouched fields as they were', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(storedStub());
+      prisma.payStub.findMany.mockResolvedValue([]);
+
+      await service.update('stub-1', { eiAmount: 60 } as any, 'acc-1');
+
+      const [[{ data }]] = prisma.payStub.update.mock.calls;
+      expect(data.regularAmount).toBe(3072);
+      expect(data.cppAmount).toBe(166.96);
+      // The one changed figure flows through to the derived totals.
+      expect(data.totalWithholding).toBe(226.96);
+      expect(data.netPay).toBe(2845.04);
+    });
+
+    it('rewrites the year-to-date chain so later stubs still reconcile', async () => {
+      // February's stub carries January's running total. Correcting January
+      // must push the correction through February as well.
+      const january = storedStub({ id: 'stub-1' });
+      const february = storedStub({
+        id: 'stub-2',
+        payDate: new Date(Date.UTC(2026, 1, 28)),
+        createdAt: new Date(Date.UTC(2026, 1, 28)),
+      });
+
+      prisma.payStub.findUnique.mockResolvedValue(january);
+      prisma.payStub.findMany.mockResolvedValue([
+        { ...january, grossPay: 4000, regularAmount: 4000, netPay: 3782.96 },
+        february,
+      ]);
+
+      await service.update('stub-1', { regularAmount: 4000 } as any, 'acc-1');
+
+      const ytdWrites = prisma.payStub.update.mock.calls
+        .map(([args]: any) => args)
+        .filter((args: any) => args.data.ytdGrossPay !== undefined);
+
+      expect(ytdWrites).toHaveLength(2);
+      expect(ytdWrites[0].where.id).toBe('stub-1');
+      expect(ytdWrites[0].data.ytdGrossPay).toBe(4000);
+      // February's YTD now includes the corrected January figure.
+      expect(ytdWrites[1].where.id).toBe('stub-2');
+      expect(ytdWrites[1].data.ytdGrossPay).toBe(7072);
+      expect(ytdWrites[1].data.ytdNetPay).toBe(6637.92);
+    });
+
+    it('walks the year in pay date order, not insertion order', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(storedStub());
+      prisma.payStub.findMany.mockResolvedValue([]);
+
+      await service.update('stub-1', { regularAmount: 3072 } as any, 'acc-1');
+
+      expect(prisma.payStub.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: [{ payDate: 'asc' }, { createdAt: 'asc' }],
+        })
+      );
+    });
+
+    it('rewrites both years when a stub moves across new year', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(storedStub());
+      prisma.payStub.findMany.mockResolvedValue([]);
+
+      await service.update('stub-1', { payDate: '2025-12-31' } as any, 'acc-1');
+
+      const years = prisma.payStub.findMany.mock.calls.map(([args]: any) =>
+        args.where.payDate.gte.getUTCFullYear()
+      );
+      expect(new Set(years)).toEqual(new Set([2025, 2026]));
+    });
+
+    it('refuses an amendment that would make net pay negative', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(storedStub());
+
+      await expect(
+        service.update('stub-1', { eiAmount: 4000 } as any, 'acc-1')
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prisma.payStub.update).not.toHaveBeenCalled();
+    });
+
+    it('refuses a period that would end before it starts', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(storedStub());
+
+      await expect(
+        service.update('stub-1', { periodEnd: '2026-01-01' } as any, 'acc-1')
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prisma.payStub.update).not.toHaveBeenCalled();
+    });
+
+    it('refuses to amend a stub that does not exist', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update('nope', { eiAmount: 1 } as any, 'acc-1')
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('audits the amendment with the figures before and after', async () => {
+      prisma.payStub.findUnique.mockResolvedValue(storedStub());
+      prisma.payStub.findMany.mockResolvedValue([]);
+
+      await service.update('stub-1', { regularAmount: 3500 } as any, 'acc-1');
+
+      expect(auditRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'UPDATE_PAY_STUB',
+          resource: 'PayStub',
+          resourceId: 'stub-1',
+          oldValue: expect.objectContaining({ grossPay: 3072 }),
+          newValue: expect.objectContaining({ grossPay: 3500 }),
+        })
+      );
     });
   });
 });

--- a/server/src/pay-stubs/pay-stubs.service.spec.ts
+++ b/server/src/pay-stubs/pay-stubs.service.spec.ts
@@ -68,6 +68,14 @@ describe('PayStubsService', () => {
         })),
         findMany: jest.fn().mockResolvedValue([]),
         findUnique: jest.fn(),
+        // create() rewrites the year in pay-date order once the row exists, so
+        // the mock has to accept those writes even in tests that ignore them.
+        update: jest.fn(({ where, data }: any) => ({
+          id: where.id,
+          createdAt: new Date('2026-01-31T00:00:00.000Z'),
+          employee,
+          ...data,
+        })),
       },
     };
     pdfService = {
@@ -152,17 +160,132 @@ describe('PayStubsService', () => {
       expect(result.ytdNetPay).toBe(5709.92);
     });
 
-    it('scopes the year-to-date query to the pay date calendar year', async () => {
+    it('sums only stubs up to this pay date, within its calendar year', async () => {
       await service.create(baseDto as any, accountant.id);
 
+      // Unbounded above, a stub backfilled for an earlier period would count a
+      // later one as prior — overstating its year-to-date and understating the
+      // CPP and EI room left when deductions are estimated.
       expect(prisma.payStub.findMany).toHaveBeenCalledWith({
         where: {
           employeeId: 'emp-1',
           payDate: {
             gte: new Date(Date.UTC(2026, 0, 1)),
-            lt: new Date(Date.UTC(2027, 0, 1)),
+            lte: new Date(Date.UTC(2026, 0, 31)),
           },
         },
+      });
+    });
+
+    /**
+     * Stubs are not always raised in pay-date order — a missed period gets
+     * backfilled, and running payroll after a period closes is a case this
+     * feature exists for. A stub landing mid-chain must leave the year
+     * reconciling, not just itself.
+     */
+    describe('raised out of pay-date order', () => {
+      /** A tiny in-memory payStub table, so the chain can actually be walked. */
+      const useStore = () => {
+        const rows: any[] = [];
+        let seq = 0;
+        prisma.payStub.create = jest.fn((args: any) => {
+          const row = {
+            id: `stub-${++seq}`,
+            createdAt: new Date(Date.UTC(2026, 5, seq)),
+            employee,
+            ...args.data,
+          };
+          rows.push(row);
+          return row;
+        });
+        prisma.payStub.findMany = jest.fn(({ where, orderBy }: any) => {
+          let out = rows.filter(
+            (row) =>
+              row.employeeId === where.employeeId &&
+              row.payDate >= where.payDate.gte &&
+              (where.payDate.lte
+                ? row.payDate <= where.payDate.lte
+                : row.payDate < where.payDate.lt)
+          );
+          if (orderBy) {
+            out = [...out].sort(
+              (a, b) =>
+                a.payDate.getTime() - b.payDate.getTime() ||
+                a.createdAt.getTime() - b.createdAt.getTime()
+            );
+          }
+          return out;
+        });
+        prisma.payStub.update = jest.fn(({ where, data }: any) => {
+          const row = rows.find((candidate) => candidate.id === where.id);
+          Object.assign(row, data);
+          return row;
+        });
+        prisma.payStub.findUnique = jest.fn(({ where }: any) =>
+          rows.find((row) => row.id === where.id)
+        );
+        return rows;
+      };
+
+      /** $1,000 gross, no deductions, so the running totals are easy to read. */
+      const stubFor = (payDate: string) => ({
+        ...baseDto,
+        payDate,
+        periodStart: payDate,
+        periodEnd: payDate,
+        regularHours: 40,
+        regularAmount: 1000,
+        eiAmount: 0,
+        cppAmount: 0,
+      });
+
+      it('does not count a later stub as prior to it', async () => {
+        useStore();
+        await service.create(stubFor('2026-02-28') as any, accountant.id);
+
+        const january = await service.create(
+          stubFor('2026-01-31') as any,
+          accountant.id
+        );
+
+        // January is first in the year, so its running total is its own gross —
+        // not February's added on top of it.
+        expect(january.ytdGrossPay).toBe(1000);
+      });
+
+      it('rewrites the stubs that come after it', async () => {
+        const rows = useStore();
+        await service.create(stubFor('2026-02-28') as any, accountant.id);
+        await service.create(stubFor('2026-01-31') as any, accountant.id);
+
+        // February was issued believing it was the year's first stub. Once
+        // January exists it has to carry both, or the year never reconciles.
+        const february = rows.find((row) => row.id === 'stub-1');
+        expect(Number(february.ytdGrossPay)).toBe(2000);
+      });
+
+      it('leaves the whole year summing to the stubs in it', async () => {
+        const rows = useStore();
+        await service.create(stubFor('2026-03-31') as any, accountant.id);
+        await service.create(stubFor('2026-01-31') as any, accountant.id);
+        await service.create(stubFor('2026-02-28') as any, accountant.id);
+
+        const chain = [...rows]
+          .sort((a, b) => a.payDate.getTime() - b.payDate.getTime())
+          .map((row) => Number(row.ytdGrossPay));
+        expect(chain).toEqual([1000, 2000, 3000]);
+      });
+
+      it('does not touch a neighbouring year', async () => {
+        const rows = useStore();
+        await service.create(stubFor('2025-12-31') as any, accountant.id);
+        await service.create(stubFor('2026-01-31') as any, accountant.id);
+
+        // Year-to-date restarts each calendar year; the rewrite must respect
+        // that boundary rather than running a total across it.
+        expect(rows.map((row) => Number(row.ytdGrossPay))).toEqual([
+          1000, 1000,
+        ]);
       });
     });
 

--- a/server/src/pay-stubs/pay-stubs.service.ts
+++ b/server/src/pay-stubs/pay-stubs.service.ts
@@ -5,7 +5,20 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '@gt-automotive/database';
-import { CreatePayStubDto, PayStubDto, PayType } from '@gt-automotive/data';
+import {
+  CreatePayStubDto,
+  PayStubDeductionEstimateDto,
+  PayStubDeductionEstimateRequestDto,
+  PayStubDto,
+  PayType,
+  UpdatePayStubDto,
+} from '@gt-automotive/data';
+import {
+  calculateDeductions,
+  getPayrollRates,
+  payPeriodLabel,
+  SupportedProvince,
+} from './canadian-payroll';
 import { PdfService } from '../pdf/pdf.service';
 import { AuditRepository } from '../audit/repositories/audit.repository';
 import {
@@ -15,6 +28,9 @@ import {
 
 /** Roles allowed to raise and read every employee's pay stubs. */
 const PAYROLL_ADMIN_ROLES = ['ADMIN', 'ACCOUNTANT'];
+
+/** The shop's province of employment, which fixes the provincial tax table. */
+const PROVINCE_OF_EMPLOYMENT: SupportedProvince = 'BC';
 
 const round2 = (value: number) => Math.round(value * 100) / 100;
 const num = (value: unknown) => Number(value ?? 0);
@@ -103,10 +119,19 @@ export class PayStubsService {
         payDate,
         companyName: company.name,
         companyAddress: company.address,
+        companyBusinessType: company.businessType,
+        companyRegistrationNumber: company.registrationNumber,
+        companyPhone: company.phone,
+        companyEmail: company.email,
         employeeName:
           [employee.firstName, employee.lastName].filter(Boolean).join(' ') ||
           employee.email,
-        position: dto.position,
+        // The job title lives on the compensation record, which is where it is
+        // maintained; the stub freezes a copy so a later change of title does
+        // not rewrite documents already issued. An explicit value from the
+        // form still wins — a stub can be raised for a role someone held only
+        // for that period.
+        position: dto.position ?? compensation?.position ?? undefined,
         payRate: dto.payRate ?? null,
         payType: compensation?.payType ?? PayType.HOURLY,
         regularHours,
@@ -155,6 +180,294 @@ export class PayStubsService {
     });
 
     return this.toDto(payStub);
+  }
+
+  /**
+   * Correct a stub that has already been issued.
+   *
+   * Pay stubs are issued documents, so this is a deliberate amendment, not a
+   * casual edit: the change is audited with both the old and new figures, and
+   * the derived totals are recomputed here rather than accepted from the
+   * client, exactly as on create.
+   *
+   * The awkward part is year-to-date. Those columns are frozen snapshots, so
+   * changing an earlier stub leaves every later one carrying a running total
+   * that no longer reconciles. Rather than leave the record internally
+   * inconsistent — which would surface at T4 time, long after anyone could
+   * explain it — the whole calendar year for that employee is rewritten in pay
+   * date order. Moving a stub across new year's rewrites both years.
+   */
+  async update(
+    id: string,
+    dto: UpdatePayStubDto,
+    userId: string
+  ): Promise<PayStubDto> {
+    const existing = await this.prisma.payStub.findUnique({ where: { id } });
+    if (!existing) {
+      throw new NotFoundException('Pay stub not found');
+    }
+
+    const periodStart = dto.periodStart
+      ? toBusinessCalendarDate(dto.periodStart)
+      : existing.periodStart;
+    const periodEnd = dto.periodEnd
+      ? toBusinessCalendarDate(dto.periodEnd)
+      : existing.periodEnd;
+    const payDate = dto.payDate
+      ? toBusinessCalendarDate(dto.payDate)
+      : existing.payDate;
+
+    if (periodEnd < periodStart) {
+      throw new BadRequestException(
+        'Pay period end cannot be before the pay period start'
+      );
+    }
+
+    const pick = (next: number | undefined, current: unknown) =>
+      round2(next ?? num(current));
+
+    const regularHours = pick(dto.regularHours, existing.regularHours);
+    const regularAmount = pick(dto.regularAmount, existing.regularAmount);
+    const grossPay = regularAmount;
+    const eiAmount = pick(dto.eiAmount, existing.eiAmount);
+    const cppAmount = pick(dto.cppAmount, existing.cppAmount);
+    const incomeTaxAmount = pick(dto.incomeTaxAmount, existing.incomeTaxAmount);
+    const otherDeductions = pick(dto.otherDeductions, existing.otherDeductions);
+    const totalWithholding = round2(
+      eiAmount + cppAmount + incomeTaxAmount + otherDeductions
+    );
+    const netPay = round2(grossPay - totalWithholding);
+
+    if (netPay < 0) {
+      throw new BadRequestException(
+        'Withholdings exceed gross pay — net pay would be negative'
+      );
+    }
+
+    await this.prisma.payStub.update({
+      where: { id },
+      data: {
+        periodStart,
+        periodEnd,
+        payDate,
+        position: dto.position === undefined ? undefined : dto.position,
+        payRate: dto.payRate === undefined ? undefined : dto.payRate,
+        regularHours,
+        regularAmount,
+        grossPay,
+        eiAmount,
+        cppAmount,
+        incomeTaxAmount,
+        otherDeductions,
+        otherDeductionsLabel:
+          dto.otherDeductionsLabel === undefined
+            ? undefined
+            : dto.otherDeductionsLabel,
+        totalWithholding,
+        netPay,
+        notes: dto.notes === undefined ? undefined : dto.notes,
+      },
+    });
+
+    // Both years, in case the pay date moved across a year boundary — the old
+    // year's chain has lost a stub and the new year's has gained one.
+    const years = new Set([
+      existing.payDate.getUTCFullYear(),
+      payDate.getUTCFullYear(),
+    ]);
+    for (const year of years) {
+      await this.recomputeYearToDate(existing.employeeId, year);
+    }
+
+    await this.auditRepository.create({
+      userId,
+      action: 'UPDATE_PAY_STUB',
+      resource: 'PayStub',
+      resourceId: id,
+      oldValue: {
+        periodStart: extractBusinessDate(existing.periodStart),
+        periodEnd: extractBusinessDate(existing.periodEnd),
+        payDate: extractBusinessDate(existing.payDate),
+        grossPay: num(existing.grossPay),
+        totalWithholding: num(existing.totalWithholding),
+        netPay: num(existing.netPay),
+      },
+      newValue: {
+        periodStart: extractBusinessDate(periodStart),
+        periodEnd: extractBusinessDate(periodEnd),
+        payDate: extractBusinessDate(payDate),
+        grossPay,
+        totalWithholding,
+        netPay,
+      },
+    });
+
+    // Re-read: the year-to-date rewrite above changed this row after the update.
+    const updated = await this.prisma.payStub.findUnique({
+      where: { id },
+      include: { employee: { include: { role: true } } },
+    });
+
+    return this.toDto(updated);
+  }
+
+  /**
+   * Rewrite one employee's year-to-date columns for a calendar year, walking
+   * their stubs in pay date order and accumulating.
+   *
+   * Ordering is by pay date, then by creation, so two stubs paid the same day
+   * accumulate in the order they were raised.
+   */
+  private async recomputeYearToDate(employeeId: string, year: number) {
+    const stubs = await this.prisma.payStub.findMany({
+      where: {
+        employeeId,
+        payDate: {
+          gte: new Date(Date.UTC(year, 0, 1)),
+          lt: new Date(Date.UTC(year + 1, 0, 1)),
+        },
+      },
+      orderBy: [{ payDate: 'asc' }, { createdAt: 'asc' }],
+    });
+
+    const running = {
+      hours: 0,
+      regularAmount: 0,
+      grossPay: 0,
+      eiAmount: 0,
+      cppAmount: 0,
+      incomeTaxAmount: 0,
+      otherDeductions: 0,
+      totalWithholding: 0,
+      netPay: 0,
+    };
+
+    for (const stub of stubs) {
+      running.hours += num(stub.regularHours);
+      running.regularAmount += num(stub.regularAmount);
+      running.grossPay += num(stub.grossPay);
+      running.eiAmount += num(stub.eiAmount);
+      running.cppAmount += num(stub.cppAmount);
+      running.incomeTaxAmount += num(stub.incomeTaxAmount);
+      running.otherDeductions += num(stub.otherDeductions);
+      running.totalWithholding += num(stub.totalWithholding);
+      running.netPay += num(stub.netPay);
+
+      await this.prisma.payStub.update({
+        where: { id: stub.id },
+        data: {
+          ytdHours: round2(running.hours),
+          ytdRegularAmount: round2(running.regularAmount),
+          ytdGrossPay: round2(running.grossPay),
+          ytdEiAmount: round2(running.eiAmount),
+          ytdCppAmount: round2(running.cppAmount),
+          ytdIncomeTaxAmount: round2(running.incomeTaxAmount),
+          ytdOtherDeductions: round2(running.otherDeductions),
+          ytdWithholding: round2(running.totalWithholding),
+          ytdNetPay: round2(running.netPay),
+        },
+      });
+    }
+  }
+
+  /**
+   * What CPP, EI and income tax the CRA formulas say should come off a given
+   * gross — a suggestion for the accountant, never applied on its own.
+   *
+   * Year-to-date CPP and EI come from this employee's earlier stubs in the same
+   * calendar year, because both stop at an annual maximum: the same $2,000 of
+   * pay attracts different contributions in January and in November. That makes
+   * the estimate only as good as the stubs already in the system — pay run
+   * outside it, and the maximums will be reached late.
+   *
+   * Returns `supported: false` rather than a figure when the pay date falls in
+   * a year with no rate table. A number computed from the wrong year's rates
+   * would look exactly as trustworthy as a right one.
+   */
+  async estimateDeductions(
+    dto: PayStubDeductionEstimateRequestDto
+  ): Promise<PayStubDeductionEstimateDto> {
+    const employee = await this.prisma.user.findUnique({
+      where: { id: dto.employeeId },
+    });
+    if (!employee) {
+      throw new NotFoundException('Employee not found');
+    }
+
+    const payDate = toBusinessCalendarDate(dto.payDate);
+    const taxYear = payDate.getUTCFullYear();
+    const priorTotals = await this.sumPriorStubsInYear(dto.employeeId, payDate);
+
+    const empty = {
+      taxYear,
+      province: PROVINCE_OF_EMPLOYMENT,
+      payPeriodsPerYear: dto.payPeriodsPerYear,
+      ytdGrossPay: round2(priorTotals.grossPay),
+      ytdCpp: round2(priorTotals.cppAmount),
+      ytdEi: round2(priorTotals.eiAmount),
+    };
+
+    const rates = getPayrollRates(PROVINCE_OF_EMPLOYMENT, taxYear);
+    if (!rates) {
+      return {
+        ...empty,
+        supported: false,
+        ei: 0,
+        cpp: 0,
+        cpp2: 0,
+        incomeTax: 0,
+        federalTax: 0,
+        provincialTax: 0,
+        annualTaxableIncome: 0,
+        cppMaxedOut: false,
+        eiMaxedOut: false,
+        assumptions: [
+          `No CRA rate table is held for ${taxYear}. Enter the deductions manually, or add the ${taxYear} rates from the CRA's T4127 guide.`,
+        ],
+      };
+    }
+
+    const estimate = calculateDeductions({
+      grossPay: dto.grossPay,
+      payPeriodsPerYear: dto.payPeriodsPerYear,
+      ytdCpp: priorTotals.cppAmount,
+      ytdEi: priorTotals.eiAmount,
+      ytdGrossPay: priorTotals.grossPay,
+      province: PROVINCE_OF_EMPLOYMENT,
+      taxYear,
+    });
+
+    // getPayrollRates just confirmed the year is supported, so this holds.
+    if (!estimate) {
+      throw new BadRequestException(
+        `Could not calculate deductions for ${taxYear}`
+      );
+    }
+
+    const assumptions = [
+      `${taxYear} CRA rates, ${PROVINCE_OF_EMPLOYMENT} — ${payPeriodLabel(
+        dto.payPeriodsPerYear
+      ).toLowerCase()} (${dto.payPeriodsPerYear} pay periods).`,
+      'Basic personal amounts only (TD1 claim code 1) — an employee claiming more will be over-deducted.',
+      'No RRSP, pension, union dues or other tax-deductible amounts.',
+    ];
+    if (estimate.cppMaxedOut) {
+      assumptions.push(
+        'CPP has reached the annual maximum, so this period takes only the remainder.'
+      );
+    }
+    if (estimate.eiMaxedOut) {
+      assumptions.push(
+        'EI has reached the annual maximum, so this period takes only the remainder.'
+      );
+    }
+    if (priorTotals.grossPay === 0) {
+      assumptions.push(
+        'No earlier stub this year, so the annual maximums are treated as untouched.'
+      );
+    }
+
+    return { ...empty, supported: true, ...estimate, assumptions };
   }
 
   /**
@@ -309,6 +622,10 @@ export class PayStubsService {
       payDate: extractBusinessDate(stub.payDate),
       companyName: stub.companyName,
       companyAddress: stub.companyAddress || undefined,
+      companyBusinessType: stub.companyBusinessType || undefined,
+      companyRegistrationNumber: stub.companyRegistrationNumber || undefined,
+      companyPhone: stub.companyPhone || undefined,
+      companyEmail: stub.companyEmail || undefined,
       employeeName: stub.employeeName,
       position: stub.position || undefined,
       payRate: stub.payRate == null ? undefined : num(stub.payRate),

--- a/server/src/pay-stubs/pay-stubs.service.ts
+++ b/server/src/pay-stubs/pay-stubs.service.ts
@@ -179,7 +179,27 @@ export class PayStubsService {
       },
     });
 
-    return this.toDto(payStub);
+    // A stub raised out of pay-date order — a missed period backfilled after a
+    // later one was issued — lands in the middle of an existing chain, leaving
+    // every stub after it carrying a running total that no longer includes
+    // everything before it. Rewriting the year in pay-date order is the same
+    // reconciliation an amendment performs, and for the same reason: a year
+    // whose stubs disagree with each other surfaces at T4 time, long after
+    // anyone could explain it.
+    //
+    // Run unconditionally rather than only when a later stub exists, so there
+    // is one path to be right about instead of two.
+    await this.recomputeYearToDate(dto.employeeId, payDate.getUTCFullYear());
+
+    // Re-read: the row above holds the totals computed before the rewrite, and
+    // returning those would show the accountant a figure the database no longer
+    // agrees with.
+    const reconciled = await this.prisma.payStub.findUnique({
+      where: { id: payStub.id },
+      include: { employee: { include: { role: true } } },
+    });
+
+    return this.toDto(reconciled ?? payStub);
   }
 
   /**
@@ -567,15 +587,26 @@ export class PayStubsService {
    * in January carries January's year-to-date regardless of which period it
    * covers.
    */
+  /**
+   * This employee's stubs in the same calendar year up to and including
+   * `payDate`.
+   *
+   * The upper bound matters. Stubs are not always raised in pay-date order — a
+   * missed period gets backfilled, and this feature exists partly to run
+   * payroll after a period has closed. Summing the whole year would count a
+   * *later* stub as prior, overstating year-to-date on the one being raised and
+   * understating the CPP and EI room left when deductions are estimated.
+   */
   private async sumPriorStubsInYear(employeeId: string, payDate: Date) {
     const year = payDate.getUTCFullYear();
     const yearStart = new Date(Date.UTC(year, 0, 1));
-    const yearEnd = new Date(Date.UTC(year + 1, 0, 1));
 
     const priorStubs = await this.prisma.payStub.findMany({
       where: {
         employeeId,
-        payDate: { gte: yearStart, lt: yearEnd },
+        // Inclusive: a stub already issued for this same pay date is earlier in
+        // the chain, since recomputeYearToDate() breaks ties on creation order.
+        payDate: { gte: yearStart, lte: payDate },
       },
     });
 

--- a/server/src/pay-stubs/pay-stubs.service.ts
+++ b/server/src/pay-stubs/pay-stubs.service.ts
@@ -1,0 +1,340 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '@gt-automotive/database';
+import { CreatePayStubDto, PayStubDto, PayType } from '@gt-automotive/data';
+import { PdfService } from '../pdf/pdf.service';
+import { AuditRepository } from '../audit/repositories/audit.repository';
+import {
+  extractBusinessDate,
+  toBusinessCalendarDate,
+} from '../config/timezone.config';
+
+/** Roles allowed to raise and read every employee's pay stubs. */
+const PAYROLL_ADMIN_ROLES = ['ADMIN', 'ACCOUNTANT'];
+
+const round2 = (value: number) => Math.round(value * 100) / 100;
+const num = (value: unknown) => Number(value ?? 0);
+
+@Injectable()
+export class PayStubsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly pdfService: PdfService,
+    private readonly auditRepository: AuditRepository
+  ) {}
+
+  /**
+   * Raise a pay stub for an employee.
+   *
+   * Everything the printed document shows is resolved and stored here — the
+   * company header, the employee's name, position and rate, the period figures
+   * and the year-to-date columns. Nothing is joined live at render time, so a
+   * later change to a compensation record, a time entry or the company name
+   * cannot alter a stub that has already been issued.
+   */
+  async create(dto: CreatePayStubDto, userId: string): Promise<PayStubDto> {
+    const employee = await this.prisma.user.findUnique({
+      where: { id: dto.employeeId },
+      include: { role: true },
+    });
+    if (!employee) {
+      throw new NotFoundException('Employee not found');
+    }
+
+    const periodStart = toBusinessCalendarDate(dto.periodStart);
+    const periodEnd = toBusinessCalendarDate(dto.periodEnd);
+    const payDate = toBusinessCalendarDate(dto.payDate);
+
+    if (periodEnd < periodStart) {
+      throw new BadRequestException(
+        'Pay period end cannot be before the pay period start'
+      );
+    }
+
+    const company = await this.prisma.company.findFirst({
+      where: { isDefault: true },
+    });
+    if (!company) {
+      throw new BadRequestException(
+        'No default company is configured — a pay stub needs a company header'
+      );
+    }
+
+    const compensation = await this.prisma.employeeCompensation.findFirst({
+      where: { employeeId: dto.employeeId, isActive: true },
+      orderBy: { effectiveFrom: 'desc' },
+    });
+
+    // Derived figures are computed here, never accepted from the client, so the
+    // arithmetic on the printed stub is always internally consistent.
+    const regularHours = round2(dto.regularHours);
+    const regularAmount = round2(dto.regularAmount);
+    const grossPay = regularAmount;
+    const eiAmount = round2(dto.eiAmount ?? 0);
+    const cppAmount = round2(dto.cppAmount ?? 0);
+    const incomeTaxAmount = round2(dto.incomeTaxAmount ?? 0);
+    const otherDeductions = round2(dto.otherDeductions ?? 0);
+    const totalWithholding = round2(
+      eiAmount + cppAmount + incomeTaxAmount + otherDeductions
+    );
+    const netPay = round2(grossPay - totalWithholding);
+
+    if (netPay < 0) {
+      throw new BadRequestException(
+        'Withholdings exceed gross pay — net pay would be negative'
+      );
+    }
+
+    // Year to date is the sum of this employee's earlier stubs in the same
+    // calendar year, plus this one. Computed once and frozen: recomputing at
+    // render time would make an old stub change every time a later one is
+    // issued, which is exactly what a pay record must not do.
+    const priorTotals = await this.sumPriorStubsInYear(dto.employeeId, payDate);
+
+    const payStub = await this.prisma.payStub.create({
+      data: {
+        employeeId: dto.employeeId,
+        periodStart,
+        periodEnd,
+        payDate,
+        companyName: company.name,
+        companyAddress: company.address,
+        employeeName:
+          [employee.firstName, employee.lastName].filter(Boolean).join(' ') ||
+          employee.email,
+        position: dto.position,
+        payRate: dto.payRate ?? null,
+        payType: compensation?.payType ?? PayType.HOURLY,
+        regularHours,
+        regularAmount,
+        grossPay,
+        eiAmount,
+        cppAmount,
+        incomeTaxAmount,
+        otherDeductions,
+        otherDeductionsLabel: dto.otherDeductionsLabel,
+        totalWithholding,
+        netPay,
+        ytdHours: round2(priorTotals.hours + regularHours),
+        ytdRegularAmount: round2(priorTotals.regularAmount + regularAmount),
+        ytdGrossPay: round2(priorTotals.grossPay + grossPay),
+        ytdEiAmount: round2(priorTotals.eiAmount + eiAmount),
+        ytdCppAmount: round2(priorTotals.cppAmount + cppAmount),
+        ytdIncomeTaxAmount: round2(
+          priorTotals.incomeTaxAmount + incomeTaxAmount
+        ),
+        ytdOtherDeductions: round2(
+          priorTotals.otherDeductions + otherDeductions
+        ),
+        ytdWithholding: round2(priorTotals.totalWithholding + totalWithholding),
+        ytdNetPay: round2(priorTotals.netPay + netPay),
+        notes: dto.notes,
+        generatedBy: userId,
+      },
+      include: { employee: { include: { role: true } } },
+    });
+
+    await this.auditRepository.create({
+      userId,
+      action: 'CREATE_PAY_STUB',
+      resource: 'PayStub',
+      resourceId: payStub.id,
+      newValue: {
+        employeeId: dto.employeeId,
+        periodStart: dto.periodStart,
+        periodEnd: dto.periodEnd,
+        payDate: dto.payDate,
+        grossPay,
+        totalWithholding,
+        netPay,
+      },
+    });
+
+    return this.toDto(payStub);
+  }
+
+  /**
+   * Pay stubs for one employee, newest first.
+   *
+   * An employee may only ever read their own; payroll roles may read anyone's.
+   */
+  async findForEmployee(
+    employeeId: string,
+    currentUser: any
+  ): Promise<PayStubDto[]> {
+    this.assertCanAccessEmployee(employeeId, currentUser);
+
+    const stubs = await this.prisma.payStub.findMany({
+      where: { employeeId },
+      include: { employee: { include: { role: true } } },
+      orderBy: [{ payDate: 'desc' }, { createdAt: 'desc' }],
+    });
+
+    return stubs.map((stub) => this.toDto(stub));
+  }
+
+  /** Every pay stub, newest first. Payroll roles only. */
+  async findAll(currentUser: any, employeeId?: string): Promise<PayStubDto[]> {
+    if (!PAYROLL_ADMIN_ROLES.includes(currentUser?.role?.name)) {
+      throw new ForbiddenException(
+        'Only admins and accountants can list all pay stubs'
+      );
+    }
+
+    const stubs = await this.prisma.payStub.findMany({
+      where: employeeId ? { employeeId } : undefined,
+      include: { employee: { include: { role: true } } },
+      orderBy: [{ payDate: 'desc' }, { createdAt: 'desc' }],
+    });
+
+    return stubs.map((stub) => this.toDto(stub));
+  }
+
+  async findOne(id: string, currentUser: any): Promise<PayStubDto> {
+    const stub = await this.getAccessibleStub(id, currentUser);
+    return this.toDto(stub);
+  }
+
+  /**
+   * Render the stub as a PDF, on demand. Nothing is stored — the document is
+   * rebuilt from the frozen row each time it is viewed, printed or emailed.
+   */
+  async generatePdf(id: string, currentUser: any): Promise<Buffer> {
+    const stub = await this.getAccessibleStub(id, currentUser);
+    const html = this.pdfService.generatePayStubHtml(this.toDto(stub));
+    return this.pdfService.generatePdfFromHtml(html);
+  }
+
+  /**
+   * Filename for a downloaded/printed stub, e.g.
+   * `paystub-2026-01-31-rohit-toora.pdf`.
+   */
+  async getPdfFilename(id: string, currentUser: any): Promise<string> {
+    const stub = await this.getAccessibleStub(id, currentUser);
+    const slug = stub.employeeName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    return `paystub-${extractBusinessDate(stub.payDate)}-${slug}.pdf`;
+  }
+
+  private async getAccessibleStub(id: string, currentUser: any) {
+    const stub = await this.prisma.payStub.findUnique({
+      where: { id },
+      include: { employee: { include: { role: true } } },
+    });
+    if (!stub) {
+      throw new NotFoundException('Pay stub not found');
+    }
+    this.assertCanAccessEmployee(stub.employeeId, currentUser);
+    return stub;
+  }
+
+  /**
+   * Pay data is the most sensitive thing in the system: an employee sees their
+   * own stubs and nobody else's. Being a supervisor or foreman is not enough —
+   * only admins and accountants, who raise them, can read another person's.
+   */
+  private assertCanAccessEmployee(employeeId: string, currentUser: any) {
+    const role = currentUser?.role?.name;
+    if (PAYROLL_ADMIN_ROLES.includes(role)) return;
+    if (currentUser?.id && currentUser.id === employeeId) return;
+    throw new ForbiddenException('You can only view your own pay stubs');
+  }
+
+  /**
+   * Totals across the employee's existing stubs in the same calendar year as
+   * `payDate`, used as the running start for this stub's YTD columns.
+   *
+   * Scoped by pay date year, matching how the printed stub is read: a stub paid
+   * in January carries January's year-to-date regardless of which period it
+   * covers.
+   */
+  private async sumPriorStubsInYear(employeeId: string, payDate: Date) {
+    const year = payDate.getUTCFullYear();
+    const yearStart = new Date(Date.UTC(year, 0, 1));
+    const yearEnd = new Date(Date.UTC(year + 1, 0, 1));
+
+    const priorStubs = await this.prisma.payStub.findMany({
+      where: {
+        employeeId,
+        payDate: { gte: yearStart, lt: yearEnd },
+      },
+    });
+
+    return priorStubs.reduce(
+      (acc, stub) => ({
+        hours: acc.hours + num(stub.regularHours),
+        regularAmount: acc.regularAmount + num(stub.regularAmount),
+        grossPay: acc.grossPay + num(stub.grossPay),
+        eiAmount: acc.eiAmount + num(stub.eiAmount),
+        cppAmount: acc.cppAmount + num(stub.cppAmount),
+        incomeTaxAmount: acc.incomeTaxAmount + num(stub.incomeTaxAmount),
+        otherDeductions: acc.otherDeductions + num(stub.otherDeductions),
+        totalWithholding: acc.totalWithholding + num(stub.totalWithholding),
+        netPay: acc.netPay + num(stub.netPay),
+      }),
+      {
+        hours: 0,
+        regularAmount: 0,
+        grossPay: 0,
+        eiAmount: 0,
+        cppAmount: 0,
+        incomeTaxAmount: 0,
+        otherDeductions: 0,
+        totalWithholding: 0,
+        netPay: 0,
+      }
+    );
+  }
+
+  private toDto(stub: any): PayStubDto {
+    return {
+      id: stub.id,
+      employeeId: stub.employeeId,
+      employee: stub.employee
+        ? {
+            id: stub.employee.id,
+            firstName: stub.employee.firstName || undefined,
+            lastName: stub.employee.lastName || undefined,
+            email: stub.employee.email,
+          }
+        : undefined,
+      periodStart: extractBusinessDate(stub.periodStart),
+      periodEnd: extractBusinessDate(stub.periodEnd),
+      payDate: extractBusinessDate(stub.payDate),
+      companyName: stub.companyName,
+      companyAddress: stub.companyAddress || undefined,
+      employeeName: stub.employeeName,
+      position: stub.position || undefined,
+      payRate: stub.payRate == null ? undefined : num(stub.payRate),
+      payType: stub.payType,
+      regularHours: num(stub.regularHours),
+      regularAmount: num(stub.regularAmount),
+      grossPay: num(stub.grossPay),
+      eiAmount: num(stub.eiAmount),
+      cppAmount: num(stub.cppAmount),
+      incomeTaxAmount: num(stub.incomeTaxAmount),
+      otherDeductions: num(stub.otherDeductions),
+      otherDeductionsLabel: stub.otherDeductionsLabel || undefined,
+      totalWithholding: num(stub.totalWithholding),
+      netPay: num(stub.netPay),
+      ytdHours: num(stub.ytdHours),
+      ytdRegularAmount: num(stub.ytdRegularAmount),
+      ytdGrossPay: num(stub.ytdGrossPay),
+      ytdEiAmount: num(stub.ytdEiAmount),
+      ytdCppAmount: num(stub.ytdCppAmount),
+      ytdIncomeTaxAmount: num(stub.ytdIncomeTaxAmount),
+      ytdOtherDeductions: num(stub.ytdOtherDeductions),
+      ytdWithholding: num(stub.ytdWithholding),
+      ytdNetPay: num(stub.ytdNetPay),
+      notes: stub.notes || undefined,
+      generatedBy: stub.generatedBy,
+      createdAt: stub.createdAt.toISOString(),
+    };
+  }
+}

--- a/server/src/pdf/pay-stub-template.spec.ts
+++ b/server/src/pdf/pay-stub-template.spec.ts
@@ -1,0 +1,144 @@
+import { PdfService } from './pdf.service';
+
+/**
+ * Tests for the pay stub template.
+ *
+ * The stub is rendered on demand rather than stored, so this template is the
+ * document — there is no saved PDF to fall back on if it drifts from the
+ * business's existing layout. These tests pin the figures and the rows that
+ * must appear, using the numbers from the sample stub the business supplied.
+ */
+describe('PdfService pay stub template', () => {
+  const service = new PdfService();
+
+  const januaryStub: any = {
+    id: 'stub-1',
+    employeeId: 'emp-1',
+    periodStart: '2026-01-05',
+    periodEnd: '2026-01-31',
+    payDate: '2026-01-31',
+    companyName: 'GT Automotive',
+    companyAddress: '2983 Nicole Ave, Prince George, BC',
+    employeeName: 'Rohit Toora',
+    position: 'Business Manager',
+    payRate: 24,
+    payType: 'HOURLY',
+    regularHours: 128,
+    regularAmount: 3072,
+    grossPay: 3072,
+    eiAmount: 50.08,
+    cppAmount: 166.96,
+    incomeTaxAmount: 0,
+    otherDeductions: 0,
+    totalWithholding: 217.04,
+    netPay: 2854.96,
+    ytdHours: 128,
+    ytdRegularAmount: 3072,
+    ytdGrossPay: 3072,
+    ytdEiAmount: 50.08,
+    ytdCppAmount: 166.96,
+    ytdIncomeTaxAmount: 0,
+    ytdOtherDeductions: 0,
+    ytdWithholding: 217.04,
+    ytdNetPay: 2854.96,
+    generatedBy: 'acc-1',
+    createdAt: '2026-01-31T00:00:00.000Z',
+  };
+
+  it('renders the company header and PAY STUB title', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    expect(html).toContain('GT Automotive');
+    expect(html).toContain('2983 Nicole Ave');
+    expect(html).toContain('PAY STUB');
+  });
+
+  it('renders the pay cycle, employee, position and rate block', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    expect(html).toContain('05/01/2026 - 31/01/2026');
+    expect(html).toContain('Rohit Toora');
+    expect(html).toContain('Business Manager');
+    expect(html).toContain('$24.00/Hr');
+    expect(html).toContain('January 31, 2026');
+  });
+
+  it('renders the five-column earnings and withholdings table', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    expect(html).toContain('Current Hours');
+    expect(html).toContain('Year-to-Date Amounts');
+    expect(html).toContain('Regular Pay');
+    expect(html).toContain('Earnings Totals');
+    expect(html).toContain('Federal Employee EI');
+    expect(html).toContain('Federal Employee CPP/QPP');
+    expect(html).toContain('Withholding Totals');
+    expect(html).toContain('NET PAY');
+    expect(html).toContain('3,072.00');
+    expect(html).toContain('2,854.96');
+  });
+
+  it('omits income tax and other deductions when they are zero', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    // The business's stubs withhold EI and CPP only; padding the document with
+    // $0.00 tax lines would misrepresent it.
+    expect(html).not.toContain('Federal Income Tax');
+    expect(html).not.toContain('Other Deductions');
+  });
+
+  it('renders income tax and a labelled other deduction when present', () => {
+    const html = service.generatePayStubHtml({
+      ...januaryStub,
+      incomeTaxAmount: 300,
+      ytdIncomeTaxAmount: 300,
+      otherDeductions: 25,
+      ytdOtherDeductions: 25,
+      otherDeductionsLabel: 'Uniform',
+      totalWithholding: 542.04,
+      netPay: 2529.96,
+    });
+
+    expect(html).toContain('Federal Income Tax');
+    expect(html).toContain('Uniform');
+  });
+
+  it('renders both signature lines', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    expect(html).toContain('Employer Signature');
+    expect(html).toContain('Employee Signature');
+  });
+
+  it('shows a year rate suffix for salaried employees', () => {
+    const html = service.generatePayStubHtml({
+      ...januaryStub,
+      payType: 'SALARIED',
+      payRate: 73000,
+    });
+
+    expect(html).toContain('/Yr');
+  });
+
+  it('escapes employee-supplied text rather than injecting it as markup', () => {
+    const html = service.generatePayStubHtml({
+      ...januaryStub,
+      employeeName: '<script>alert(1)</script>',
+    });
+
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('formats calendar dates in UTC so the printed day matches the stored business day', () => {
+    // A pay date stored as 2026-01-31 must print as January 31 regardless of
+    // the server's timezone — this is the class of bug that shifted invoice
+    // dates by a day for anything created after 5 PM PST.
+    const html = service.generatePayStubHtml({
+      ...januaryStub,
+      payDate: '2026-01-01',
+    });
+
+    expect(html).toContain('January 1, 2026');
+  });
+});

--- a/server/src/pdf/pay-stub-template.spec.ts
+++ b/server/src/pdf/pay-stub-template.spec.ts
@@ -3,10 +3,11 @@ import { PdfService } from './pdf.service';
 /**
  * Tests for the pay stub template.
  *
- * The stub is rendered on demand rather than stored, so this template is the
- * document — there is no saved PDF to fall back on if it drifts from the
- * business's existing layout. These tests pin the figures and the rows that
- * must appear, using the numbers from the sample stub the business supplied.
+ * The stub is rendered on demand rather than stored, so this template *is* the
+ * document — there is no saved PDF to fall back on if it drifts. Two things are
+ * pinned here: the figures from the sample stub the business supplied, and the
+ * items BC's Employment Standards Act s.27 requires a wage statement to carry.
+ * A redesign may move any of it around; it may not drop it.
  */
 describe('PdfService pay stub template', () => {
   const service = new PdfService();
@@ -19,6 +20,10 @@ describe('PdfService pay stub template', () => {
     payDate: '2026-01-31',
     companyName: 'GT Automotive',
     companyAddress: '2983 Nicole Ave, Prince George, BC',
+    companyBusinessType: 'Professional Tire & Auto Services',
+    companyRegistrationNumber: '16472991',
+    companyPhone: '2505702333',
+    companyEmail: 'gt-automotives@outlook.com',
     employeeName: 'Rohit Toora',
     position: 'Business Manager',
     payRate: 24,
@@ -45,37 +50,87 @@ describe('PdfService pay stub template', () => {
     createdAt: '2026-01-31T00:00:00.000Z',
   };
 
-  it('renders the company header and PAY STUB title', () => {
+  it('identifies the employer by trading name, incorporated name and address', () => {
     const html = service.generatePayStubHtml(januaryStub);
+
+    // s.27(a) — the employer's name and address. A wage statement identifies
+    // who is paying, so the incorporated name prints; the contact details and
+    // line of business the invoice carries are sales context and are not shown.
+    expect(html).toContain('GT Automotive');
+    expect(html).toContain('16472991 Canada INC.');
+    expect(html).toContain('2983 Nicole Ave');
+    expect(html).toContain('Prince George');
+    expect(html).toContain('Pay Statement');
+
+    expect(html).not.toContain('Professional Tire');
+    expect(html).not.toContain('Phone:');
+    expect(html).not.toContain('Email:');
+  });
+
+  it('omits the incorporated name on a stub issued without one', () => {
+    // Stubs raised before that column existed have no value to print, and
+    // borrowing today's would misrepresent the document as issued.
+    const html = service.generatePayStubHtml({
+      ...januaryStub,
+      companyRegistrationNumber: undefined,
+    });
 
     expect(html).toContain('GT Automotive');
     expect(html).toContain('2983 Nicole Ave');
-    expect(html).toContain('PAY STUB');
+    expect(html).not.toContain('Canada INC.');
   });
 
-  it('renders the pay cycle, employee, position and rate block', () => {
+  it('renders the pay period, employee, position and rate', () => {
     const html = service.generatePayStubHtml(januaryStub);
 
-    expect(html).toContain('05/01/2026 - 31/01/2026');
+    // Pay date and pay period are both labelled, and both spelled out — a
+    // numeric date is ambiguous between day/month and month/day orders.
+    expect(html).toContain('Pay date');
+    expect(html).toContain('Pay period');
+    expect(html).toContain('January 5, 2026');
+    expect(html).toContain('January 31, 2026');
+    expect(html).not.toContain('05/01/2026');
     expect(html).toContain('Rohit Toora');
     expect(html).toContain('Business Manager');
-    expect(html).toContain('$24.00/Hr');
+    // s.27(c) — the wage rate.
+    expect(html).toContain('$24.00 / hour');
     expect(html).toContain('January 31, 2026');
   });
 
-  it('renders the five-column earnings and withholdings table', () => {
+  it('leads with net pay, gross and total deductions', () => {
     const html = service.generatePayStubHtml(januaryStub);
 
-    expect(html).toContain('Current Hours');
-    expect(html).toContain('Year-to-Date Amounts');
-    expect(html).toContain('Regular Pay');
-    expect(html).toContain('Earnings Totals');
-    expect(html).toContain('Federal Employee EI');
-    expect(html).toContain('Federal Employee CPP/QPP');
-    expect(html).toContain('Withholding Totals');
-    expect(html).toContain('NET PAY');
+    expect(html).toContain('Net Pay');
+    expect(html).toContain('Gross Pay');
+    expect(html).toContain('Deductions');
+    // s.27(i) — gross and net wages.
     expect(html).toContain('3,072.00');
     expect(html).toContain('2,854.96');
+  });
+
+  it('renders the earnings and deductions columns with current and YTD figures', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    expect(html).toContain('Earnings');
+    expect(html).toContain('Year to Date');
+    expect(html).toContain('Regular Pay');
+    // s.27(b) — hours worked, and s.27(g) — each deduction with its purpose.
+    expect(html).toContain('128.00');
+    expect(html).toContain('Employment Insurance (EI)');
+    expect(html).toContain('Canada Pension Plan (CPP)');
+    expect(html).toContain('Total Deductions');
+    expect(html).toContain('50.08');
+    expect(html).toContain('166.96');
+    expect(html).toContain('217.04');
+  });
+
+  it('shows how the gross was split, as proportional segments', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    // Take-home is 2854.96 / 3072 = 92.9% of gross.
+    expect(html).toContain('92.9%');
+    expect(html).toMatch(/class="bar-part" style="width:92\.9\d+%/);
+    expect(html).toContain('Take-home');
   });
 
   it('omits income tax and other deductions when they are zero', () => {
@@ -83,7 +138,7 @@ describe('PdfService pay stub template', () => {
 
     // The business's stubs withhold EI and CPP only; padding the document with
     // $0.00 tax lines would misrepresent it.
-    expect(html).not.toContain('Federal Income Tax');
+    expect(html).not.toContain('Income Tax');
     expect(html).not.toContain('Other Deductions');
   });
 
@@ -99,15 +154,26 @@ describe('PdfService pay stub template', () => {
       netPay: 2529.96,
     });
 
-    expect(html).toContain('Federal Income Tax');
+    expect(html).toContain('Income Tax');
     expect(html).toContain('Uniform');
   });
 
-  it('renders both signature lines', () => {
-    const html = service.generatePayStubHtml(januaryStub);
+  it('stays a complete document when there is no gross to split', () => {
+    const html = service.generatePayStubHtml({
+      ...januaryStub,
+      regularHours: 0,
+      regularAmount: 0,
+      grossPay: 0,
+      eiAmount: 0,
+      cppAmount: 0,
+      totalWithholding: 0,
+      netPay: 0,
+    });
 
-    expect(html).toContain('Employer Signature');
-    expect(html).toContain('Employee Signature');
+    // No bar rather than a divide-by-zero one, and the rest still prints.
+    expect(html).not.toContain('class="bar-part"');
+    expect(html).toContain('Pay Statement');
+    expect(html).toContain('Net Pay');
   });
 
   it('shows a year rate suffix for salaried employees', () => {
@@ -117,7 +183,16 @@ describe('PdfService pay stub template', () => {
       payRate: 73000,
     });
 
-    expect(html).toContain('/Yr');
+    expect(html).toContain('/ year');
+  });
+
+  it('pins its colour scheme so a dark-mode renderer cannot invert it', () => {
+    const html = service.generatePayStubHtml(januaryStub);
+
+    expect(html).toContain('color-scheme: only light');
+    // The net-pay panel and the distribution bar carry meaning in their fills,
+    // so backgrounds must survive the print pipeline.
+    expect(html).toContain('print-color-adjust: exact');
   });
 
   it('escapes employee-supplied text rather than injecting it as markup', () => {

--- a/server/src/pdf/pdf.service.ts
+++ b/server/src/pdf/pdf.service.ts
@@ -8,7 +8,14 @@ import {
   renderDeclinedItemsHtml,
   renderSignatureHtml,
   renderTermsAndConditionsHtml,
+  PayStubDto,
 } from '@gt-automotive/data';
+
+/**
+ * The fields the pay stub template renders. A structural type rather than the
+ * full DTO so the template documents exactly what it depends on.
+ */
+type PayStubDocument = PayStubDto;
 
 @Injectable()
 export class PdfService {
@@ -1290,5 +1297,302 @@ ${
     const html = this.generatePreInspectionHtml(data);
     const pdfBuffer = await this.generatePdfFromHtml(html);
     return pdfBuffer.toString('base64');
+  }
+
+  /**
+   * Pay stub HTML.
+   *
+   * This is the *only* pay stub template. The on-screen view, the print action
+   * and any future emailed copy all render this same document, so unlike the
+   * invoice — which grew three templates that had to be reconciled by
+   * `invoice-print-sections.ts` — there is nothing here that can drift.
+   *
+   * Every value comes from the stored PayStub row, never from a live join, so
+   * reprinting an old stub reproduces exactly the figures it was issued with.
+   *
+   * Layout follows the business's existing stub: company header block with the
+   * PAY STUB title, a pay-cycle/employee detail block, a five-column earnings
+   * and withholdings table carrying both current-period and year-to-date
+   * figures, and employer/employee signature lines.
+   */
+  generatePayStubHtml(stub: PayStubDocument): string {
+    const escapeHtml = (value: unknown): string =>
+      String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+    const money = (amount: number) =>
+      new Intl.NumberFormat('en-CA', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(Number(amount || 0));
+
+    const hours = (value: number) => Number(value || 0).toFixed(2);
+
+    // Dates arrive as YYYY-MM-DD calendar dates. Format them in UTC so the
+    // printed day matches the business day they were stored as, on any server.
+    const shortDate = (value: string) => {
+      const [year, month, day] = value.split('-');
+      return `${day}/${month}/${year}`;
+    };
+    const longDate = (value: string) => {
+      const [year, month, day] = value.split('-').map(Number);
+      return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString(
+        'en-CA',
+        { month: 'long', day: 'numeric', year: 'numeric', timeZone: 'UTC' }
+      );
+    };
+
+    const logoBase64 = this.loadGtLogoBase64('pay stub');
+
+    // Amount-only rows (withholdings) leave the hours columns blank rather than
+    // printing 0.00, which would read as "zero hours worked" against a
+    // deduction line.
+    const earningRow = (
+      label: string,
+      currentHours: number,
+      currentAmount: number,
+      ytdHours: number,
+      ytdAmount: number,
+      strong = false
+    ) => `
+      <tr class="${strong ? 'total-row' : ''}">
+        <td>${escapeHtml(label)}</td>
+        <td class="num">${hours(currentHours)}</td>
+        <td class="num">${money(currentAmount)}</td>
+        <td class="num">${hours(ytdHours)}</td>
+        <td class="num">${money(ytdAmount)}</td>
+      </tr>`;
+
+    const amountRow = (
+      label: string,
+      currentAmount: number,
+      ytdAmount: number,
+      strong = false
+    ) => `
+      <tr class="${strong ? 'total-row' : ''}">
+        <td>${escapeHtml(label)}</td>
+        <td class="num">&mdash;</td>
+        <td class="num">${money(currentAmount)}</td>
+        <td class="num">&mdash;</td>
+        <td class="num">${money(ytdAmount)}</td>
+      </tr>`;
+
+    // EI and CPP always print, matching the business's existing stub. Income
+    // tax and any other deduction only appear when they carry a value, so a
+    // stub that withholds neither is not padded with empty $0.00 lines.
+    const withholdingRows = [
+      amountRow('Federal Employee EI', stub.eiAmount, stub.ytdEiAmount),
+      amountRow('Federal Employee CPP/QPP', stub.cppAmount, stub.ytdCppAmount),
+      stub.incomeTaxAmount > 0 || stub.ytdIncomeTaxAmount > 0
+        ? amountRow(
+            'Federal Income Tax',
+            stub.incomeTaxAmount,
+            stub.ytdIncomeTaxAmount
+          )
+        : '',
+      stub.otherDeductions > 0 || stub.ytdOtherDeductions > 0
+        ? amountRow(
+            stub.otherDeductionsLabel || 'Other Deductions',
+            stub.otherDeductions,
+            stub.ytdOtherDeductions
+          )
+        : '',
+    ]
+      .filter(Boolean)
+      .join('');
+
+    const payRateLine =
+      stub.payRate != null && stub.payRate > 0
+        ? `<div class="detail"><span>Pay Rate:</span> $${money(stub.payRate)}${
+            stub.payType === 'SALARIED' ? '/Yr' : '/Hr'
+          }</div>`
+        : '';
+
+    return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Pay Stub — ${escapeHtml(stub.employeeName)}</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      color: #1a1a1a;
+      margin: 0;
+      padding: 24px;
+      font-size: 12px;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      border-bottom: 2px solid #243c55;
+      padding-bottom: 12px;
+      margin-bottom: 16px;
+    }
+    .company { display: flex; gap: 12px; align-items: flex-start; }
+    .company img { height: 54px; width: auto; }
+    .company-name { font-size: 18px; font-weight: 700; color: #243c55; }
+    .company-address { color: #555; line-height: 1.5; }
+    .doc-title {
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 2px;
+      color: #243c55;
+    }
+    .details {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 4px 24px;
+      margin-bottom: 18px;
+    }
+    .detail span { font-weight: 700; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 7px 8px; border-bottom: 1px solid #e0e0e0; }
+    th {
+      background: #f2f5f8;
+      text-align: left;
+      font-size: 10px;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      color: #243c55;
+      border-bottom: 2px solid #243c55;
+    }
+    th.num, td.num { text-align: right; }
+    .total-row td { font-weight: 700; background: #fafbfc; }
+    .net-row td {
+      font-weight: 700;
+      font-size: 14px;
+      background: #243c55;
+      color: #fff;
+      border-bottom: none;
+    }
+    .section-label td {
+      padding-top: 14px;
+      font-weight: 700;
+      color: #243c55;
+      border-bottom: none;
+    }
+    .notes { margin-top: 18px; color: #555; }
+    .signatures {
+      display: flex;
+      justify-content: space-between;
+      gap: 48px;
+      margin-top: 56px;
+      page-break-inside: avoid;
+    }
+    .signature { flex: 1; }
+    .signature-line {
+      border-top: 1px solid #333;
+      padding-top: 6px;
+      font-size: 11px;
+      color: #555;
+    }
+    @media print {
+      body { padding: 0; }
+      @page { size: letter; margin: 12mm; }
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="company">
+      ${logoBase64 ? `<img src="${logoBase64}" alt="" />` : ''}
+      <div>
+        <div class="company-name">${escapeHtml(stub.companyName)}</div>
+        <div class="company-address">${escapeHtml(
+          stub.companyAddress || ''
+        ).replace(/,\s*/g, ',<br />')}</div>
+      </div>
+    </div>
+    <div class="doc-title">PAY STUB</div>
+  </div>
+
+  <div class="details">
+    <div class="detail"><span>Pay Cycle:</span> ${shortDate(
+      stub.periodStart
+    )} - ${shortDate(stub.periodEnd)}</div>
+    <div class="detail"><span>Pay Date:</span> ${longDate(stub.payDate)}</div>
+    <div class="detail"><span>Employee name:</span> ${escapeHtml(
+      stub.employeeName
+    )}</div>
+    ${
+      stub.position
+        ? `<div class="detail"><span>Position:</span> ${escapeHtml(
+            stub.position
+          )}</div>`
+        : ''
+    }
+    ${payRateLine}
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Descriptions</th>
+        <th class="num">Current Hours</th>
+        <th class="num">Current Amounts</th>
+        <th class="num">Year-to-Date Hours</th>
+        <th class="num">Year-to-Date Amounts</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${earningRow(
+        'Regular Pay',
+        stub.regularHours,
+        stub.regularAmount,
+        stub.ytdHours,
+        stub.ytdRegularAmount
+      )}
+      ${earningRow(
+        'Earnings Totals',
+        stub.regularHours,
+        stub.grossPay,
+        stub.ytdHours,
+        stub.ytdGrossPay,
+        true
+      )}
+      ${withholdingRows}
+      ${amountRow(
+        'Withholding Totals',
+        stub.totalWithholding,
+        stub.ytdWithholding,
+        true
+      )}
+      <tr class="net-row">
+        <td>NET PAY</td>
+        <td class="num">&mdash;</td>
+        <td class="num">${money(stub.netPay)}</td>
+        <td class="num">&mdash;</td>
+        <td class="num">${money(stub.ytdNetPay)}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  ${
+    stub.notes
+      ? `<div class="notes"><strong>Notes:</strong> ${escapeHtml(
+          stub.notes
+        )}</div>`
+      : ''
+  }
+
+  <div class="signatures">
+    <div class="signature">
+      <div class="signature-line">Employer Signature</div>
+    </div>
+    <div class="signature">
+      <div class="signature-line">Employee Signature</div>
+    </div>
+  </div>
+</body>
+</html>`;
+  }
+
+  async generatePayStubPdf(stub: PayStubDocument): Promise<Buffer> {
+    return this.generatePdfFromHtml(this.generatePayStubHtml(stub));
   }
 }

--- a/server/src/pdf/pdf.service.ts
+++ b/server/src/pdf/pdf.service.ts
@@ -1310,10 +1310,12 @@ ${
    * Every value comes from the stored PayStub row, never from a live join, so
    * reprinting an old stub reproduces exactly the figures it was issued with.
    *
-   * Layout follows the business's existing stub: company header block with the
-   * PAY STUB title, a pay-cycle/employee detail block, a five-column earnings
-   * and withholdings table carrying both current-period and year-to-date
-   * figures, and employer/employee signature lines.
+   * The layout leads with what the employee came for — net pay, gross and
+   * total deductions as summary figures, then a proportional bar showing how
+   * the gross was split — before the earnings and deductions detail, each
+   * carrying current-period and year-to-date columns. It is also a legal wage
+   * statement: BC's Employment Standards Act s.27 fixes what it must contain,
+   * and `pay-stub-template.spec.ts` guards those items.
    */
   generatePayStubHtml(stub: PayStubDocument): string {
     const escapeHtml = (value: unknown): string =>
@@ -1333,10 +1335,8 @@ ${
 
     // Dates arrive as YYYY-MM-DD calendar dates. Format them in UTC so the
     // printed day matches the business day they were stored as, on any server.
-    const shortDate = (value: string) => {
-      const [year, month, day] = value.split('-');
-      return `${day}/${month}/${year}`;
-    };
+    // One format throughout: a numeric date is ambiguous between day/month and
+    // month/day orders, which is not a thing to leave open on a pay record.
     const longDate = (value: string) => {
       const [year, month, day] = value.split('-').map(Number);
       return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString(
@@ -1347,69 +1347,127 @@ ${
 
     const logoBase64 = this.loadGtLogoBase64('pay stub');
 
-    // Amount-only rows (withholdings) leave the hours columns blank rather than
-    // printing 0.00, which would read as "zero hours worked" against a
-    // deduction line.
-    const earningRow = (
-      label: string,
-      currentHours: number,
-      currentAmount: number,
-      ytdHours: number,
-      ytdAmount: number,
-      strong = false
-    ) => `
-      <tr class="${strong ? 'total-row' : ''}">
-        <td>${escapeHtml(label)}</td>
-        <td class="num">${hours(currentHours)}</td>
-        <td class="num">${money(currentAmount)}</td>
-        <td class="num">${hours(ytdHours)}</td>
-        <td class="num">${money(ytdAmount)}</td>
-      </tr>`;
+    /**
+     * Deductions, each with the purpose named — BC's Employment Standards Act
+     * s.27(g) requires the amount *and* purpose of every deduction, so these
+     * labels are not decorative.
+     *
+     * EI and CPP always print, matching the business's existing stub. Income
+     * tax and any other deduction only appear when they carry a value, so a
+     * stub that withholds neither is not padded with empty $0.00 lines.
+     */
+    const deductions = [
+      {
+        label: 'Employment Insurance (EI)',
+        current: stub.eiAmount,
+        ytd: stub.ytdEiAmount,
+        colour: '#7d93ad',
+        always: true,
+      },
+      {
+        label: 'Canada Pension Plan (CPP)',
+        current: stub.cppAmount,
+        ytd: stub.ytdCppAmount,
+        colour: '#3a5270',
+        always: true,
+      },
+      {
+        label: 'Income Tax',
+        current: stub.incomeTaxAmount,
+        ytd: stub.ytdIncomeTaxAmount,
+        colour: '#ff6b35',
+        always: false,
+      },
+      {
+        label: stub.otherDeductionsLabel || 'Other Deductions',
+        current: stub.otherDeductions,
+        ytd: stub.ytdOtherDeductions,
+        colour: '#b9c4d0',
+        always: false,
+      },
+    ].filter((row) => row.always || row.current > 0 || row.ytd > 0);
 
-    const amountRow = (
-      label: string,
-      currentAmount: number,
-      ytdAmount: number,
-      strong = false
-    ) => `
-      <tr class="${strong ? 'total-row' : ''}">
-        <td>${escapeHtml(label)}</td>
-        <td class="num">&mdash;</td>
-        <td class="num">${money(currentAmount)}</td>
-        <td class="num">&mdash;</td>
-        <td class="num">${money(ytdAmount)}</td>
-      </tr>`;
-
-    // EI and CPP always print, matching the business's existing stub. Income
-    // tax and any other deduction only appear when they carry a value, so a
-    // stub that withholds neither is not padded with empty $0.00 lines.
-    const withholdingRows = [
-      amountRow('Federal Employee EI', stub.eiAmount, stub.ytdEiAmount),
-      amountRow('Federal Employee CPP/QPP', stub.cppAmount, stub.ytdCppAmount),
-      stub.incomeTaxAmount > 0 || stub.ytdIncomeTaxAmount > 0
-        ? amountRow(
-            'Federal Income Tax',
-            stub.incomeTaxAmount,
-            stub.ytdIncomeTaxAmount
-          )
-        : '',
-      stub.otherDeductions > 0 || stub.ytdOtherDeductions > 0
-        ? amountRow(
-            stub.otherDeductionsLabel || 'Other Deductions',
-            stub.otherDeductions,
-            stub.ytdOtherDeductions
-          )
-        : '',
-    ]
-      .filter(Boolean)
+    const deductionRows = deductions
+      .map(
+        (row) => `
+      <tr>
+        <td><span class="swatch" style="background:${
+          row.colour
+        }"></span>${escapeHtml(row.label)}</td>
+        <td class="num">${money(row.current)}</td>
+        <td class="num muted">${money(row.ytd)}</td>
+      </tr>`
+      )
       .join('');
 
-    const payRateLine =
-      stub.payRate != null && stub.payRate > 0
-        ? `<div class="detail"><span>Pay Rate:</span> $${money(stub.payRate)}${
-            stub.payType === 'SALARIED' ? '/Yr' : '/Hr'
-          }</div>`
+    /**
+     * Where the gross went, as one bar.
+     *
+     * This is the part of a pay stub people actually want answered — how much
+     * of what I earned reached me — and a proportional bar answers it at a
+     * glance in a way a column of figures never does. Widths are percentages of
+     * gross computed here; the document carries no scripts, so nothing is
+     * measured or drawn at render time.
+     */
+    const gross = Number(stub.grossPay || 0);
+    const share = (amount: number) => (gross > 0 ? (amount / gross) * 100 : 0);
+    const barSegments = [
+      {
+        label: 'Take-home',
+        amount: Number(stub.netPay || 0),
+        colour: '#243c55',
+      },
+      ...deductions
+        .filter((row) => row.current > 0)
+        .map((row) => ({
+          label: row.label,
+          amount: row.current,
+          colour: row.colour,
+        })),
+    ].filter((segment) => segment.amount > 0);
+
+    const distribution =
+      gross > 0 && barSegments.length > 0
+        ? `
+      <div class="distribution">
+        <div class="bar">
+          ${barSegments
+            .map(
+              (segment) =>
+                `<div class="bar-part" style="width:${share(
+                  segment.amount
+                ).toFixed(4)}%;background:${segment.colour}"></div>`
+            )
+            .join('')}
+        </div>
+        <div class="legend">
+          ${barSegments
+            .map(
+              (segment) => `
+            <span class="legend-item">
+              <span class="swatch" style="background:${segment.colour}"></span>
+              ${escapeHtml(segment.label)}
+              <strong>${share(segment.amount).toFixed(1)}%</strong>
+            </span>`
+            )
+            .join('')}
+        </div>
+      </div>`
         : '';
+
+    const payRateValue =
+      stub.payRate != null && stub.payRate > 0
+        ? `$${money(stub.payRate)}${
+            stub.payType === 'SALARIED' ? ' / year' : ' / hour'
+          }`
+        : '&mdash;';
+
+    const detail = (label: string, value: string, sub?: string) => `
+      <div class="detail">
+        <div class="detail-label">${escapeHtml(label)}</div>
+        <div class="detail-value">${value}</div>
+        ${sub ? `<div class="detail-sub">${sub}</div>` : ''}
+      </div>`;
 
     return `<!DOCTYPE html>
 <html>
@@ -1418,83 +1476,248 @@ ${
   <title>Pay Stub — ${escapeHtml(stub.employeeName)}</title>
   <style>
     * { box-sizing: border-box; }
-    body {
-      font-family: Arial, Helvetica, sans-serif;
-      color: #1a1a1a;
-      margin: 0;
-      padding: 24px;
-      font-size: 12px;
+
+    /* Backgrounds carry meaning here — the net-pay card and the distribution
+       bar are not decoration — so they must survive the print pipeline. The
+       colour scheme is pinned too: a wage statement must look the same
+       everywhere, and a renderer in dark mode would otherwise invert it. */
+    html {
+      color-scheme: only light;
     }
+    html, body {
+      background: #ffffff;
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+
+    body {
+      font-family: 'Segoe UI', Arial, Helvetica, sans-serif;
+      color: #1f2933;
+      margin: 0;
+      padding: 0;
+      font-size: 11px;
+      line-height: 1.45;
+    }
+
+    /* Figures line up column-wise only with tabular figures; proportional
+       digits make a column of money look ragged. */
+    .num, .amount, .stat-value, .summary-value {
+      font-variant-numeric: tabular-nums;
+      font-feature-settings: 'tnum' 1;
+    }
+
     .header {
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
-      border-bottom: 2px solid #243c55;
       padding-bottom: 12px;
-      margin-bottom: 16px;
+      border-bottom: 3px solid #243c55;
     }
     .company { display: flex; gap: 12px; align-items: flex-start; }
-    .company img { height: 54px; width: auto; }
-    .company-name { font-size: 18px; font-weight: 700; color: #243c55; }
-    .company-address { color: #555; line-height: 1.5; }
+    .company img { height: 52px; width: auto; }
+    .company-name {
+      font-size: 17px;
+      font-weight: 700;
+      color: #243c55;
+      letter-spacing: -0.2px;
+    }
+    /* The incorporated name is what legally identifies the employer on a wage
+       statement, so it reads at nearly the weight of the trading name rather
+       than as fine print. */
+    .company-registration {
+      color: #243c55;
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .company-address { color: #66727f; line-height: 1.45; margin-top: 4px; }
+    .doc-meta { text-align: right; }
     .doc-title {
-      font-size: 22px;
+      font-size: 13px;
       font-weight: 700;
-      letter-spacing: 2px;
+      letter-spacing: 3px;
       color: #243c55;
-    }
-    .details {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 4px 24px;
-      margin-bottom: 18px;
-    }
-    .detail span { font-weight: 700; }
-    table { width: 100%; border-collapse: collapse; }
-    th, td { padding: 7px 8px; border-bottom: 1px solid #e0e0e0; }
-    th {
-      background: #f2f5f8;
-      text-align: left;
-      font-size: 10px;
-      letter-spacing: 0.4px;
       text-transform: uppercase;
-      color: #243c55;
-      border-bottom: 2px solid #243c55;
     }
-    th.num, td.num { text-align: right; }
-    .total-row td { font-weight: 700; background: #fafbfc; }
-    .net-row td {
-      font-weight: 700;
-      font-size: 14px;
-      background: #243c55;
-      color: #fff;
-      border-bottom: none;
-    }
-    .section-label td {
-      padding-top: 14px;
-      font-weight: 700;
-      color: #243c55;
-      border-bottom: none;
-    }
-    .notes { margin-top: 18px; color: #555; }
-    .signatures {
+    /* Label and value are set apart rather than run together, so the dates read
+       as values instead of as the tail of a sentence. */
+    .doc-sub {
       display: flex;
-      justify-content: space-between;
-      gap: 48px;
-      margin-top: 56px;
+      justify-content: flex-end;
+      gap: 12px;
+      margin-top: 3px;
+    }
+    .doc-sub-label { color: #7b8794; }
+    .doc-sub strong { color: #1f2933; font-weight: 600; }
+
+    /* Summary cards — the three figures an employee looks for first. */
+    .summary {
+      display: flex;
+      gap: 10px;
+      margin-top: 16px;
       page-break-inside: avoid;
     }
-    .signature { flex: 1; }
-    .signature-line {
-      border-top: 1px solid #333;
-      padding-top: 6px;
-      font-size: 11px;
-      color: #555;
+    .stat {
+      flex: 1;
+      border: 1px solid #dfe4ea;
+      border-radius: 6px;
+      padding: 10px 12px;
     }
-    @media print {
-      body { padding: 0; }
-      @page { size: letter; margin: 12mm; }
+    .stat-label {
+      font-size: 9px;
+      letter-spacing: 1.1px;
+      text-transform: uppercase;
+      color: #7b8794;
+      font-weight: 700;
     }
+    .stat-value {
+      font-size: 19px;
+      font-weight: 700;
+      color: #1f2933;
+      margin-top: 2px;
+      letter-spacing: -0.4px;
+    }
+    .stat-ytd { color: #7b8794; font-size: 10px; }
+    /* Net pay is the headline figure, but it earns that with weight and a
+       heavier rule rather than a block of ink — a filled panel dominates the
+       page and costs toner on every stub printed. */
+    .stat.net {
+      border: 2px solid #243c55;
+      flex: 1.35;
+    }
+    .stat.net .stat-label { color: #243c55; }
+    .stat.net .stat-value { color: #243c55; font-size: 25px; }
+    .stat.deductions .stat-value { color: #c2410c; }
+
+    /* Where the gross went. */
+    .distribution { margin-top: 12px; page-break-inside: avoid; }
+    .bar {
+      display: flex;
+      height: 12px;
+      border-radius: 6px;
+      overflow: hidden;
+      background: #eef1f5;
+    }
+    .bar-part { height: 100%; }
+    .legend {
+      margin-top: 6px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px 16px;
+      color: #66727f;
+      font-size: 10px;
+    }
+    .legend-item { display: inline-flex; align-items: center; gap: 5px; }
+    .legend-item strong { color: #1f2933; }
+    .swatch {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 2px;
+      margin-right: 6px;
+      vertical-align: baseline;
+    }
+    .legend-item .swatch { margin-right: 0; }
+
+    .details {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 10px 16px;
+      margin-top: 16px;
+      padding: 12px 14px;
+      background: #f7f9fb;
+      border-radius: 6px;
+      page-break-inside: avoid;
+    }
+    .detail-label {
+      font-size: 9px;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      color: #7b8794;
+      font-weight: 700;
+    }
+    .detail-value { color: #1f2933; font-weight: 600; }
+    .detail-sub { color: #7b8794; font-size: 10px; }
+
+    .columns {
+      display: flex;
+      gap: 16px;
+      margin-top: 16px;
+      page-break-inside: avoid;
+    }
+    .column { flex: 1; }
+    .column-title {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 1.2px;
+      text-transform: uppercase;
+      color: #243c55;
+      padding-bottom: 6px;
+      border-bottom: 2px solid #243c55;
+    }
+
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 6px 2px; border-bottom: 1px solid #eceff3; }
+    th {
+      text-align: left;
+      font-size: 9px;
+      letter-spacing: 0.6px;
+      text-transform: uppercase;
+      color: #7b8794;
+      font-weight: 700;
+    }
+    th.num, td.num { text-align: right; }
+    td.muted { color: #7b8794; }
+    .total-row td {
+      font-weight: 700;
+      border-top: 1px solid #cbd2d9;
+      border-bottom: none;
+      padding-top: 7px;
+    }
+
+    /* The arithmetic of the stub, spelled out: gross − deductions = net. */
+    .summary-strip {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-top: 18px;
+      padding: 12px 14px;
+      border: 1px solid #dfe4ea;
+      border-left: 4px solid #243c55;
+      border-radius: 6px;
+      page-break-inside: avoid;
+    }
+    .summary-cell { flex: 1; }
+    .summary-label {
+      font-size: 9px;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      color: #7b8794;
+      font-weight: 700;
+    }
+    .summary-value { font-size: 14px; font-weight: 700; }
+    .summary-op { font-size: 16px; color: #9aa5b1; font-weight: 700; }
+    .summary-cell.net .summary-value { color: #243c55; font-size: 17px; }
+    .summary-ytd { color: #7b8794; font-size: 10px; }
+
+    .notes {
+      margin-top: 14px;
+      padding: 10px 12px;
+      background: #f7f9fb;
+      border-radius: 6px;
+      color: #52606d;
+    }
+    .notes strong { color: #1f2933; }
+
+    .footer {
+      margin-top: 28px;
+      padding-top: 10px;
+      border-top: 1px solid #eceff3;
+      color: #9aa5b1;
+      font-size: 9px;
+      text-align: center;
+    }
+
+    @page { size: letter; margin: 12mm; }
   </style>
 </head>
 <body>
@@ -1503,74 +1726,138 @@ ${
       ${logoBase64 ? `<img src="${logoBase64}" alt="" />` : ''}
       <div>
         <div class="company-name">${escapeHtml(stub.companyName)}</div>
-        <div class="company-address">${escapeHtml(
-          stub.companyAddress || ''
-        ).replace(/,\s*/g, ',<br />')}</div>
+        ${
+          stub.companyRegistrationNumber
+            ? `<div class="company-registration">${escapeHtml(
+                stub.companyRegistrationNumber
+              )} Canada INC.</div>`
+            : ''
+        }
+        ${
+          stub.companyAddress
+            ? `<div class="company-address">${escapeHtml(
+                stub.companyAddress
+              )}</div>`
+            : ''
+        }
       </div>
     </div>
-    <div class="doc-title">PAY STUB</div>
+    <div class="doc-meta">
+      <div class="doc-title">Pay Statement</div>
+      <div class="doc-sub">
+        <span class="doc-sub-label">Pay date</span>
+        <strong>${longDate(stub.payDate)}</strong>
+      </div>
+      <div class="doc-sub">
+        <span class="doc-sub-label">Pay period</span>
+        <strong>${longDate(stub.periodStart)} &ndash; ${longDate(
+      stub.periodEnd
+    )}</strong>
+      </div>
+    </div>
   </div>
+
+  <div class="summary">
+    <div class="stat net">
+      <div class="stat-label">Net Pay &middot; This Period</div>
+      <div class="stat-value">$${money(stub.netPay)}</div>
+      <div class="stat-ytd">$${money(stub.ytdNetPay)} year to date</div>
+    </div>
+    <div class="stat">
+      <div class="stat-label">Gross Pay</div>
+      <div class="stat-value">$${money(stub.grossPay)}</div>
+      <div class="stat-ytd">$${money(stub.ytdGrossPay)} YTD</div>
+    </div>
+    <div class="stat deductions">
+      <div class="stat-label">Deductions</div>
+      <div class="stat-value">$${money(stub.totalWithholding)}</div>
+      <div class="stat-ytd">$${money(stub.ytdWithholding)} YTD</div>
+    </div>
+  </div>
+
+  ${distribution}
 
   <div class="details">
-    <div class="detail"><span>Pay Cycle:</span> ${shortDate(
-      stub.periodStart
-    )} - ${shortDate(stub.periodEnd)}</div>
-    <div class="detail"><span>Pay Date:</span> ${longDate(stub.payDate)}</div>
-    <div class="detail"><span>Employee name:</span> ${escapeHtml(
-      stub.employeeName
-    )}</div>
-    ${
-      stub.position
-        ? `<div class="detail"><span>Position:</span> ${escapeHtml(
-            stub.position
-          )}</div>`
-        : ''
-    }
-    ${payRateLine}
+    ${detail('Employee', escapeHtml(stub.employeeName))}
+    ${detail('Position', escapeHtml(stub.position || '—'))}
+    ${detail('Pay Rate', payRateValue)}
+    ${detail(
+      'Hours',
+      hours(stub.regularHours),
+      `${hours(stub.ytdHours)} year to date`
+    )}
   </div>
 
-  <table>
-    <thead>
-      <tr>
-        <th>Descriptions</th>
-        <th class="num">Current Hours</th>
-        <th class="num">Current Amounts</th>
-        <th class="num">Year-to-Date Hours</th>
-        <th class="num">Year-to-Date Amounts</th>
-      </tr>
-    </thead>
-    <tbody>
-      ${earningRow(
-        'Regular Pay',
-        stub.regularHours,
-        stub.regularAmount,
-        stub.ytdHours,
-        stub.ytdRegularAmount
-      )}
-      ${earningRow(
-        'Earnings Totals',
-        stub.regularHours,
-        stub.grossPay,
-        stub.ytdHours,
-        stub.ytdGrossPay,
-        true
-      )}
-      ${withholdingRows}
-      ${amountRow(
-        'Withholding Totals',
-        stub.totalWithholding,
-        stub.ytdWithholding,
-        true
-      )}
-      <tr class="net-row">
-        <td>NET PAY</td>
-        <td class="num">&mdash;</td>
-        <td class="num">${money(stub.netPay)}</td>
-        <td class="num">&mdash;</td>
-        <td class="num">${money(stub.ytdNetPay)}</td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="columns">
+    <div class="column">
+      <div class="column-title">Earnings</div>
+      <table>
+        <thead>
+          <tr>
+            <th>Description</th>
+            <th class="num">Hours</th>
+            <th class="num">Current</th>
+            <th class="num">Year to Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Regular Pay</td>
+            <td class="num">${hours(stub.regularHours)}</td>
+            <td class="num">${money(stub.regularAmount)}</td>
+            <td class="num muted">${money(stub.ytdRegularAmount)}</td>
+          </tr>
+          <tr class="total-row">
+            <td>Gross Pay</td>
+            <td class="num">${hours(stub.regularHours)}</td>
+            <td class="num">${money(stub.grossPay)}</td>
+            <td class="num">${money(stub.ytdGrossPay)}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="column">
+      <div class="column-title">Deductions</div>
+      <table>
+        <thead>
+          <tr>
+            <th>Description</th>
+            <th class="num">Current</th>
+            <th class="num">Year to Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${deductionRows}
+          <tr class="total-row">
+            <td>Total Deductions</td>
+            <td class="num">${money(stub.totalWithholding)}</td>
+            <td class="num">${money(stub.ytdWithholding)}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="summary-strip">
+    <div class="summary-cell">
+      <div class="summary-label">Gross Pay</div>
+      <div class="summary-value">$${money(stub.grossPay)}</div>
+      <div class="summary-ytd">$${money(stub.ytdGrossPay)} YTD</div>
+    </div>
+    <div class="summary-op">&minus;</div>
+    <div class="summary-cell">
+      <div class="summary-label">Deductions</div>
+      <div class="summary-value">$${money(stub.totalWithholding)}</div>
+      <div class="summary-ytd">$${money(stub.ytdWithholding)} YTD</div>
+    </div>
+    <div class="summary-op">=</div>
+    <div class="summary-cell net">
+      <div class="summary-label">Net Pay</div>
+      <div class="summary-value">$${money(stub.netPay)}</div>
+      <div class="summary-ytd">$${money(stub.ytdNetPay)} YTD</div>
+    </div>
+  </div>
 
   ${
     stub.notes
@@ -1580,13 +1867,12 @@ ${
       : ''
   }
 
-  <div class="signatures">
-    <div class="signature">
-      <div class="signature-line">Employer Signature</div>
-    </div>
-    <div class="signature">
-      <div class="signature-line">Employee Signature</div>
-    </div>
+  <div class="footer">
+    ${escapeHtml(stub.companyName)} &middot; Pay statement for ${longDate(
+      stub.periodStart
+    )} &ndash; ${longDate(
+      stub.periodEnd
+    )} &middot; Retain this statement for your records
   </div>
 </body>
 </html>`;

--- a/server/src/time-clock/time-clock-payroll-hours.service.spec.ts
+++ b/server/src/time-clock/time-clock-payroll-hours.service.spec.ts
@@ -1,0 +1,167 @@
+import { TimeClockService } from './time-clock.service';
+
+/**
+ * Unit tests for the read-only payroll hours calculation.
+ *
+ * The guarantee under test is the one that makes pay stub pre-fill safe:
+ * reading an employee's hours must never mark their time entries as processed.
+ * processPayroll() does stamp them, and both paths share one calculation, so
+ * these tests pin down which behaviour belongs to which entry point.
+ */
+describe('TimeClockService payroll hours', () => {
+  let service: TimeClockService;
+  let prisma: any;
+  let auditRepository: any;
+
+  const employee = {
+    id: 'emp-1',
+    firstName: 'Rohit',
+    lastName: 'Toora',
+    email: 'rohit@example.com',
+    role: { name: 'STAFF' },
+  };
+
+  // Two approved 8-hour entries, one already put through payroll.
+  const entries = [
+    {
+      id: 'te-1',
+      employeeId: 'emp-1',
+      clockInAt: new Date('2026-01-05T17:00:00.000Z'),
+      clockOutAt: new Date('2026-01-06T01:00:00.000Z'),
+      status: 'APPROVED',
+      payrollProcessedAt: null,
+      breaks: [],
+      employee,
+    },
+    {
+      id: 'te-2',
+      employeeId: 'emp-1',
+      clockInAt: new Date('2026-01-06T17:00:00.000Z'),
+      clockOutAt: new Date('2026-01-07T01:00:00.000Z'),
+      status: 'APPROVED',
+      payrollProcessedAt: new Date('2026-01-08T00:00:00.000Z'),
+      breaks: [],
+      employee,
+    },
+  ];
+
+  beforeEach(() => {
+    prisma = {
+      user: {
+        findUnique: jest.fn().mockResolvedValue(employee),
+        findMany: jest.fn().mockResolvedValue([employee]),
+      },
+      timeEntry: {
+        findMany: jest.fn(({ where }: any) =>
+          Promise.resolve(
+            where.payrollProcessedAt === null
+              ? entries.filter((entry) => !entry.payrollProcessedAt)
+              : entries
+          )
+        ),
+        updateMany: jest.fn(),
+      },
+      employeeCompensation: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValue({ payType: 'HOURLY', hourlyRate: 24 }),
+      },
+    };
+    auditRepository = { create: jest.fn() };
+
+    service = new TimeClockService(prisma, auditRepository);
+  });
+
+  describe('getPayrollHours', () => {
+    it('never stamps entries as processed', async () => {
+      await service.getPayrollHours(
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-31T23:59:59.000Z',
+        'emp-1'
+      );
+
+      expect(prisma.timeEntry.updateMany).not.toHaveBeenCalled();
+      expect(auditRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('counts approved entries whether or not payroll has processed them', async () => {
+      const [row] = await service.getPayrollHours(
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-31T23:59:59.000Z',
+        'emp-1'
+      );
+
+      // A stub describes the period, so it must not collapse to the unprocessed
+      // subset just because payroll happened to run first.
+      expect(row.hours).toBe(16);
+      expect(row.processedHours).toBe(8);
+      expect(row.grossPay).toBe(384);
+    });
+
+    it('carries the employee summary so callers need no access to the user list', async () => {
+      const [row] = await service.getPayrollHours(
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-31T23:59:59.000Z',
+        'emp-1'
+      );
+
+      expect(row.employee).toEqual(
+        expect.objectContaining({ id: 'emp-1', firstName: 'Rohit' })
+      );
+    });
+
+    it('prorates an annual salary instead of reporting $0 gross for salaried staff', async () => {
+      prisma.employeeCompensation.findFirst.mockResolvedValue({
+        payType: 'SALARIED',
+        annualSalary: 73000,
+      });
+
+      const [row] = await service.getPayrollHours(
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-31T00:00:00.000Z',
+        'emp-1'
+      );
+
+      expect(row.hourlyRate).toBe(0);
+      expect(row.salaryPay).toBeGreaterThan(0);
+      expect(row.grossPay).toBe(row.salaryPay);
+    });
+
+    it('reports when an employee has no active compensation record', async () => {
+      prisma.employeeCompensation.findFirst.mockResolvedValue(null);
+
+      const [row] = await service.getPayrollHours(
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-31T23:59:59.000Z',
+        'emp-1'
+      );
+
+      expect(row.hasCompensation).toBe(false);
+      expect(row.grossPay).toBe(0);
+    });
+  });
+
+  describe('processPayroll', () => {
+    it('consumes only unprocessed entries and stamps them', async () => {
+      const result = await service.processPayroll(
+        {
+          employeeId: 'emp-1',
+          startDate: '2026-01-01T00:00:00.000Z',
+          endDate: '2026-01-31T23:59:59.000Z',
+        } as any,
+        'admin-1'
+      );
+
+      // Only te-1 is unprocessed, so payroll must not pay te-2 a second time.
+      expect(result.processedHours).toBe(8);
+      expect(prisma.timeEntry.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: { in: ['te-1'] } },
+        })
+      );
+      expect(auditRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'PROCESS_PAYROLL_HOURS' })
+      );
+    });
+  });
+});

--- a/server/src/time-clock/time-clock-payroll-hours.service.spec.ts
+++ b/server/src/time-clock/time-clock-payroll-hours.service.spec.ts
@@ -38,7 +38,7 @@ describe('TimeClockService payroll hours', () => {
       employeeId: 'emp-1',
       clockInAt: new Date('2026-01-06T17:00:00.000Z'),
       clockOutAt: new Date('2026-01-07T01:00:00.000Z'),
-      status: 'APPROVED',
+      status: 'PROCESSED',
       payrollProcessedAt: new Date('2026-01-08T00:00:00.000Z'),
       breaks: [],
       employee,
@@ -60,6 +60,9 @@ describe('TimeClockService payroll hours', () => {
           )
         ),
         updateMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn((args: any) => ({ ...entries[0], ...args.data })),
+        delete: jest.fn(),
       },
       employeeCompensation: {
         findFirst: jest
@@ -162,6 +165,76 @@ describe('TimeClockService payroll hours', () => {
       expect(auditRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'PROCESS_PAYROLL_HOURS' })
       );
+    });
+
+    it('moves processed entries onto the terminal status', async () => {
+      await service.processPayroll(
+        {
+          employeeId: 'emp-1',
+          startDate: '2026-01-01T00:00:00.000Z',
+          endDate: '2026-01-31T23:59:59.000Z',
+        } as any,
+        'admin-1'
+      );
+
+      // A paid entry should not still read as merely approved.
+      const [[{ data }]] = prisma.timeEntry.updateMany.mock.calls;
+      expect(data.status).toBe('PROCESSED');
+      expect(data.payrollProcessedAt).toBeInstanceOf(Date);
+      expect(data.payrollProcessedBy).toBe('admin-1');
+    });
+  });
+
+  describe('a processed entry is final', () => {
+    // The record behind money that has already left the business.
+    const processed = {
+      id: 'te-2',
+      employeeId: 'emp-1',
+      clockInAt: new Date('2026-01-06T17:00:00.000Z'),
+      clockOutAt: new Date('2026-01-07T01:00:00.000Z'),
+      status: 'PROCESSED',
+      payrollProcessedAt: new Date('2026-01-08T00:00:00.000Z'),
+      breaks: [],
+      employee,
+    };
+
+    beforeEach(() => {
+      prisma.timeEntry.findUnique.mockResolvedValue(processed);
+    });
+
+    const rejected = async (run: () => Promise<unknown>) => {
+      await expect(run()).rejects.toThrow(/already been processed for payroll/);
+      expect(prisma.timeEntry.update).not.toHaveBeenCalled();
+      expect(prisma.timeEntry.delete).not.toHaveBeenCalled();
+    };
+
+    it('cannot be edited', async () => {
+      await rejected(() =>
+        service.updateEntry(
+          'te-2',
+          {
+            clockOutAt: '2026-01-07T02:00:00.000Z',
+            adjustmentReason: 'fix',
+          } as any,
+          'admin-1'
+        )
+      );
+    });
+
+    it('cannot be voided', async () => {
+      await rejected(() => service.voidEntry('te-2', 'admin-1', 'mistake'));
+    });
+
+    it('cannot be deleted', async () => {
+      await rejected(() => service.deleteEntry('te-2', 'admin-1'));
+    });
+
+    it('cannot be unapproved', async () => {
+      await rejected(() => service.unapproveEntry('te-2', 'admin-1'));
+    });
+
+    it('cannot be re-approved', async () => {
+      await rejected(() => service.approveEntry('te-2', 'admin-1'));
     });
   });
 });

--- a/server/src/time-clock/time-clock.controller.ts
+++ b/server/src/time-clock/time-clock.controller.ts
@@ -104,8 +104,10 @@ export class TimeClockController {
     return this.timeClockService.getCurrentEntries();
   }
 
+  // ACCOUNTANT is read-only across time clock: they need hours to raise pay
+  // stubs, but approving, adjusting and processing stay with ADMIN/FOREMAN.
   @Get('entries')
-  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR')
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'ACCOUNTANT')
   getEntries(
     @CurrentUser() user: any,
     @Query('employeeId') employeeId?: string,
@@ -164,7 +166,7 @@ export class TimeClockController {
   }
 
   @Get('employees/:employeeId/compensation')
-  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR')
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'ACCOUNTANT')
   getCompensation(@Param('employeeId') employeeId: string) {
     return this.timeClockService.getCompensation(employeeId);
   }
@@ -210,13 +212,32 @@ export class TimeClockController {
   }
 
   @Get('payroll-summary')
-  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR')
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'ACCOUNTANT')
   getPayrollSummary(
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
     @Query('employeeId') employeeId?: string
   ) {
     return this.timeClockService.getPayrollSummary(
+      startDate,
+      endDate,
+      employeeId
+    );
+  }
+
+  /**
+   * Approved hours and gross pay per employee over a period. Read-only — this
+   * is what the accountant's hours view and the pay stub form pre-fill read,
+   * and it must never stamp entries the way POST process-payroll does.
+   */
+  @Get('payroll-hours')
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'ACCOUNTANT')
+  getPayrollHours(
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+    @Query('employeeId') employeeId?: string
+  ) {
+    return this.timeClockService.getPayrollHours(
       startDate,
       endDate,
       employeeId

--- a/server/src/time-clock/time-clock.service.ts
+++ b/server/src/time-clock/time-clock.service.ts
@@ -26,6 +26,15 @@ const ACTIVE_TIME_ENTRY_STATUSES = [
   TimeEntryStatus.OPEN,
   TimeEntryStatus.ON_BREAK,
 ];
+/**
+ * Work the business has agreed to pay for: approved, and approved-then-paid.
+ * Processing moves an entry from one to the other, so anything counting payable
+ * hours must accept both or the totals collapse the moment payroll is run.
+ */
+const PAYABLE_TIME_ENTRY_STATUSES = [
+  TimeEntryStatus.APPROVED,
+  TimeEntryStatus.PROCESSED,
+];
 const STAFF_PAYROLL_ROLES = ['ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF'];
 
 @Injectable()
@@ -303,6 +312,23 @@ export class TimeClockService {
     return this.toTimeEntryDto(entry);
   }
 
+  /**
+   * A processed entry is the evidence behind money that has already left the
+   * business. Changing it after the fact would leave the pay that was issued
+   * unsupported by the record it was calculated from, so every mutation stops
+   * here rather than each one remembering to check.
+   */
+  private assertNotProcessed(
+    entry: { payrollProcessedAt?: Date | null },
+    action: string
+  ) {
+    if (entry.payrollProcessedAt) {
+      throw new BadRequestException(
+        `Cannot ${action} an entry that has already been processed for payroll`
+      );
+    }
+  }
+
   async updateEntry(id: string, dto: UpdateTimeEntryDto, userId: string) {
     const existing = await this.prisma.timeEntry.findUnique({
       where: { id },
@@ -312,6 +338,8 @@ export class TimeClockService {
     if (!existing) {
       throw new NotFoundException('Time entry not found');
     }
+
+    this.assertNotProcessed(existing, 'edit');
 
     if (existing.status === TimeEntryStatus.APPROVED) {
       throw new BadRequestException(
@@ -399,6 +427,7 @@ export class TimeClockService {
     if (!existing.clockOutAt) {
       throw new BadRequestException('Cannot approve an open time entry');
     }
+    this.assertNotProcessed(existing, 'approve');
 
     const updated = await this.prisma.timeEntry.update({
       where: { id },
@@ -427,13 +456,12 @@ export class TimeClockService {
     if (!existing) {
       throw new NotFoundException('Time entry not found');
     }
+    // Processed first: it is the stronger rule, and a processed entry is no
+    // longer APPROVED, so the status check alone would refuse it for the wrong
+    // reason and tell the user something unhelpful.
+    this.assertNotProcessed(existing, 'unapprove');
     if (existing.status !== TimeEntryStatus.APPROVED) {
       throw new BadRequestException('Only approved entries can be unapproved');
-    }
-    if (existing.payrollProcessedAt) {
-      throw new BadRequestException(
-        'Cannot unapprove an entry that has already been processed for payroll'
-      );
     }
 
     const updated = await this.prisma.timeEntry.update({
@@ -466,11 +494,7 @@ export class TimeClockService {
     if (!existing) {
       throw new NotFoundException('Time entry not found');
     }
-    if (existing.payrollProcessedAt) {
-      throw new BadRequestException(
-        'Cannot delete an entry that has already been processed for payroll'
-      );
-    }
+    this.assertNotProcessed(existing, 'delete');
 
     await this.prisma.timeEntry.delete({ where: { id } });
 
@@ -490,6 +514,7 @@ export class TimeClockService {
     if (!existing) {
       throw new NotFoundException('Time entry not found');
     }
+    this.assertNotProcessed(existing, 'void');
 
     const updated = await this.prisma.timeEntry.update({
       where: { id },
@@ -593,7 +618,9 @@ export class TimeClockService {
     const entries = await this.prisma.timeEntry.findMany({
       where: {
         employeeId,
-        status: TimeEntryStatus.APPROVED as any,
+        status: options.unprocessedOnly
+          ? (TimeEntryStatus.APPROVED as any)
+          : ({ in: PAYABLE_TIME_ENTRY_STATUSES as any[] } as any),
         ...(options.unprocessedOnly ? { payrollProcessedAt: null } : {}),
         clockInAt: this.dateRangeFilter(startDate, endDate),
       },
@@ -725,6 +752,9 @@ export class TimeClockService {
       await this.prisma.timeEntry.updateMany({
         where: { id: { in: entries.map((entry) => entry.id) } },
         data: {
+          // The status carries the outcome, not just the timestamp: an entry
+          // that has been paid should not still read as merely "approved".
+          status: TimeEntryStatus.PROCESSED as any,
           payrollProcessedAt: processedAt,
           payrollProcessedBy: userId,
         },
@@ -767,7 +797,7 @@ export class TimeClockService {
           employeeId,
           status: {
             in: [
-              TimeEntryStatus.APPROVED,
+              ...PAYABLE_TIME_ENTRY_STATUSES,
               TimeEntryStatus.CLOCKED_OUT,
               TimeEntryStatus.ADJUSTED,
             ] as any[],
@@ -818,7 +848,7 @@ export class TimeClockService {
     for (const entry of entries) {
       const bucket = getBucket(entry.employee);
       const hours = this.calculateMinutes(entry).paidMinutes / 60;
-      if (entry.status === TimeEntryStatus.APPROVED) {
+      if (PAYABLE_TIME_ENTRY_STATUSES.includes(entry.status as any)) {
         bucket.approvedHours += hours;
         if (entry.payrollProcessedAt) {
           bucket.processedHours += hours;

--- a/server/src/time-clock/time-clock.service.ts
+++ b/server/src/time-clock/time-clock.service.ts
@@ -56,6 +56,7 @@ export class TimeClockService {
       return tx.employeeCompensation.create({
         data: {
           employeeId,
+          position: dto.position?.trim() || null,
           payType: dto.payType as any,
           hourlyRate: dto.hourlyRate,
           annualSalary: dto.annualSalary,
@@ -636,6 +637,9 @@ export class TimeClockService {
       hours,
       payType: compensation?.payType,
       hasCompensation: Boolean(compensation),
+      // Carried so the pay stub form can pre-fill the job title without a
+      // second round trip for the compensation record.
+      position: compensation?.position || undefined,
       hourlyRate,
       salaryPay,
       grossPay,
@@ -1020,6 +1024,7 @@ export class TimeClockService {
     return {
       id: compensation.id,
       employeeId: compensation.employeeId,
+      position: compensation.position || undefined,
       payType: compensation.payType,
       hourlyRate:
         compensation.hourlyRate === null

--- a/server/src/time-clock/time-clock.service.ts
+++ b/server/src/time-clock/time-clock.service.ts
@@ -209,8 +209,21 @@ export class TimeClockService {
     },
     currentUser: any
   ) {
+    // STAFF only ever see their own entries. Every other role that reaches this
+    // endpoint — ADMIN, FOREMAN, SUPERVISOR and ACCOUNTANT — is trusted with
+    // the whole team, so the employee filter is theirs to choose. Stated as an
+    // explicit list rather than "not STAFF" so adding a role to the guard is a
+    // deliberate decision here too, not an accident of the default branch.
     const role = currentUser?.role?.name;
-    const employeeId = role === 'STAFF' ? currentUser.id : filters.employeeId;
+    const canViewAllEmployees = [
+      'ADMIN',
+      'FOREMAN',
+      'SUPERVISOR',
+      'ACCOUNTANT',
+    ].includes(role);
+    const employeeId = canViewAllEmployees
+      ? filters.employeeId
+      : currentUser.id;
 
     const entries = await this.prisma.timeEntry.findMany({
       where: {
@@ -551,20 +564,42 @@ export class TimeClockService {
     return adjustments.map((adjustment) => this.toAdjustmentDto(adjustment));
   }
 
-  async processPayroll(dto: ProcessPayrollDto, userId: string) {
-    await this.assertPayrollEmployee(dto.employeeId);
-
+  /**
+   * Hours and gross pay for one employee over a date range. Pure read — this
+   * method never writes, so it is safe to call from anything that only wants
+   * the numbers (the pay stub form pre-fill, the accountant's hours view).
+   *
+   * It is the single source of truth for "what is this employee paid for this
+   * period": processPayroll() below consumes it too, so the figure a stub shows
+   * and the figure payroll processes can never be computed two different ways.
+   *
+   * `unprocessedOnly` is the only behavioural difference between the callers:
+   *  - true  — approved entries not yet stamped for payroll. What
+   *            processPayroll() must use, so hours are never paid twice.
+   *  - false — every approved entry in the period, stamped or not. What a pay
+   *            stub needs: the stub describes a period, and must not collapse
+   *            to zero just because payroll was processed before it was issued.
+   *
+   * Unapproved entries never count, under either flag. An employee should not
+   * be paid from a time entry nobody has approved.
+   */
+  async calculatePayrollHours(
+    employeeId: string,
+    startDate: string,
+    endDate: string,
+    options: { unprocessedOnly: boolean }
+  ) {
     const entries = await this.prisma.timeEntry.findMany({
       where: {
-        employeeId: dto.employeeId,
+        employeeId,
         status: TimeEntryStatus.APPROVED as any,
-        payrollProcessedAt: null,
-        clockInAt: this.dateRangeFilter(dto.startDate, dto.endDate),
+        ...(options.unprocessedOnly ? { payrollProcessedAt: null } : {}),
+        clockInAt: this.dateRangeFilter(startDate, endDate),
       },
       include: this.timeEntryInclude(),
     });
 
-    const processedHours = this.round2(
+    const hours = this.round2(
       entries.reduce(
         (sum, entry) => sum + this.calculateMinutes(entry).paidMinutes / 60,
         0
@@ -572,15 +607,114 @@ export class TimeClockService {
     );
 
     const compensation = await this.prisma.employeeCompensation.findFirst({
-      where: { employeeId: dto.employeeId, isActive: true },
+      where: { employeeId, isActive: true },
       orderBy: { effectiveFrom: 'desc' },
     });
 
-    const hourlyRate =
-      compensation?.payType === PayType.HOURLY
-        ? Number(compensation.hourlyRate || 0)
+    // A salaried employee has no hourly rate to multiply by, so hours × rate
+    // would report $0 gross and quietly understate their pay. Prorate the
+    // annual salary over the period instead, and tell the caller which basis
+    // was used so it can label the figure honestly.
+    const isHourly = compensation?.payType === PayType.HOURLY;
+    const hourlyRate = isHourly ? Number(compensation?.hourlyRate || 0) : 0;
+    const salaryPay =
+      compensation?.payType === PayType.SALARIED
+        ? this.calculateSalaryForPeriod(
+            Number(compensation.annualSalary || 0),
+            startDate,
+            endDate
+          )
         : 0;
-    const grossPay = this.round2(processedHours * hourlyRate);
+    const grossPay = this.round2(hours * hourlyRate + salaryPay);
+
+    return {
+      employeeId,
+      startDate,
+      endDate,
+      entries,
+      entryCount: entries.length,
+      hours,
+      payType: compensation?.payType,
+      hasCompensation: Boolean(compensation),
+      hourlyRate,
+      salaryPay,
+      grossPay,
+    };
+  }
+
+  /**
+   * Read-only wrapper for callers outside payroll processing — the accountant's
+   * hours view and the pay stub form pre-fill. Deliberately a separate entry
+   * point from processPayroll() so that reading the numbers can never stamp
+   * entries as processed.
+   *
+   * Returns one row per payroll-eligible employee, or a single row when
+   * `employeeId` is given. Each row is produced by calculatePayrollHours(), so
+   * the totals an accountant reviews and the figures a stub is pre-filled with
+   * are the same calculation rather than two that can drift apart.
+   */
+  async getPayrollHours(
+    startDate: string,
+    endDate: string,
+    employeeId?: string
+  ) {
+    if (employeeId) {
+      await this.assertPayrollEmployee(employeeId);
+    }
+
+    // The employee summary rides along on each row so the accountant's view can
+    // show names without also being granted GET /api/users, which would expose
+    // far more than the payroll roster.
+    const employees = await this.prisma.user.findMany({
+      where: employeeId
+        ? { id: employeeId }
+        : { role: { name: { in: STAFF_PAYROLL_ROLES as any[] } } },
+      include: { role: true },
+      orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+    });
+
+    // One calculation per employee rather than a single grouped query: the team
+    // is small, and sharing calculatePayrollHours() with processPayroll()
+    // matters more here than saving a few round trips.
+    return Promise.all(
+      employees.map(async (employee) => {
+        const { entries, ...summary } = await this.calculatePayrollHours(
+          employee.id,
+          startDate,
+          endDate,
+          { unprocessedOnly: false }
+        );
+        return {
+          ...summary,
+          employee: this.toEmployeeDto(employee),
+          processedHours: this.round2(
+            entries
+              .filter((entry) => entry.payrollProcessedAt)
+              .reduce(
+                (sum, entry) =>
+                  sum + this.calculateMinutes(entry).paidMinutes / 60,
+                0
+              )
+          ),
+        };
+      })
+    );
+  }
+
+  async processPayroll(dto: ProcessPayrollDto, userId: string) {
+    await this.assertPayrollEmployee(dto.employeeId);
+
+    const {
+      entries,
+      hours: processedHours,
+      grossPay,
+    } = await this.calculatePayrollHours(
+      dto.employeeId,
+      dto.startDate,
+      dto.endDate,
+      { unprocessedOnly: true }
+    );
+
     const processedAt = new Date();
 
     if (entries.length > 0) {


### PR DESCRIPTION
Jira: [GA-55](https://gt-automotives.atlassian.net/browse/GA-55) · [GA-56](https://gt-automotives.atlassian.net/browse/GA-56) · [GA-57](https://gt-automotives.atlassian.net/browse/GA-57) · [GA-58](https://gt-automotives.atlassian.net/browse/GA-58)

> [#101](https://github.com/vishaltoora/GT-Automotives-App/pull/101) (GA-59) is stacked on this branch and should merge after it.

## Pay stubs

The shop had no way to issue a wage statement. This adds one, end to end: an accountant raises a stub for an employee and a period, and gets a printable CRA-shaped document.

**Everything printed is snapshotted at creation** — company header, employee name, position, pay rate, period figures, year-to-date columns. Nothing is joined live at render time, so re-printing a stub years later reproduces the document as issued, even if the business has since changed its address or the employee their title.

**Year-to-date is frozen per stub**, because a pay record must not change when a later one is issued. Amending a stub therefore rewrites that employee's whole year in pay-date order, rather than leaving later documents carrying totals that no longer reconcile.

## CRA deduction auto-fill

`canadian-payroll.ts` implements EI, CPP (including the CPP2 slice above YMPE) and combined federal + BC income tax withholding from the T4127 formulas, with annual maximums so the last contribution of the year is the exact remainder.

These are **suggestions**. The accountant can type over any of them, and what they confirm is what gets stored — a stub must record what was actually withheld, not what a formula thinks should have been. Overriding a field stops it being recalculated. The calculator assumes basic TD1 amounts, which is stated on the form rather than hidden.

Pay frequency is an explicit field defaulting to semi-monthly, not inferred from the dates: it scales every figure, so a wrong guess would quietly skew the tax on every stub.

## Accountant hours view

A read-only `GET /time-clock/payroll-hours` returning approved hours and gross pay per employee. Deliberately a separate entry point from `POST process-payroll` so that *reading* the numbers can never stamp anyone's time entries as processed — the accountant's view and the stub pre-fill share one calculation with the payroll run, so the figures cannot drift apart.

## PROCESSED time entries

An entry paid out through payroll now moves to a terminal `PROCESSED` status. Edit, approve, unapprove, void and delete all refuse it through a single `assertNotProcessed` guard rather than each path remembering to check a timestamp. Payable hours consequently mean approved *or* processed — counting only approved would have collapsed every total the moment payroll ran.

The Time Entries From/To pickers were clamped to the browsed month, which read as them being broken for every earlier one. They now drive the fetch.

## Invoices and quotations

Line items are editable in place rather than delete-and-re-add, and quotations can be previewed in-app instead of only as a print dialog.

## Also

`chore(tooling)` adds the `code-reviewer` agent and `/review` command that gated this PR.

## Decisions worth reviewing

- **Deductions are overridable by design.** The formulas assume basic TD1 claims; treating an override as an error would be wrong more often than the calculator is right.
- **Amendments rewrite a whole year** rather than leaving stubs internally inconsistent. Moving a stub across new year's rewrites both years.
- **Stub figures are stored, not derived.** More columns, but the alternative is a document that changes retroactively.

## Testing

- 726 tests pass (53 suites), typecheck, lint and both builds clean.
- Six migrations, all additive; the enum add and its backfill are split into separate migrations because Postgres will not use a new enum value in the transaction that declares it. Both data migrations are idempotent and guarded. No `DROP`, no non-null-without-default.
- Heaviest coverage is on the money: CPP base/CPP2 split, annual-maximum clipping, K2 credit caps, the federal/provincial split forced to match the CRA-rounded combined figure, the negative-net guard, and the year-to-date chain.

### Fixed by review before opening

`sumPriorStubsInYear` had no upper bound, so a stub **backfilled** for an earlier period counted later stubs as prior — writing a year-to-date higher than the stub that follows it, with nothing revisiting the later ones. A year could end up with stubs disagreeing with each other and with the sum of their periods. Reachable as soon as anyone backfills a missed period, which is exactly what this feature enables. Now bounded at the stub's own pay date, with `create` rewriting the year in pay-date order as `update` already did. Four regression tests, each verified to fail beforehand.

### Not covered

The six migrations were read, not run against a database, and the Puppeteer render was not exercised end to end (only the HTML template spec). Worth issuing one real stub against a staging database before this goes to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
