### PR TITLE
fix(lists): keep invoice and RO filters on navigate-back, refresh one row (GA-60)

### DIFF
--- a/apps/webApp/src/app/hooks/usePersistedState.spec.tsx
+++ b/apps/webApp/src/app/hooks/usePersistedState.spec.tsx
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react';
+import { usePersistedState } from './usePersistedState';
+
+describe('usePersistedState', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('starts from the defaults when nothing is stored', () => {
+    const { result } = renderHook(() =>
+      usePersistedState('filters', { search: '', status: 'ALL' })
+    );
+
+    expect(result.current[0]).toEqual({ search: '', status: 'ALL' });
+  });
+
+  it('restores what a previous visit stored', () => {
+    sessionStorage.setItem(
+      'filters',
+      JSON.stringify({ search: 'Smith', status: 'OPEN' })
+    );
+
+    const { result } = renderHook(() =>
+      usePersistedState('filters', { search: '', status: 'ALL' })
+    );
+
+    expect(result.current[0]).toEqual({ search: 'Smith', status: 'OPEN' });
+  });
+
+  it('writes updates back to storage so a remount picks them up', () => {
+    const first = renderHook(() => usePersistedState('page', 1));
+
+    act(() => {
+      first.result.current[1](3);
+    });
+
+    first.unmount();
+
+    const second = renderHook(() => usePersistedState('page', 1));
+    expect(second.result.current[0]).toBe(3);
+  });
+
+  it('supports updater functions', () => {
+    const { result } = renderHook(() =>
+      usePersistedState('filters', { search: '', status: 'ALL' })
+    );
+
+    act(() => {
+      result.current[1]((prev) => ({ ...prev, status: 'READY' }));
+    });
+
+    expect(result.current[0]).toEqual({ search: '', status: 'READY' });
+  });
+
+  // A filter added after a user last visited must not come back missing —
+  // otherwise the control it feeds renders uncontrolled and warns.
+  it('fills in keys the stored value predates', () => {
+    sessionStorage.setItem('filters', JSON.stringify({ search: 'Smith' }));
+
+    const { result } = renderHook(() =>
+      usePersistedState('filters', { search: '', status: 'ALL' })
+    );
+
+    expect(result.current[0]).toEqual({ search: 'Smith', status: 'ALL' });
+  });
+
+  it('falls back to the defaults when storage holds the wrong shape', () => {
+    sessionStorage.setItem('page', JSON.stringify('not-a-number'));
+
+    const { result } = renderHook(() => usePersistedState('page', 1));
+
+    expect(result.current[0]).toBe(1);
+  });
+
+  it('falls back to the defaults when storage holds unparseable text', () => {
+    sessionStorage.setItem('filters', '{ broken');
+
+    const { result } = renderHook(() =>
+      usePersistedState('filters', { search: '' })
+    );
+
+    expect(result.current[0]).toEqual({ search: '' });
+  });
+
+  // Private browsing and a full quota both throw on write. Losing the filter is
+  // acceptable; taking the screen down with it is not.
+  it('survives storage that refuses writes', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => usePersistedState('page', 1));
+
+    expect(() => {
+      act(() => {
+        result.current[1](2);
+      });
+    }).not.toThrow();
+    expect(result.current[0]).toBe(2);
+  });
+});

--- a/apps/webApp/src/app/hooks/usePersistedState.ts
+++ b/apps/webApp/src/app/hooks/usePersistedState.ts
@@ -1,0 +1,58 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+/**
+ * `useState` that survives leaving the page and coming back.
+ *
+ * List screens keep their filters, search text and page number here. Without
+ * it, opening a record and pressing Back re-mounts the list with everything
+ * cleared — so working through a filtered set means re-typing the search after
+ * every record. The value is held in `sessionStorage` rather than the URL so
+ * existing deep links keep working, and it is scoped to the tab: two tabs on
+ * the same list are usually two different pieces of work.
+ *
+ * The stored value is merged over the defaults on read, so adding a filter to a
+ * screen does not leave returning users with `undefined` where the new field
+ * should be.
+ */
+export function usePersistedState<T>(
+  storageKey: string,
+  defaults: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => readStored(storageKey, defaults));
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(storageKey, JSON.stringify(value));
+    } catch {
+      // Private browsing and a full quota both throw here. Losing the filter on
+      // the next visit is a much smaller problem than breaking the screen.
+    }
+  }, [storageKey, value]);
+
+  return [value, setValue];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readStored<T>(storageKey: string, defaults: T): T {
+  try {
+    const saved = sessionStorage.getItem(storageKey);
+    if (saved === null) return defaults;
+
+    const parsed = JSON.parse(saved);
+
+    // Merge object shapes so a filter added since the value was stored still
+    // gets its default instead of coming back missing.
+    if (isPlainObject(defaults) && isPlainObject(parsed)) {
+      return { ...defaults, ...parsed } as T;
+    }
+
+    // Anything of the wrong shape is stale storage from an earlier version of
+    // the screen — fall back rather than hand the caller a surprise type.
+    return typeof parsed === typeof defaults ? (parsed as T) : defaults;
+  } catch {
+    return defaults;
+  }
+}

--- a/apps/webApp/src/app/pages/invoices/InvoiceList.tsx
+++ b/apps/webApp/src/app/pages/invoices/InvoiceList.tsx
@@ -23,6 +23,7 @@ import {
   Pagination,
   IconButton,
   Link,
+  CircularProgress,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -52,6 +53,27 @@ import {
   isInvoicePartiallyPaid,
 } from '@gt-automotive/data';
 import { colors } from '../../theme/colors';
+import { usePersistedState } from '../../hooks/usePersistedState';
+
+type InvoiceSearchParams = {
+  /** Combined search for invoice number and customer name. */
+  search: string;
+  status: string;
+  companyId: string;
+  startDate: string;
+  endDate: string;
+};
+
+const SEARCH_STORAGE_KEY = 'invoiceListSearchParams';
+const PAGE_STORAGE_KEY = 'invoiceListPage';
+
+const DEFAULT_SEARCH_PARAMS: InvoiceSearchParams = {
+  search: '',
+  status: '',
+  companyId: '',
+  startDate: '',
+  endDate: '',
+};
 
 const InvoiceList: React.FC = () => {
   const navigate = useNavigate();
@@ -63,37 +85,20 @@ const InvoiceList: React.FC = () => {
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [companies, setCompanies] = useState<Company[]>([]);
   const [loading, setLoading] = useState(true);
-  // Persist search/filters across navigation (e.g. view details -> back)
-  const SEARCH_STORAGE_KEY = 'invoiceListSearchParams';
-  type InvoiceSearchParams = {
-    search: string;
-    status: string;
-    companyId: string;
-    startDate: string;
-    endDate: string;
-  };
-  const getStoredSearchParams = (): InvoiceSearchParams => {
-    const defaults: InvoiceSearchParams = {
-      search: '', // Combined search for invoice number and customer name
-      status: '',
-      companyId: '',
-      startDate: '',
-      endDate: '',
-    };
-    try {
-      const saved = sessionStorage.getItem(SEARCH_STORAGE_KEY);
-      if (saved) return { ...defaults, ...JSON.parse(saved) };
-    } catch {
-      // ignore malformed storage
-    }
-    return defaults;
-  };
-  // Immediate input value for responsive typing (combined search)
-  const [searchInput, setSearchInput] = useState(
-    () => getStoredSearchParams().search || ''
+  // The row currently being mutated, so the user gets feedback on that row
+  // instead of the whole list going blank.
+  const [updatingInvoiceId, setUpdatingInvoiceId] = useState<string | null>(
+    null
   );
-  // Debounced search params that trigger API calls
-  const [searchParams, setSearchParams] = useState(getStoredSearchParams);
+  // Debounced search params that trigger API calls. Persisted so they survive
+  // navigating to an invoice and back.
+  const [searchParams, setSearchParams] =
+    usePersistedState<InvoiceSearchParams>(
+      SEARCH_STORAGE_KEY,
+      DEFAULT_SEARCH_PARAMS
+    );
+  // Immediate input value for responsive typing (combined search)
+  const [searchInput, setSearchInput] = useState(() => searchParams.search);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingInvoice, setEditingInvoice] = useState<Invoice | null>(null);
   const [filtersExpanded, setFiltersExpanded] = useState(false);
@@ -104,8 +109,9 @@ const InvoiceList: React.FC = () => {
   const [emailDialogOpen, setEmailDialogOpen] = useState(false);
   const [invoiceForEmail, setInvoiceForEmail] = useState<Invoice | null>(null);
 
-  // Pagination state
-  const [page, setPage] = useState(1);
+  // Pagination state. Persisted alongside the filters: returning from an
+  // invoice should land on the page it was opened from, not back at page 1.
+  const [page, setPage] = usePersistedState(PAGE_STORAGE_KEY, 1);
   const [rowsPerPage] = useState(isMobile ? 10 : 20);
 
   // Calculate paginated data
@@ -127,10 +133,7 @@ const InvoiceList: React.FC = () => {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (searchInput !== searchParams.search) {
-        setSearchParams((prev) => ({
-          ...prev,
-          search: searchInput,
-        }));
+        updateFilters({ search: searchInput });
       }
     }, 300);
 
@@ -142,14 +145,13 @@ const InvoiceList: React.FC = () => {
     handleSearch();
   }, [searchParams]);
 
-  // Persist search/filters so they survive navigating to details and back
+  // A restored page can outrun the result set — invoices may have been paid or
+  // deleted elsewhere since, or a narrower filter was restored with it.
   useEffect(() => {
-    try {
-      sessionStorage.setItem(SEARCH_STORAGE_KEY, JSON.stringify(searchParams));
-    } catch {
-      // ignore storage write failures
+    if (totalPages > 0 && page > totalPages) {
+      setPage(totalPages);
     }
-  }, [searchParams]);
+  }, [totalPages, page]);
 
   const loadCompanies = async () => {
     try {
@@ -157,18 +159,6 @@ const InvoiceList: React.FC = () => {
       setCompanies(data);
     } catch (error) {
       showApiError(error, 'Failed to load companies');
-    }
-  };
-
-  const loadInvoices = async () => {
-    try {
-      setLoading(true);
-      const data = await invoiceService.getInvoices();
-      setInvoices(data);
-    } catch (error) {
-      showApiError(error, 'Failed to load invoices');
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -194,10 +184,41 @@ const InvoiceList: React.FC = () => {
         : await invoiceService.getInvoices();
 
       setInvoices(filtered);
-      setPage(1); // Reset to first page after search
     } catch (error) {
       showApiError(error, 'Failed to search invoices');
+    } finally {
+      setLoading(false);
     }
+  };
+
+  /**
+   * Change a filter and return to the first page.
+   *
+   * The page reset belongs here rather than in `handleSearch`: the search runs
+   * again on mount with the restored filters, and resetting there would throw
+   * away the page the user came back to.
+   */
+  const updateFilters = (patch: Partial<InvoiceSearchParams>) => {
+    setSearchParams((prev) => ({ ...prev, ...patch }));
+    setPage(1);
+  };
+
+  /**
+   * Fold an updated invoice back into the list.
+   *
+   * Mutating one invoice must not refetch the list: a reload discards the page
+   * the user is on and costs a round trip to redisplay rows that have not
+   * changed. Merging over the existing row rather than replacing it keeps any
+   * list-only field the single-invoice response happens not to carry.
+   *
+   * A row that no longer matches the active filter — marked paid while
+   * filtering on Pending — deliberately stays put with its new status. Making
+   * it vanish mid-interaction reads as the action having failed.
+   */
+  const patchInvoiceRow = (updated: Invoice) => {
+    setInvoices((prev) =>
+      prev.map((inv) => (inv.id === updated.id ? { ...inv, ...updated } : inv))
+    );
   };
 
   const handlePageChange = (
@@ -224,10 +245,15 @@ const InvoiceList: React.FC = () => {
 
     if (confirmed) {
       try {
+        setUpdatingInvoiceId(invoice.id);
         await invoiceService.deleteInvoice(invoice.id);
-        loadInvoices();
+        // Drop the row locally. The rest of the list is unaffected, so there is
+        // nothing for a refetch to correct.
+        setInvoices((prev) => prev.filter((inv) => inv.id !== invoice.id));
       } catch (error) {
         showApiError(error, 'Failed to delete invoice');
+      } finally {
+        setUpdatingInvoiceId(null);
       }
     }
   };
@@ -248,11 +274,24 @@ const InvoiceList: React.FC = () => {
     if (!invoiceToMarkPaid) return;
 
     try {
-      await invoiceService.recordInvoicePayments(invoiceToMarkPaid.id, entries);
-      loadInvoices(); // Refresh the list
+      setUpdatingInvoiceId(invoiceToMarkPaid.id);
+      const updated = await invoiceService.recordInvoicePayments(
+        invoiceToMarkPaid.id,
+        entries
+      );
+      // Patch first, so the row the user acted on settles immediately.
+      patchInvoiceRow(updated);
       setInvoiceToMarkPaid(null);
+      // Then re-read the list. Paying a combined invoice also settles the
+      // child invoices rolled into it (settleConsolidatedChildren), and those
+      // are rows of their own — patching only the parent would leave them
+      // reading PENDING against money already collected. Re-running the search
+      // rather than reloading keeps the filters and the current page.
+      await handleSearch();
     } catch (error) {
       showApiError(error, 'Failed to record payment');
+    } finally {
+      setUpdatingInvoiceId(null);
     }
   };
 
@@ -281,9 +320,12 @@ const InvoiceList: React.FC = () => {
       setEmailDialogOpen(false);
       setInvoiceForEmail(null);
 
-      // Refresh invoices to show updated customer email if saved
+      // A saved address belongs to the customer, not to the invoice it was
+      // typed on, so every row for that customer is now stale — including the
+      // addresses the email dialog would offer next time. Re-run the search;
+      // it keeps the filters and the current page.
       if (saveToCustomer) {
-        loadInvoices();
+        await handleSearch();
       }
 
       await confirm({
@@ -305,8 +347,12 @@ const InvoiceList: React.FC = () => {
   };
 
   const handleInvoiceSuccess = (invoice: any) => {
-    // Refresh the invoice list to show the new/updated invoice
-    loadInvoices();
+    // An edit changes one row; fold it in and leave the filters and page as
+    // they are. A new invoice needs no refresh here: the block below navigates
+    // straight to it, and the list re-runs its search when it is next mounted.
+    if (editingInvoice) {
+      patchInvoiceRow(invoice);
+    }
     // Reset editing state
     setEditingInvoice(null);
     // Optionally navigate to the invoice details (only for new invoices)
@@ -550,9 +596,7 @@ const InvoiceList: React.FC = () => {
                 select
                 label="Status"
                 value={searchParams.status}
-                onChange={(e) =>
-                  setSearchParams({ ...searchParams, status: e.target.value })
-                }
+                onChange={(e) => updateFilters({ status: e.target.value })}
                 size={isMobile ? 'small' : 'medium'}
               >
                 <MenuItem value="">All</MenuItem>
@@ -569,12 +613,7 @@ const InvoiceList: React.FC = () => {
                 select
                 label="Company"
                 value={searchParams.companyId}
-                onChange={(e) =>
-                  setSearchParams({
-                    ...searchParams,
-                    companyId: e.target.value,
-                  })
-                }
+                onChange={(e) => updateFilters({ companyId: e.target.value })}
                 size={isMobile ? 'small' : 'medium'}
               >
                 <MenuItem value="">All Companies</MenuItem>
@@ -591,12 +630,7 @@ const InvoiceList: React.FC = () => {
                 type="date"
                 label="Start Date"
                 value={searchParams.startDate}
-                onChange={(e) =>
-                  setSearchParams({
-                    ...searchParams,
-                    startDate: e.target.value,
-                  })
-                }
+                onChange={(e) => updateFilters({ startDate: e.target.value })}
                 size={isMobile ? 'small' : 'medium'}
                 InputLabelProps={{ shrink: true }}
               />
@@ -607,9 +641,7 @@ const InvoiceList: React.FC = () => {
                 type="date"
                 label="End Date"
                 value={searchParams.endDate}
-                onChange={(e) =>
-                  setSearchParams({ ...searchParams, endDate: e.target.value })
-                }
+                onChange={(e) => updateFilters({ endDate: e.target.value })}
                 size={isMobile ? 'small' : 'medium'}
                 InputLabelProps={{ shrink: true }}
               />
@@ -634,6 +666,8 @@ const InvoiceList: React.FC = () => {
                 elevation={0}
                 sx={{
                   p: 1.5,
+                  opacity: updatingInvoiceId === invoice.id ? 0.5 : 1,
+                  transition: 'opacity 150ms',
                   border: `1px solid ${theme.palette.divider}`,
                   borderLeft: `4px solid ${
                     invoice.status === 'PAID'
@@ -692,11 +726,15 @@ const InvoiceList: React.FC = () => {
                       {formatDate(invoice.invoiceDate || invoice.createdAt)}
                     </Typography>
                   </Box>
-                  <ActionsMenu
-                    actions={getInvoiceActions(invoice)}
-                    tooltip={`Actions for Invoice ${invoice.invoiceNumber}`}
-                    id={`invoice-${invoice.id}`}
-                  />
+                  {updatingInvoiceId === invoice.id ? (
+                    <CircularProgress size={20} />
+                  ) : (
+                    <ActionsMenu
+                      actions={getInvoiceActions(invoice)}
+                      tooltip={`Actions for Invoice ${invoice.invoiceNumber}`}
+                      id={`invoice-${invoice.id}`}
+                    />
+                  )}
                 </Box>
 
                 <Typography
@@ -857,7 +895,15 @@ const InvoiceList: React.FC = () => {
             </TableHead>
             <TableBody>
               {paginatedInvoices.map((invoice) => (
-                <TableRow key={invoice.id}>
+                <TableRow
+                  key={invoice.id}
+                  sx={{
+                    // Feedback stays on the row being changed — the rest of
+                    // the list is still valid and still readable.
+                    opacity: updatingInvoiceId === invoice.id ? 0.5 : 1,
+                    transition: 'opacity 150ms',
+                  }}
+                >
                   <TableCell>
                     <Link
                       onClick={() => {
@@ -977,11 +1023,15 @@ const InvoiceList: React.FC = () => {
                       : '-'}
                   </TableCell>
                   <TableCell align="center">
-                    <ActionsMenu
-                      actions={getInvoiceActions(invoice)}
-                      tooltip={`Actions for Invoice ${invoice.invoiceNumber}`}
-                      id={`invoice-${invoice.id}`}
-                    />
+                    {updatingInvoiceId === invoice.id ? (
+                      <CircularProgress size={20} />
+                    ) : (
+                      <ActionsMenu
+                        actions={getInvoiceActions(invoice)}
+                        tooltip={`Actions for Invoice ${invoice.invoiceNumber}`}
+                        id={`invoice-${invoice.id}`}
+                      />
+                    )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/apps/webApp/src/app/pages/repair-orders/ROList.tsx
+++ b/apps/webApp/src/app/pages/repair-orders/ROList.tsx
@@ -30,6 +30,7 @@ import {
 import { useAuth } from '../../hooks/useAuth';
 import { colors } from '../../theme/colors';
 import { formatBusinessDate } from '../../utils/dateUtils';
+import { usePersistedState } from '../../hooks/usePersistedState';
 
 const STATUS_META: Record<
   ROStatus,
@@ -62,6 +63,18 @@ const ALL_STATUSES: ROStatus[] = [
   'INVOICED',
 ];
 
+type ROListFilters = {
+  search: string;
+  status: ROStatus | 'ALL';
+};
+
+const FILTERS_STORAGE_KEY = 'roListFilters';
+
+const DEFAULT_FILTERS: ROListFilters = {
+  search: '',
+  status: 'ALL',
+};
+
 function customerName(ro: RepairOrder) {
   if (ro.customer.businessName) return ro.customer.businessName;
   return `${ro.customer.firstName} ${ro.customer.lastName}`.trim();
@@ -88,8 +101,16 @@ export function ROList() {
   const [ros, setRos] = useState<RepairOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<ROStatus | 'ALL'>('ALL');
+  // Filters are persisted so opening an RO and pressing Back returns to the
+  // same filtered list rather than the full set with the search cleared.
+  const [filters, setFilters] = usePersistedState<ROListFilters>(
+    FILTERS_STORAGE_KEY,
+    DEFAULT_FILTERS
+  );
+  const { search, status: statusFilter } = filters;
+  // Immediate input value, so typing stays responsive while the query behind
+  // it is debounced.
+  const [searchInput, setSearchInput] = useState(() => filters.search);
 
   const baseRoute = location.pathname.startsWith('/staff')
     ? '/staff'
@@ -99,8 +120,21 @@ export function ROList() {
     ? '/foreman'
     : '/admin';
 
+  // Debounce the text input so a search costs one request rather than one per
+  // keystroke (300ms, matching the invoice list).
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchInput !== filters.search) {
+        setFilters((prev) => ({ ...prev, search: searchInput }));
+      }
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
   useEffect(() => {
     setLoading(true);
+    setError(null);
     const params: Record<string, string> = {};
     if (statusFilter !== 'ALL') params.status = statusFilter;
     if (search.trim()) params.search = search.trim();
@@ -131,8 +165,8 @@ export function ROList() {
         <TextField
           size="small"
           placeholder="Search RO#, customer, phone, vehicle or VIN…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -149,7 +183,10 @@ export function ROList() {
             label="Status"
             value={statusFilter}
             onChange={(e) =>
-              setStatusFilter(e.target.value as ROStatus | 'ALL')
+              setFilters((prev) => ({
+                ...prev,
+                status: e.target.value as ROStatus | 'ALL',
+              }))
             }
           >
             <MenuItem value="ALL">All Statuses</MenuItem>


### PR DESCRIPTION
Closes [GA-60](https://gt-automotives.atlassian.net/browse/GA-60).

## Problem

Working through a filtered list was disrupted by every action taken on it. Marking an invoice paid refetched the whole list and reset the page, so a search on page 3 came back as an unfiltered page 1. The repair order list held its filters in plain state, so opening an RO and pressing Back cleared them entirely. Processing five invoices for one customer meant typing the same search five times.

## What changed

**Filters and page survive navigation.** Both lists now share `usePersistedState`, a small `sessionStorage` hook. The page reset moves out of the search itself and into the filter handlers — the search re-runs on mount with the restored filters, and resetting there was what threw away the page being returned to.

**Single-record actions update one row.** Edit and delete fold their result into the row instead of reloading. A row that no longer matches the filter — marked paid while filtering on Pending — deliberately stays put with its new status, since making it vanish mid-interaction reads as the action having failed.

**Two cases deliberately re-run the search instead**, because the server changes more than the row acted on:
- Paying a combined invoice also settles the child invoices rolled into it (`settleConsolidatedChildren`), which are rows of their own.
- A saved email address belongs to the customer, not to the invoice it was typed on, so every row for that customer goes stale — including the addresses the email dialog offers next time.

Re-running the search keeps the filters and the current page, so neither case regresses what this ticket is for.

**The RO search picks up the 300ms debounce** the invoice list already had; it was issuing a request per keystroke.

## Verification

- `tsc --noEmit` clean on `apps/webApp`
- 163 webApp tests pass, including 8 new `usePersistedState` tests (restore, updater functions, forward-compatible key merge, malformed storage, storage that refuses writes)
- `/review` run pre-PR; all three findings fixed in this branch

## Testing notes

Worth exercising by hand: search on the invoice list, go to page 2, mark one paid, and confirm the search text and page survive; then open an RO from a filtered list and press Back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)