### PR TITLE
feat(invoices): one statement email for everything a customer owes (GA-61)

### DIFF
--- a/apps/webApp/src/app/components/customers/CustomerDetailsDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDetailsDialog.tsx
@@ -453,11 +453,19 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
     ) || [];
 
   // Invoices that can still take a payment (includes partially-paid) — the
-  // pool the bulk "Process Payment" flow selects from.
+  // pool the bulk "Process Payment" flow selects from. Drafts are included:
+  // someone paying in the bay may well be settling one before it is finalised.
   const payableInvoices =
     customer?.invoices?.filter((inv) =>
       ['PENDING', 'DRAFT', 'PARTIALLY_PAID'].includes(inv.status)
     ) || [];
+
+  // What a statement may ask a customer for. Drafts are deliberately excluded:
+  // a draft is not a finalised invoice, and emailing one as money owed asks for
+  // payment against figures the shop has not committed to yet.
+  const emailableInvoices = payableInvoices.filter(
+    (inv) => inv.status !== 'DRAFT'
+  );
 
   const paidInvoices =
     customer?.invoices?.filter((inv) => inv.status === 'PAID') || [];
@@ -1064,7 +1072,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                           <Box sx={{ display: 'flex', gap: 1 }}>
                             {/* One click beats opening every invoice in turn
                                 to chase a customer with several outstanding. */}
-                            {payableInvoices.length > 1 && (
+                            {emailableInvoices.length > 1 && (
                               <Button
                                 size="small"
                                 variant="outlined"
@@ -1072,7 +1080,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                 startIcon={<EmailIcon />}
                                 onClick={() => setBulkEmailOpen(true)}
                               >
-                                Email {payableInvoices.length} Invoices
+                                Email {emailableInvoices.length} Invoices
                               </Button>
                             )}
                             {payableInvoices.length > 0 && (
@@ -1494,7 +1502,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                           <Box sx={{ display: 'flex', gap: 1 }}>
                             {/* One click beats opening every invoice in turn
                                 to chase a customer with several outstanding. */}
-                            {payableInvoices.length > 1 && (
+                            {emailableInvoices.length > 1 && (
                               <Button
                                 size="small"
                                 variant="outlined"
@@ -1502,7 +1510,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                                 startIcon={<EmailIcon />}
                                 onClick={() => setBulkEmailOpen(true)}
                               >
-                                Email {payableInvoices.length} Invoices
+                                Email {emailableInvoices.length} Invoices
                               </Button>
                             )}
                             {payableInvoices.length > 0 && (
@@ -1843,7 +1851,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
           `${customer?.firstName ?? ''} ${customer?.lastName ?? ''}`.trim()
         }
         customerId={customer?.id}
-        invoices={payableInvoices}
+        invoices={emailableInvoices}
         availableEmails={[
           ...(customer?.email ? [customer.email] : []),
           ...(customer?.additionalEmails ?? []),

--- a/apps/webApp/src/app/components/customers/CustomerDetailsDialog.tsx
+++ b/apps/webApp/src/app/components/customers/CustomerDetailsDialog.tsx
@@ -70,6 +70,7 @@ import { PaymentDialog } from '../appointments/PaymentDialog';
 import { InvoiceDetailsDialog } from '../invoices/InvoiceDetailsDialog';
 import { PaymentMethodDialog } from '../invoices/PaymentMethodDialog';
 import { BulkInvoicePaymentDialog } from '../invoices/BulkInvoicePaymentDialog';
+import { BulkInvoiceEmailDialog } from '../invoices/BulkInvoiceEmailDialog';
 import { SquarePaymentForm } from '../payments/SquarePaymentForm';
 import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
 import { invoiceService } from '../../requests/invoice.requests';
@@ -138,6 +139,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
   );
   const [paymentDialogOpen, setPaymentDialogOpen] = useState(false);
   const [bulkPaymentOpen, setBulkPaymentOpen] = useState(false);
+  const [bulkEmailOpen, setBulkEmailOpen] = useState(false);
   const [selectedInvoiceForPayment, setSelectedInvoiceForPayment] =
     useState<Invoice | null>(null);
   const [squarePaymentDialogOpen, setSquarePaymentDialogOpen] = useState(false);
@@ -1041,7 +1043,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                     </Card>
 
                     {/* Unpaid Invoice Cards */}
-                    {unpaidInvoices.length > 0 && (
+                    {payableInvoices.length > 0 && (
                       <Box mb={3}>
                         <Box
                           sx={{
@@ -1057,22 +1059,37 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                             color="warning.main"
                             fontWeight="bold"
                           >
-                            Unpaid Invoices ({unpaidInvoices.length})
+                            Unpaid Invoices ({payableInvoices.length})
                           </Typography>
-                          {payableInvoices.length > 0 && (
-                            <Button
-                              size="small"
-                              variant="contained"
-                              color="success"
-                              startIcon={<PaymentIcon />}
-                              onClick={() => setBulkPaymentOpen(true)}
-                            >
-                              Process Payment
-                            </Button>
-                          )}
+                          <Box sx={{ display: 'flex', gap: 1 }}>
+                            {/* One click beats opening every invoice in turn
+                                to chase a customer with several outstanding. */}
+                            {payableInvoices.length > 1 && (
+                              <Button
+                                size="small"
+                                variant="outlined"
+                                color="primary"
+                                startIcon={<EmailIcon />}
+                                onClick={() => setBulkEmailOpen(true)}
+                              >
+                                Email {payableInvoices.length} Invoices
+                              </Button>
+                            )}
+                            {payableInvoices.length > 0 && (
+                              <Button
+                                size="small"
+                                variant="contained"
+                                color="success"
+                                startIcon={<PaymentIcon />}
+                                onClick={() => setBulkPaymentOpen(true)}
+                              >
+                                Process Payment
+                              </Button>
+                            )}
+                          </Box>
                         </Box>
                         <Grid container spacing={2}>
-                          {unpaidInvoices.map((invoice: Invoice) => (
+                          {payableInvoices.map((invoice: Invoice) => (
                             <Grid size={{ xs: 12, sm: 6 }} key={invoice.id}>
                               <Card variant="outlined" sx={{ height: '100%' }}>
                                 <CardContent>
@@ -1456,7 +1473,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                 {customer.invoices && customer.invoices.length > 0 ? (
                   <Box>
                     {/* Unpaid Invoices Section */}
-                    {unpaidInvoices.length > 0 && (
+                    {payableInvoices.length > 0 && (
                       <Box mb={3}>
                         <Box
                           sx={{
@@ -1472,19 +1489,34 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                             color="warning.main"
                             fontWeight="bold"
                           >
-                            Unpaid Invoices ({unpaidInvoices.length})
+                            Unpaid Invoices ({payableInvoices.length})
                           </Typography>
-                          {payableInvoices.length > 0 && (
-                            <Button
-                              size="small"
-                              variant="contained"
-                              color="success"
-                              startIcon={<PaymentIcon />}
-                              onClick={() => setBulkPaymentOpen(true)}
-                            >
-                              Process Payment
-                            </Button>
-                          )}
+                          <Box sx={{ display: 'flex', gap: 1 }}>
+                            {/* One click beats opening every invoice in turn
+                                to chase a customer with several outstanding. */}
+                            {payableInvoices.length > 1 && (
+                              <Button
+                                size="small"
+                                variant="outlined"
+                                color="primary"
+                                startIcon={<EmailIcon />}
+                                onClick={() => setBulkEmailOpen(true)}
+                              >
+                                Email {payableInvoices.length} Invoices
+                              </Button>
+                            )}
+                            {payableInvoices.length > 0 && (
+                              <Button
+                                size="small"
+                                variant="contained"
+                                color="success"
+                                startIcon={<PaymentIcon />}
+                                onClick={() => setBulkPaymentOpen(true)}
+                              >
+                                Process Payment
+                              </Button>
+                            )}
+                          </Box>
                         </Box>
                         <TableContainer component={Paper} variant="outlined">
                           <Table size="small">
@@ -1498,7 +1530,7 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
                               </TableRow>
                             </TableHead>
                             <TableBody>
-                              {unpaidInvoices.map((invoice: Invoice) => (
+                              {payableInvoices.map((invoice: Invoice) => (
                                 <TableRow key={invoice.id} hover>
                                   <TableCell>
                                     <Link
@@ -1800,6 +1832,24 @@ export const CustomerDetailsDialog: React.FC<CustomerDetailsDialogProps> = ({
           loadCustomer();
           onPaymentSuccess?.();
         }}
+      />
+
+      {/* Email every outstanding invoice in one pass */}
+      <BulkInvoiceEmailDialog
+        open={bulkEmailOpen}
+        onClose={() => setBulkEmailOpen(false)}
+        customerName={
+          customer?.businessName ||
+          `${customer?.firstName ?? ''} ${customer?.lastName ?? ''}`.trim()
+        }
+        customerId={customer?.id}
+        invoices={payableInvoices}
+        availableEmails={[
+          ...(customer?.email ? [customer.email] : []),
+          ...(customer?.additionalEmails ?? []),
+        ]}
+        // Saving new addresses updates the customer, so re-read it.
+        onSent={loadCustomer}
       />
 
       {/* Appointment Payment Dialog */}

--- a/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.spec.tsx
+++ b/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.spec.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  BulkInvoiceEmailDialog,
+  BulkEmailableInvoice,
+} from './BulkInvoiceEmailDialog';
+
+const mockSendInvoiceEmail = jest.fn();
+
+jest.mock('../../requests/invoice.requests', () => ({
+  invoiceService: {
+    sendInvoiceEmail: (...args: unknown[]) => mockSendInvoiceEmail(...args),
+  },
+}));
+
+const INVOICES: BulkEmailableInvoice[] = [
+  {
+    id: 'inv-1',
+    invoiceNumber: '1001',
+    total: 100,
+    status: 'PENDING',
+    invoiceDate: '2026-08-01T00:00:00.000Z',
+  },
+  {
+    id: 'inv-2',
+    invoiceNumber: '1002',
+    total: 250,
+    amountPaid: 50,
+    status: 'PARTIALLY_PAID',
+    invoiceDate: '2026-08-02T00:00:00.000Z',
+  },
+  {
+    id: 'inv-3',
+    invoiceNumber: '1003',
+    total: 75,
+    status: 'PENDING',
+    invoiceDate: '2026-08-03T00:00:00.000Z',
+  },
+];
+
+const setup = (props: Partial<Parameters<typeof BulkInvoiceEmailDialog>[0]>) =>
+  render(
+    <BulkInvoiceEmailDialog
+      open
+      onClose={jest.fn()}
+      customerName="Northern Fleet Ltd"
+      customerId="cust-1"
+      invoices={INVOICES}
+      availableEmails={['fleet@northern.ca']}
+      {...props}
+    />
+  );
+
+const clickSend = () =>
+  fireEvent.click(screen.getByRole('button', { name: /^Send \d+ invoices?$/ }));
+
+describe('BulkInvoiceEmailDialog', () => {
+  beforeEach(() => {
+    mockSendInvoiceEmail.mockReset();
+    mockSendInvoiceEmail.mockResolvedValue({ success: true });
+  });
+
+  it('sends every invoice by default, each to the selected recipients', async () => {
+    const onSent = jest.fn();
+    setup({ onSent });
+
+    clickSend();
+
+    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(3));
+    expect(mockSendInvoiceEmail.mock.calls.map((c) => c[0])).toEqual([
+      'inv-1',
+      'inv-2',
+      'inv-3',
+    ]);
+    mockSendInvoiceEmail.mock.calls.forEach((call) => {
+      expect(call[1]).toEqual(['fleet@northern.ca']);
+    });
+    await waitFor(() => expect(onSent).toHaveBeenCalled());
+  });
+
+  it('totals the balance due, not the invoice totals', () => {
+    setup({});
+
+    // 100 + (250 - 50) + 75
+    expect(screen.getByText('$375.00')).toBeTruthy();
+  });
+
+  it('skips invoices the user unticks', async () => {
+    setup({});
+
+    fireEvent.click(screen.getByText('#1002'));
+    clickSend();
+
+    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(2));
+    expect(mockSendInvoiceEmail.mock.calls.map((c) => c[0])).toEqual([
+      'inv-1',
+      'inv-3',
+    ]);
+  });
+
+  // Saving the address list on every send would rewrite the same list N times.
+  it('asks to save new addresses only once', async () => {
+    setup({});
+
+    clickSend();
+
+    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(3));
+    expect(mockSendInvoiceEmail.mock.calls.map((c) => c[2])).toEqual([
+      true,
+      false,
+      false,
+    ]);
+  });
+
+  it('names the invoice that failed and leaves the others sent', async () => {
+    mockSendInvoiceEmail
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce({
+        response: { data: { message: 'Mailbox unavailable' } },
+      })
+      .mockResolvedValueOnce({ success: true });
+
+    setup({});
+    clickSend();
+
+    await waitFor(() =>
+      expect(screen.getByText(/2 of 3 invoices were emailed/)).toBeTruthy()
+    );
+    expect(screen.getByText('Mailbox unavailable')).toBeTruthy();
+    expect(screen.getAllByText('Sent')).toHaveLength(2);
+  });
+
+  it('retries only the failed invoice', async () => {
+    mockSendInvoiceEmail
+      .mockResolvedValueOnce({ success: true })
+      .mockRejectedValueOnce(new Error('SMTP timeout'))
+      .mockResolvedValueOnce({ success: true });
+
+    setup({});
+    clickSend();
+
+    const retry = await screen.findByRole('button', { name: /Retry 1 failed/ });
+    mockSendInvoiceEmail.mockClear();
+    mockSendInvoiceEmail.mockResolvedValue({ success: true });
+
+    fireEvent.click(retry);
+
+    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(1));
+    expect(mockSendInvoiceEmail.mock.calls[0][0]).toBe('inv-2');
+    // The retry reports the whole run, not just what it re-sent.
+    await waitFor(() => expect(screen.getAllByText('Sent')).toHaveLength(3));
+  });
+
+  it('cannot send with no recipient selected', () => {
+    setup({ availableEmails: [] });
+
+    expect(
+      screen.getByText('This customer has no email on file. Add one below.')
+    ).toBeTruthy();
+    expect(
+      screen.getByRole<HTMLButtonElement>('button', {
+        name: /^Send \d+ invoices?$/,
+      }).disabled
+    ).toBe(true);
+  });
+
+  /**
+   * The real parent re-renders when the send finishes.
+   *
+   * CustomerDetailsDialog passes `invoices` and `availableEmails` as fresh
+   * array literals and reloads the customer from `onSent`, so a reset effect
+   * keyed on either prop fires the moment a send completes — wiping the result
+   * summary and re-ticking every invoice. A bare jest.fn() for `onSent` cannot
+   * catch that, because nothing re-renders.
+   */
+  describe('when the parent re-renders after sending', () => {
+    function ParentLikeCustomerDialog() {
+      const [reloads, setReloads] = useState(0);
+      return (
+        <BulkInvoiceEmailDialog
+          open
+          onClose={jest.fn()}
+          customerName="Northern Fleet Ltd"
+          customerId="cust-1"
+          // Fresh identities on every render, exactly as the real parent does.
+          invoices={INVOICES.map((invoice) => ({ ...invoice }))}
+          availableEmails={['fleet@northern.ca']}
+          onSent={() => setReloads((count) => count + 1)}
+          data-reloads={reloads}
+        />
+      );
+    }
+
+    it('keeps the result summary on screen', async () => {
+      mockSendInvoiceEmail
+        .mockResolvedValueOnce({ success: true })
+        .mockRejectedValueOnce({
+          response: { data: { message: 'Mailbox unavailable' } },
+        })
+        .mockResolvedValueOnce({ success: true });
+
+      render(<ParentLikeCustomerDialog />);
+      clickSend();
+
+      await waitFor(() =>
+        expect(screen.getByText(/2 of 3 invoices were emailed/)).toBeTruthy()
+      );
+
+      // Give the parent's re-render a chance to clobber it.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(screen.getByText(/2 of 3 invoices were emailed/)).toBeTruthy();
+      expect(screen.getByText('Mailbox unavailable')).toBeTruthy();
+      expect(
+        screen.getByRole('button', { name: /Retry 1 failed/ })
+      ).toBeTruthy();
+    });
+
+    it('does not re-arm Send with every invoice re-ticked', async () => {
+      render(<ParentLikeCustomerDialog />);
+      clickSend();
+
+      await waitFor(() =>
+        expect(screen.getByText(/emailed to fleet@northern.ca/)).toBeTruthy()
+      );
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      // Re-pressing a re-armed Send is how the customer gets the same three
+      // invoices twice.
+      expect(
+        screen.queryByRole('button', { name: /^Send \d+ invoices?$/ })
+      ).toBeNull();
+      expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.spec.tsx
+++ b/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.spec.tsx
@@ -5,11 +5,12 @@ import {
   BulkEmailableInvoice,
 } from './BulkInvoiceEmailDialog';
 
-const mockSendInvoiceEmail = jest.fn();
+const mockSendInvoiceStatement = jest.fn();
 
 jest.mock('../../requests/invoice.requests', () => ({
   invoiceService: {
-    sendInvoiceEmail: (...args: unknown[]) => mockSendInvoiceEmail(...args),
+    sendInvoiceStatement: (...args: unknown[]) =>
+      mockSendInvoiceStatement(...args),
   },
 }));
 
@@ -52,30 +53,40 @@ const setup = (props: Partial<Parameters<typeof BulkInvoiceEmailDialog>[0]>) =>
   );
 
 const clickSend = () =>
-  fireEvent.click(screen.getByRole('button', { name: /^Send \d+ invoices?$/ }));
+  fireEvent.click(
+    screen.getByRole('button', {
+      name: /^Send (statement \(\d+ invoices\)|1 invoice)$/,
+    })
+  );
 
 describe('BulkInvoiceEmailDialog', () => {
   beforeEach(() => {
-    mockSendInvoiceEmail.mockReset();
-    mockSendInvoiceEmail.mockResolvedValue({ success: true });
+    mockSendInvoiceStatement.mockReset();
+    mockSendInvoiceStatement.mockResolvedValue({
+      success: true,
+      message: 'Statement email sent successfully',
+      emailUsed: 'fleet@northern.ca',
+      invoiceCount: 3,
+      totalOwing: 375,
+    });
   });
 
-  it('sends every invoice by default, each to the selected recipients', async () => {
-    const onSent = jest.fn();
-    setup({ onSent });
+  // The whole point of the rework: a customer with seven outstanding invoices
+  // gets one message, not seven.
+  it('sends a single statement covering every selected invoice', async () => {
+    setup({});
 
     clickSend();
 
-    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(3));
-    expect(mockSendInvoiceEmail.mock.calls.map((c) => c[0])).toEqual([
-      'inv-1',
-      'inv-2',
-      'inv-3',
-    ]);
-    mockSendInvoiceEmail.mock.calls.forEach((call) => {
-      expect(call[1]).toEqual(['fleet@northern.ca']);
-    });
-    await waitFor(() => expect(onSent).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockSendInvoiceStatement).toHaveBeenCalledTimes(1)
+    );
+    const [customerId, invoiceIds, emails, saveToCustomer] =
+      mockSendInvoiceStatement.mock.calls[0];
+    expect(customerId).toBe('cust-1');
+    expect(invoiceIds).toEqual(['inv-1', 'inv-2', 'inv-3']);
+    expect(emails).toEqual(['fleet@northern.ca']);
+    expect(saveToCustomer).toBe(true);
   });
 
   it('totals the balance due, not the invoice totals', () => {
@@ -85,70 +96,56 @@ describe('BulkInvoiceEmailDialog', () => {
     expect(screen.getByText('$375.00')).toBeTruthy();
   });
 
-  it('skips invoices the user unticks', async () => {
+  it('leaves out invoices the user unticks', async () => {
     setup({});
 
     fireEvent.click(screen.getByText('#1002'));
     clickSend();
 
-    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(2));
-    expect(mockSendInvoiceEmail.mock.calls.map((c) => c[0])).toEqual([
+    await waitFor(() =>
+      expect(mockSendInvoiceStatement).toHaveBeenCalledTimes(1)
+    );
+    expect(mockSendInvoiceStatement.mock.calls[0][1]).toEqual([
       'inv-1',
       'inv-3',
     ]);
   });
 
-  // Saving the address list on every send would rewrite the same list N times.
-  it('asks to save new addresses only once', async () => {
+  it('confirms what was sent, and the total owing', async () => {
     setup({});
 
     clickSend();
 
-    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(3));
-    expect(mockSendInvoiceEmail.mock.calls.map((c) => c[2])).toEqual([
-      true,
-      false,
-      false,
-    ]);
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /A statement for 3 invoices was emailed to fleet@northern.ca/
+        )
+      ).toBeTruthy()
+    );
+    expect(screen.getByText('Total owing')).toBeTruthy();
   });
 
-  it('names the invoice that failed and leaves the others sent', async () => {
-    mockSendInvoiceEmail
-      .mockResolvedValueOnce({ success: true })
-      .mockRejectedValueOnce({
-        response: { data: { message: 'Mailbox unavailable' } },
-      })
-      .mockResolvedValueOnce({ success: true });
+  it('reports a failure without claiming anything was sent', async () => {
+    mockSendInvoiceStatement.mockRejectedValue({
+      response: { data: { message: 'Mailbox unavailable' } },
+    });
 
     setup({});
     clickSend();
 
     await waitFor(() =>
-      expect(screen.getByText(/2 of 3 invoices were emailed/)).toBeTruthy()
+      expect(
+        screen.getByText(/The statement was not sent: Mailbox unavailable/)
+      ).toBeTruthy()
     );
-    expect(screen.getByText('Mailbox unavailable')).toBeTruthy();
-    expect(screen.getAllByText('Sent')).toHaveLength(2);
-  });
-
-  it('retries only the failed invoice', async () => {
-    mockSendInvoiceEmail
-      .mockResolvedValueOnce({ success: true })
-      .mockRejectedValueOnce(new Error('SMTP timeout'))
-      .mockResolvedValueOnce({ success: true });
-
-    setup({});
-    clickSend();
-
-    const retry = await screen.findByRole('button', { name: /Retry 1 failed/ });
-    mockSendInvoiceEmail.mockClear();
-    mockSendInvoiceEmail.mockResolvedValue({ success: true });
-
-    fireEvent.click(retry);
-
-    await waitFor(() => expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(1));
-    expect(mockSendInvoiceEmail.mock.calls[0][0]).toBe('inv-2');
-    // The retry reports the whole run, not just what it re-sent.
-    await waitFor(() => expect(screen.getAllByText('Sent')).toHaveLength(3));
+    // Send stays available, because one email either went or it did not —
+    // pressing it again is a safe retry rather than a duplicate.
+    expect(
+      screen.getByRole('button', {
+        name: /^Send statement \(3 invoices\)$/,
+      })
+    ).toBeTruthy();
   });
 
   it('cannot send with no recipient selected', () => {
@@ -159,7 +156,7 @@ describe('BulkInvoiceEmailDialog', () => {
     ).toBeTruthy();
     expect(
       screen.getByRole<HTMLButtonElement>('button', {
-        name: /^Send \d+ invoices?$/,
+        name: /^Send statement \(3 invoices\)$/,
       }).disabled
     ).toBe(true);
   });
@@ -169,9 +166,9 @@ describe('BulkInvoiceEmailDialog', () => {
    *
    * CustomerDetailsDialog passes `invoices` and `availableEmails` as fresh
    * array literals and reloads the customer from `onSent`, so a reset effect
-   * keyed on either prop fires the moment a send completes — wiping the result
-   * summary and re-ticking every invoice. A bare jest.fn() for `onSent` cannot
-   * catch that, because nothing re-renders.
+   * keyed on either prop fires the moment a send completes — wiping the
+   * confirmation and re-arming Send. A bare jest.fn() for `onSent` cannot catch
+   * that, because nothing re-renders.
    */
   describe('when the parent re-renders after sending', () => {
     function ParentLikeCustomerDialog() {
@@ -191,46 +188,37 @@ describe('BulkInvoiceEmailDialog', () => {
       );
     }
 
-    it('keeps the result summary on screen', async () => {
-      mockSendInvoiceEmail
-        .mockResolvedValueOnce({ success: true })
-        .mockRejectedValueOnce({
-          response: { data: { message: 'Mailbox unavailable' } },
-        })
-        .mockResolvedValueOnce({ success: true });
-
+    it('keeps the confirmation on screen', async () => {
       render(<ParentLikeCustomerDialog />);
       clickSend();
 
       await waitFor(() =>
-        expect(screen.getByText(/2 of 3 invoices were emailed/)).toBeTruthy()
+        expect(
+          screen.getByText(/was emailed to fleet@northern.ca/)
+        ).toBeTruthy()
       );
 
       // Give the parent's re-render a chance to clobber it.
       await new Promise((resolve) => setTimeout(resolve, 150));
 
-      expect(screen.getByText(/2 of 3 invoices were emailed/)).toBeTruthy();
-      expect(screen.getByText('Mailbox unavailable')).toBeTruthy();
-      expect(
-        screen.getByRole('button', { name: /Retry 1 failed/ })
-      ).toBeTruthy();
+      expect(screen.getByText(/was emailed to fleet@northern.ca/)).toBeTruthy();
     });
 
-    it('does not re-arm Send with every invoice re-ticked', async () => {
+    it('does not re-arm Send, which would send the statement twice', async () => {
       render(<ParentLikeCustomerDialog />);
       clickSend();
 
       await waitFor(() =>
-        expect(screen.getByText(/emailed to fleet@northern.ca/)).toBeTruthy()
+        expect(
+          screen.getByText(/was emailed to fleet@northern.ca/)
+        ).toBeTruthy()
       );
       await new Promise((resolve) => setTimeout(resolve, 150));
 
-      // Re-pressing a re-armed Send is how the customer gets the same three
-      // invoices twice.
       expect(
-        screen.queryByRole('button', { name: /^Send \d+ invoices?$/ })
+        screen.queryByRole('button', { name: /^Send statement/ })
       ).toBeNull();
-      expect(mockSendInvoiceEmail).toHaveBeenCalledTimes(3);
+      expect(mockSendInvoiceStatement).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
@@ -1,0 +1,599 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  IconButton,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  CheckCircle as SuccessIcon,
+  Close as CloseIcon,
+  Delete as DeleteIcon,
+  Email as EmailIcon,
+  ErrorOutline as FailureIcon,
+} from '@mui/icons-material';
+import { getInvoiceBalanceDue } from '@gt-automotive/data';
+import { invoiceService } from '../../requests/invoice.requests';
+
+/**
+ * Minimal invoice shape this dialog needs — satisfied by both the full
+ * InvoiceResponseDto and the lighter CustomerInvoiceDto.
+ */
+export interface BulkEmailableInvoice {
+  id: string;
+  invoiceNumber: string;
+  total: number | string;
+  status: string;
+  amountPaid?: number | string | null;
+  invoiceDate?: string;
+  createdAt?: string;
+}
+
+/** What became of one invoice's send, so partial failure can be reported exactly. */
+interface SendOutcome {
+  id: string;
+  invoiceNumber: string;
+  ok: boolean;
+  error?: string;
+}
+
+interface BulkInvoiceEmailDialogProps {
+  open: boolean;
+  onClose: () => void;
+  customerName: string;
+  customerId?: string;
+  /** Outstanding invoices to choose from. */
+  invoices: BulkEmailableInvoice[];
+  /** Known addresses for this customer (primary first, then additional). */
+  availableEmails?: string[];
+  /** Called once at least one invoice has been sent, so callers can refresh. */
+  onSent?: () => void;
+}
+
+const validateEmail = (email: string): boolean =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+const formatCurrency = (amount: number) =>
+  new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(amount);
+
+const formatDate = (invoice: BulkEmailableInvoice) => {
+  const raw = invoice.invoiceDate || invoice.createdAt;
+  if (!raw) return '';
+  // Invoice dates are stored as midnight-UTC calendar dates; read them back in
+  // UTC or an evening invoice reads as the day before.
+  return new Date(raw).toLocaleDateString('en-CA', { timeZone: 'UTC' });
+};
+
+const errorMessage = (err: unknown): string => {
+  const response = (err as { response?: { data?: { message?: unknown } } })
+    ?.response;
+  const message = response?.data?.message;
+  if (typeof message === 'string') return message;
+  if (Array.isArray(message)) return message.join(', ');
+  return err instanceof Error ? err.message : 'Unknown error';
+};
+
+/**
+ * Email several of a customer's outstanding invoices in one go.
+ *
+ * Chasing a fleet customer with seven pending invoices otherwise means seven
+ * trips through the single-invoice email dialog, and it is easy to miss one.
+ *
+ * Each invoice is sent as its own email with its own PDF — this is not a
+ * combined statement (see GA-33 for that). Sends run one at a time rather than
+ * concurrently: every PDF is rendered by Puppeteer on the server, and firing
+ * seven Chromium renders at once at a 1.75GB app service is how you turn a
+ * slow send into a failed one.
+ */
+export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
+  open,
+  onClose,
+  customerName,
+  customerId,
+  invoices,
+  availableEmails,
+  onSent,
+}) => {
+  const knownEmails = useMemo(
+    () => Array.from(new Set((availableEmails ?? []).filter(Boolean))),
+    [availableEmails]
+  );
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedEmails, setSelectedEmails] = useState<string[]>([]);
+  const [extraEmails, setExtraEmails] = useState<string[]>([]);
+  const [newEmail, setNewEmail] = useState('');
+  const [saveToCustomer, setSaveToCustomer] = useState(true);
+  const [error, setError] = useState('');
+
+  const [sending, setSending] = useState(false);
+  const [progress, setProgress] = useState({ done: 0, total: 0 });
+  const [outcomes, setOutcomes] = useState<SendOutcome[] | null>(null);
+
+  // Everything selected each time the dialog opens — the common case is
+  // sending the lot.
+  useEffect(() => {
+    if (!open) return;
+    setSelectedIds(new Set(invoices.map((inv) => inv.id)));
+    setSelectedEmails(knownEmails);
+    setExtraEmails([]);
+    setNewEmail('');
+    setSaveToCustomer(true);
+    setError('');
+    setSending(false);
+    setProgress({ done: 0, total: 0 });
+    setOutcomes(null);
+    // Keyed on `open` alone, and deliberately so. The parent passes `invoices`
+    // and `availableEmails` as fresh array literals, so both change identity on
+    // every one of its renders — and a successful send triggers exactly that,
+    // via onSent -> loadCustomer. Listing either here wipes the result summary
+    // and re-ticks every invoice the instant the send finishes, leaving the
+    // user looking at the selection screen with no idea what happened and one
+    // click away from emailing the whole lot a second time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const selectedInvoices = useMemo(
+    () => invoices.filter((inv) => selectedIds.has(inv.id)),
+    [invoices, selectedIds]
+  );
+
+  const outstandingTotal = useMemo(
+    () =>
+      selectedInvoices.reduce((sum, inv) => sum + getInvoiceBalanceDue(inv), 0),
+    [selectedInvoices]
+  );
+
+  const allSelected =
+    invoices.length > 0 && selectedIds.size === invoices.length;
+
+  const failed = outcomes?.filter((o) => !o.ok) ?? [];
+  const succeeded = outcomes?.filter((o) => o.ok) ?? [];
+
+  const toggleInvoice = (id: string) =>
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const toggleAllInvoices = () =>
+    setSelectedIds((prev) =>
+      prev.size === invoices.length
+        ? new Set()
+        : new Set(invoices.map((inv) => inv.id))
+    );
+
+  const toggleEmail = (email: string) => {
+    setSelectedEmails((prev) =>
+      prev.includes(email) ? prev.filter((e) => e !== email) : [...prev, email]
+    );
+    setError('');
+  };
+
+  const handleAddEmail = () => {
+    const trimmed = newEmail.trim();
+    if (!trimmed) return;
+    if (!validateEmail(trimmed)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+    if ([...knownEmails, ...extraEmails].includes(trimmed)) {
+      setError('That email is already in the list');
+      return;
+    }
+    setExtraEmails((prev) => [...prev, trimmed]);
+    setSelectedEmails((prev) => [...prev, trimmed]);
+    setNewEmail('');
+    setError('');
+  };
+
+  const handleRemoveExtra = (email: string) => {
+    setExtraEmails((prev) => prev.filter((e) => e !== email));
+    setSelectedEmails((prev) => prev.filter((e) => e !== email));
+  };
+
+  /**
+   * Send the given invoices one at a time, recording what happened to each.
+   *
+   * A failure part-way through leaves the invoices already sent alone: they
+   * have genuinely been emailed, and re-sending them to "clean up" would put a
+   * duplicate in the customer's inbox.
+   */
+  const sendInvoices = async (targets: BulkEmailableInvoice[]) => {
+    if (targets.length === 0 || selectedEmails.length === 0) return;
+
+    setSending(true);
+    setError('');
+    setProgress({ done: 0, total: targets.length });
+
+    const results: SendOutcome[] = [];
+    // New addresses only need persisting once, and only if a send actually
+    // succeeds — saving them off the back of a failed request would record
+    // addresses that were never reached.
+    let emailsSaved = false;
+
+    for (const [index, invoice] of targets.entries()) {
+      try {
+        await invoiceService.sendInvoiceEmail(
+          invoice.id,
+          selectedEmails,
+          saveToCustomer && !!customerId && !emailsSaved
+        );
+        emailsSaved = emailsSaved || (saveToCustomer && !!customerId);
+        results.push({
+          id: invoice.id,
+          invoiceNumber: invoice.invoiceNumber,
+          ok: true,
+        });
+      } catch (err) {
+        results.push({
+          id: invoice.id,
+          invoiceNumber: invoice.invoiceNumber,
+          ok: false,
+          error: errorMessage(err),
+        });
+      }
+      setProgress({ done: index + 1, total: targets.length });
+    }
+
+    // A retry reports the whole run, not just the invoices it re-sent.
+    setOutcomes((prev) => {
+      if (!prev) return results;
+      const byId = new Map(prev.map((o) => [o.id, o]));
+      results.forEach((o) => byId.set(o.id, o));
+      return Array.from(byId.values());
+    });
+    setSending(false);
+
+    if (results.some((o) => o.ok)) onSent?.();
+  };
+
+  const handleSend = () => sendInvoices(selectedInvoices);
+
+  const handleRetryFailed = () =>
+    sendInvoices(invoices.filter((inv) => failed.some((f) => f.id === inv.id)));
+
+  const handleClose = () => {
+    if (sending) return;
+    onClose();
+  };
+
+  const canSend = selectedInvoices.length > 0 && selectedEmails.length > 0;
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle
+        sx={{
+          bgcolor: 'primary.main',
+          color: 'white',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <EmailIcon />
+          Email Pending Invoices
+        </Box>
+        <IconButton
+          onClick={handleClose}
+          size="small"
+          sx={{ color: 'white' }}
+          disabled={sending}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {outcomes ? (
+          <Box sx={{ pt: 1 }}>
+            {failed.length === 0 ? (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                {`${
+                  succeeded.length === 1
+                    ? '1 invoice was'
+                    : `All ${succeeded.length} invoices were`
+                } emailed to ${selectedEmails.join(', ')}.`}
+              </Alert>
+            ) : (
+              <Alert severity="warning" sx={{ mb: 2 }}>
+                {`${succeeded.length} of ${outcomes.length} invoices were emailed. The rest are listed below and can be retried \u2014 the ones that went out will not be sent again.`}
+              </Alert>
+            )}
+
+            <List dense disablePadding>
+              {outcomes.map((outcome) => (
+                <ListItem key={outcome.id} disableGutters>
+                  <ListItemIcon sx={{ minWidth: 36 }}>
+                    {outcome.ok ? (
+                      <SuccessIcon color="success" fontSize="small" />
+                    ) : (
+                      <FailureIcon color="error" fontSize="small" />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={`#${outcome.invoiceNumber}`}
+                    secondary={outcome.ok ? 'Sent' : outcome.error}
+                    secondaryTypographyProps={{
+                      color: outcome.ok ? 'text.secondary' : 'error',
+                    }}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+        ) : (
+          <Box sx={{ pt: 1 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Select the invoices to email to <strong>{customerName}</strong>.
+              Each one is sent as its own email with its own PDF attached.
+            </Typography>
+
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={allSelected}
+                  indeterminate={!allSelected && selectedIds.size > 0}
+                  onChange={toggleAllInvoices}
+                  disabled={sending}
+                />
+              }
+              label={`Select all (${invoices.length})`}
+            />
+
+            <List
+              dense
+              disablePadding
+              sx={{ maxHeight: 220, overflow: 'auto' }}
+            >
+              {invoices.map((invoice) => (
+                <ListItem key={invoice.id} disablePadding>
+                  <ListItemButton
+                    onClick={() => toggleInvoice(invoice.id)}
+                    disabled={sending}
+                    dense
+                  >
+                    <ListItemIcon sx={{ minWidth: 36 }}>
+                      <Checkbox
+                        edge="start"
+                        checked={selectedIds.has(invoice.id)}
+                        tabIndex={-1}
+                        disableRipple
+                        size="small"
+                      />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={`#${invoice.invoiceNumber}`}
+                      secondary={[formatDate(invoice), invoice.status]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    />
+                    <Box sx={{ textAlign: 'right' }}>
+                      <Typography variant="body2" fontWeight={600}>
+                        {formatCurrency(getInvoiceBalanceDue(invoice))}
+                      </Typography>
+                      {Number(invoice.amountPaid ?? 0) > 0 && (
+                        <Typography variant="caption" color="text.secondary">
+                          of {formatCurrency(Number(invoice.total))}
+                        </Typography>
+                      )}
+                    </Box>
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+
+            <Divider sx={{ my: 1 }} />
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                mb: 2,
+              }}
+            >
+              <Typography variant="subtitle2">
+                {selectedInvoices.length} selected
+              </Typography>
+              <Typography variant="h6" fontWeight={700}>
+                {formatCurrency(outstandingTotal)}
+              </Typography>
+            </Box>
+
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+              Send to
+            </Typography>
+
+            {knownEmails.length === 0 && extraEmails.length === 0 && (
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                This customer has no email on file. Add one below.
+              </Typography>
+            )}
+
+            <List dense disablePadding>
+              {knownEmails.map((email, index) => (
+                <ListItem key={email} disableGutters disablePadding>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={selectedEmails.includes(email)}
+                        onChange={() => toggleEmail(email)}
+                        disabled={sending}
+                        color="primary"
+                      />
+                    }
+                    label={
+                      <Typography variant="body2">
+                        {email}
+                        {index === 0 && (
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ ml: 1 }}
+                          >
+                            (primary)
+                          </Typography>
+                        )}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              ))}
+            </List>
+
+            {extraEmails.map((email) => (
+              <Box key={email} display="flex" alignItems="center" gap={1}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedEmails.includes(email)}
+                      onChange={() => toggleEmail(email)}
+                      disabled={sending}
+                      color="primary"
+                    />
+                  }
+                  label={<Typography variant="body2">{email}</Typography>}
+                />
+                <IconButton
+                  aria-label="Remove email"
+                  size="small"
+                  onClick={() => handleRemoveExtra(email)}
+                  disabled={sending}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </Box>
+            ))}
+
+            <Box display="flex" alignItems="flex-start" gap={1} sx={{ mt: 1 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Add another email"
+                type="email"
+                value={newEmail}
+                onChange={(e) => {
+                  setNewEmail(e.target.value);
+                  setError('');
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddEmail();
+                  }
+                }}
+                placeholder="someone@example.com"
+                error={!!error}
+                helperText={error}
+                autoComplete="off"
+                disabled={sending}
+              />
+              <Button
+                onClick={handleAddEmail}
+                startIcon={<AddIcon />}
+                sx={{ mt: 0.5, whiteSpace: 'nowrap' }}
+                disabled={!newEmail.trim() || sending}
+              >
+                Add
+              </Button>
+            </Box>
+
+            {customerId && (
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={saveToCustomer}
+                    onChange={(e) => setSaveToCustomer(e.target.checked)}
+                    disabled={sending}
+                    color="primary"
+                  />
+                }
+                label={
+                  <Typography variant="body2">
+                    Save new emails to {customerName || 'customer'}'s profile
+                  </Typography>
+                }
+                sx={{ mt: 1 }}
+              />
+            )}
+          </Box>
+        )}
+
+        {sending && (
+          <Box sx={{ mt: 2 }}>
+            <LinearProgress
+              variant="determinate"
+              value={
+                progress.total ? (progress.done / progress.total) * 100 : 0
+              }
+            />
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 1, textAlign: 'center' }}
+            >
+              Sending {Math.min(progress.done + 1, progress.total)} of{' '}
+              {progress.total}…
+            </Typography>
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleClose} color="inherit" disabled={sending}>
+          {outcomes ? 'Close' : 'Cancel'}
+        </Button>
+        {outcomes
+          ? failed.length > 0 && (
+              <Button
+                onClick={handleRetryFailed}
+                variant="contained"
+                startIcon={<EmailIcon />}
+                disabled={sending}
+              >
+                {failed.length === 1
+                  ? 'Retry 1 failed'
+                  : `Retry ${failed.length} failed`}
+              </Button>
+            )
+          : !sending && (
+              <Button
+                onClick={handleSend}
+                variant="contained"
+                startIcon={<EmailIcon />}
+                disabled={!canSend}
+              >
+                {selectedInvoices.length === 1
+                  ? 'Send 1 invoice'
+                  : `Send ${selectedInvoices.length} invoices`}
+              </Button>
+            )}
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default BulkInvoiceEmailDialog;

--- a/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
@@ -26,7 +26,6 @@ import {
   Close as CloseIcon,
   Delete as DeleteIcon,
   Email as EmailIcon,
-  ErrorOutline as FailureIcon,
 } from '@mui/icons-material';
 import { getInvoiceBalanceDue } from '@gt-automotive/data';
 import { invoiceService } from '../../requests/invoice.requests';
@@ -45,12 +44,11 @@ export interface BulkEmailableInvoice {
   createdAt?: string;
 }
 
-/** What became of one invoice's send, so partial failure can be reported exactly. */
-interface SendOutcome {
-  id: string;
-  invoiceNumber: string;
-  ok: boolean;
-  error?: string;
+/** What the server reported back about the statement it sent. */
+interface SendResult {
+  invoiceCount: number;
+  totalOwing: number;
+  emailUsed: string;
 }
 
 interface BulkInvoiceEmailDialogProps {
@@ -126,8 +124,8 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
   const [error, setError] = useState('');
 
   const [sending, setSending] = useState(false);
-  const [progress, setProgress] = useState({ done: 0, total: 0 });
-  const [outcomes, setOutcomes] = useState<SendOutcome[] | null>(null);
+  const [sent, setSent] = useState<SendResult | null>(null);
+  const [sendError, setSendError] = useState<string | null>(null);
 
   // Everything selected each time the dialog opens — the common case is
   // sending the lot.
@@ -140,8 +138,8 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
     setSaveToCustomer(true);
     setError('');
     setSending(false);
-    setProgress({ done: 0, total: 0 });
-    setOutcomes(null);
+    setSent(null);
+    setSendError(null);
     // Keyed on `open` alone, and deliberately so. The parent passes `invoices`
     // and `availableEmails` as fresh array literals, so both change identity on
     // every one of its renders — and a successful send triggers exactly that,
@@ -165,9 +163,6 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
 
   const allSelected =
     invoices.length > 0 && selectedIds.size === invoices.length;
-
-  const failed = outcomes?.filter((o) => !o.ok) ?? [];
-  const succeeded = outcomes?.filter((o) => o.ok) ?? [];
 
   const toggleInvoice = (id: string) =>
     setSelectedIds((prev) => {
@@ -214,65 +209,47 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
   };
 
   /**
-   * Send the given invoices one at a time, recording what happened to each.
+   * Send one statement covering every selected invoice.
    *
-   * A failure part-way through leaves the invoices already sent alone: they
-   * have genuinely been emailed, and re-sending them to "clean up" would put a
-   * duplicate in the customer's inbox.
+   * One message, not one per invoice: seven separate emails leave the customer
+   * adding the balances up themselves, and make the shop look disorganised. The
+   * statement lists each invoice with its balance, states the total owing once,
+   * and carries every invoice as its own PDF attachment.
    */
-  const sendInvoices = async (targets: BulkEmailableInvoice[]) => {
-    if (targets.length === 0 || selectedEmails.length === 0) return;
+  const sendStatement = async () => {
+    if (selectedInvoices.length === 0 || selectedEmails.length === 0) return;
+    if (!customerId) {
+      setSendError(
+        'This customer record is missing an id — reopen the customer and try again.'
+      );
+      return;
+    }
 
     setSending(true);
     setError('');
-    setProgress({ done: 0, total: targets.length });
+    setSendError(null);
 
-    const results: SendOutcome[] = [];
-    // New addresses only need persisting once, and only if a send actually
-    // succeeds — saving them off the back of a failed request would record
-    // addresses that were never reached.
-    let emailsSaved = false;
-
-    for (const [index, invoice] of targets.entries()) {
-      try {
-        await invoiceService.sendInvoiceEmail(
-          invoice.id,
-          selectedEmails,
-          saveToCustomer && !!customerId && !emailsSaved
-        );
-        emailsSaved = emailsSaved || (saveToCustomer && !!customerId);
-        results.push({
-          id: invoice.id,
-          invoiceNumber: invoice.invoiceNumber,
-          ok: true,
-        });
-      } catch (err) {
-        results.push({
-          id: invoice.id,
-          invoiceNumber: invoice.invoiceNumber,
-          ok: false,
-          error: errorMessage(err),
-        });
-      }
-      setProgress({ done: index + 1, total: targets.length });
+    try {
+      const result = await invoiceService.sendInvoiceStatement(
+        customerId,
+        selectedInvoices.map((invoice) => invoice.id),
+        selectedEmails,
+        saveToCustomer
+      );
+      setSent({
+        invoiceCount: result.invoiceCount ?? selectedInvoices.length,
+        totalOwing: result.totalOwing ?? outstandingTotal,
+        emailUsed: result.emailUsed ?? selectedEmails.join(', '),
+      });
+      onSent?.();
+    } catch (err) {
+      // Nothing partial to report: the statement is one email, so it either
+      // went or it did not, and pressing Send again is a safe retry.
+      setSendError(errorMessage(err));
+    } finally {
+      setSending(false);
     }
-
-    // A retry reports the whole run, not just the invoices it re-sent.
-    setOutcomes((prev) => {
-      if (!prev) return results;
-      const byId = new Map(prev.map((o) => [o.id, o]));
-      results.forEach((o) => byId.set(o.id, o));
-      return Array.from(byId.values());
-    });
-    setSending(false);
-
-    if (results.some((o) => o.ok)) onSent?.();
   };
-
-  const handleSend = () => sendInvoices(selectedInvoices);
-
-  const handleRetryFailed = () =>
-    sendInvoices(invoices.filter((inv) => failed.some((f) => f.id === inv.id)));
 
   const handleClose = () => {
     if (sending) return;
@@ -307,48 +284,36 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
       </DialogTitle>
 
       <DialogContent dividers>
-        {outcomes ? (
+        {sent ? (
           <Box sx={{ pt: 1 }}>
-            {failed.length === 0 ? (
-              <Alert severity="success" sx={{ mb: 2 }}>
-                {`${
-                  succeeded.length === 1
-                    ? '1 invoice was'
-                    : `All ${succeeded.length} invoices were`
-                } emailed to ${selectedEmails.join(', ')}.`}
-              </Alert>
-            ) : (
-              <Alert severity="warning" sx={{ mb: 2 }}>
-                {`${succeeded.length} of ${outcomes.length} invoices were emailed. The rest are listed below and can be retried \u2014 the ones that went out will not be sent again.`}
-              </Alert>
-            )}
-
-            <List dense disablePadding>
-              {outcomes.map((outcome) => (
-                <ListItem key={outcome.id} disableGutters>
-                  <ListItemIcon sx={{ minWidth: 36 }}>
-                    {outcome.ok ? (
-                      <SuccessIcon color="success" fontSize="small" />
-                    ) : (
-                      <FailureIcon color="error" fontSize="small" />
-                    )}
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={`#${outcome.invoiceNumber}`}
-                    secondary={outcome.ok ? 'Sent' : outcome.error}
-                    secondaryTypographyProps={{
-                      color: outcome.ok ? 'text.secondary' : 'error',
-                    }}
-                  />
-                </ListItem>
-              ))}
-            </List>
+            <Alert severity="success" icon={<SuccessIcon />} sx={{ mb: 2 }}>
+              {`${
+                sent.invoiceCount === 1
+                  ? '1 invoice'
+                  : `A statement for ${sent.invoiceCount} invoices`
+              } was emailed to ${sent.emailUsed}.`}
+            </Alert>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                px: 1,
+              }}
+            >
+              <Typography variant="subtitle2">Total owing</Typography>
+              <Typography variant="h6" fontWeight={700}>
+                {formatCurrency(sent.totalOwing)}
+              </Typography>
+            </Box>
           </Box>
         ) : (
           <Box sx={{ pt: 1 }}>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              Select the invoices to email to <strong>{customerName}</strong>.
-              Each one is sent as its own email with its own PDF attached.
+              Select the invoices to include in the statement for{' '}
+              <strong>{customerName}</strong>. They go out as one email listing
+              each invoice and the total owing, with every invoice attached as a
+              PDF.
             </Typography>
 
             <FormControlLabel
@@ -521,6 +486,12 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
               </Button>
             </Box>
 
+            {sendError && (
+              <Alert severity="error" sx={{ mt: 2 }}>
+                {`The statement was not sent: ${sendError}`}
+              </Alert>
+            )}
+
             {customerId && (
               <FormControlLabel
                 control={
@@ -544,19 +515,15 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
 
         {sending && (
           <Box sx={{ mt: 2 }}>
-            <LinearProgress
-              variant="determinate"
-              value={
-                progress.total ? (progress.done / progress.total) * 100 : 0
-              }
-            />
+            <LinearProgress />
             <Typography
               variant="body2"
               color="text.secondary"
               sx={{ mt: 1, textAlign: 'center' }}
             >
-              Sending {Math.min(progress.done + 1, progress.total)} of{' '}
-              {progress.total}…
+              {selectedInvoices.length === 1
+                ? 'Preparing the invoice and sending…'
+                : `Preparing ${selectedInvoices.length} invoices and sending…`}
             </Typography>
           </Box>
         )}
@@ -564,33 +531,20 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
 
       <DialogActions sx={{ px: 3, pb: 2 }}>
         <Button onClick={handleClose} color="inherit" disabled={sending}>
-          {outcomes ? 'Close' : 'Cancel'}
+          {sent ? 'Close' : 'Cancel'}
         </Button>
-        {outcomes
-          ? failed.length > 0 && (
-              <Button
-                onClick={handleRetryFailed}
-                variant="contained"
-                startIcon={<EmailIcon />}
-                disabled={sending}
-              >
-                {failed.length === 1
-                  ? 'Retry 1 failed'
-                  : `Retry ${failed.length} failed`}
-              </Button>
-            )
-          : !sending && (
-              <Button
-                onClick={handleSend}
-                variant="contained"
-                startIcon={<EmailIcon />}
-                disabled={!canSend}
-              >
-                {selectedInvoices.length === 1
-                  ? 'Send 1 invoice'
-                  : `Send ${selectedInvoices.length} invoices`}
-              </Button>
-            )}
+        {!sent && !sending && (
+          <Button
+            onClick={sendStatement}
+            variant="contained"
+            startIcon={<EmailIcon />}
+            disabled={!canSend}
+          >
+            {selectedInvoices.length === 1
+              ? 'Send 1 invoice'
+              : `Send statement (${selectedInvoices.length} invoices)`}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/apps/webApp/src/app/requests/invoice.requests.ts
+++ b/apps/webApp/src/app/requests/invoice.requests.ts
@@ -257,6 +257,30 @@ class InvoiceService {
     return response.data;
   }
 
+  /**
+   * Email one statement covering several invoices, with each attached as a PDF
+   * and the total owing stated once — rather than one email per invoice.
+   */
+  async sendInvoiceStatement(
+    customerId: string,
+    invoiceIds: string[],
+    emails?: string[],
+    saveToCustomer?: boolean
+  ): Promise<{
+    success: boolean;
+    message: string;
+    emailUsed?: string;
+    invoiceCount?: number;
+    totalOwing?: number;
+  }> {
+    const response = await axios.post(
+      `${API_URL}/api/invoices/send-statement`,
+      { customerId, invoiceIds, emails, saveToCustomer },
+      { headers: await this.getHeaders() }
+    );
+    return response.data;
+  }
+
   async deleteInvoice(id: string): Promise<void> {
     await axios.delete(`${API_URL}/api/invoices/${id}`, {
       headers: await this.getHeaders(),

--- a/apps/webApp/src/test-setup.ts
+++ b/apps/webApp/src/test-setup.ts
@@ -1,3 +1,9 @@
+// The DTOs in @gt-automotive/data carry class-validator decorators, which need
+// Reflect.getMetadata at module-evaluation time. Vite's build supplies it; Jest
+// does not, so any test that reaches the shared library fails to even load
+// without this.
+import 'reflect-metadata';
+
 // Mock import.meta.env for Jest
 (global as any).testImportMetaEnv = {
   env: {
@@ -20,7 +26,7 @@ process.env = {
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: jest.fn().mockImplementation(query => ({
+  value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,

--- a/server/src/email/email.service.ts
+++ b/server/src/email/email.service.ts
@@ -1563,6 +1563,247 @@ export class EmailService {
   }
 
   /**
+   * One statement email covering everything a customer currently owes.
+   *
+   * Chasing a fleet customer used to mean one email per invoice, so seven
+   * outstanding invoices arrived as seven separate messages with no total
+   * anywhere — leaving the customer to add them up and us to look disorganised.
+   * This sends a single message: every invoice listed with its balance, the
+   * total owing stated once, and each invoice still attached as its own PDF so
+   * nothing is lost against the per-invoice email it replaces.
+   */
+  async sendInvoiceStatementEmail(
+    recipients: string[],
+    statement: {
+      customerName: string;
+      invoices: Array<{
+        invoiceNumber: string;
+        invoiceDate?: string;
+        total: number;
+        amountPaid: number;
+        balanceDue: number;
+      }>;
+      totalOwing: number;
+      attachments: Array<{ name: string; content: string }>;
+    }
+  ): Promise<{ success: boolean; messageId?: string }> {
+    if (!this.enabled) {
+      this.logger.warn(
+        '[EMAIL] Email service disabled - skipping invoice statement email'
+      );
+      return { success: false };
+    }
+
+    const to = Array.from(
+      new Set(recipients.map((e) => e.trim()).filter((e) => e !== ''))
+    );
+
+    if (to.length === 0) {
+      this.logger.warn('[EMAIL] No valid recipients for invoice statement');
+      return { success: false };
+    }
+
+    const escapeHtml = (value: unknown): string =>
+      String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+    const money = (amount: number) =>
+      new Intl.NumberFormat('en-CA', {
+        style: 'currency',
+        currency: 'CAD',
+      }).format(Number(amount) || 0);
+
+    // Invoice dates are stored as midnight-UTC calendar dates, so read them
+    // back in UTC or an evening invoice reads as the day before.
+    const invoiceDate = (value?: string) => {
+      if (!value) return '';
+      return new Date(value).toLocaleDateString('en-CA', {
+        timeZone: 'UTC',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    };
+
+    const subject =
+      statement.invoices.length === 1
+        ? `Invoice ${statement.invoices[0].invoiceNumber} - GT Automotives`
+        : `Statement of Account (${statement.invoices.length} invoices) - GT Automotives`;
+
+    try {
+      this.logger.log(
+        `[EMAIL] Sending statement of ${
+          statement.invoices.length
+        } invoice(s) to ${to.join(', ')}`
+      );
+
+      const logoImg = this.logoBase64
+        ? `<img src="${this.logoBase64}" alt="GT Automotives" style="width: 80px; height: 80px; object-fit: contain;" />`
+        : `<img src="https://gt-automotives.com/logo.png" alt="GT Automotives" style="width: 80px; height: 80px; object-fit: contain;" />`;
+
+      const rows = statement.invoices
+        .map(
+          (invoice) => `
+            <tr>
+              <td style="padding: 10px 8px; border-bottom: 1px solid #eeeeee; font-size: 14px; color: #333333;">
+                ${escapeHtml(invoice.invoiceNumber)}
+              </td>
+              <td style="padding: 10px 8px; border-bottom: 1px solid #eeeeee; font-size: 14px; color: #666666;">
+                ${escapeHtml(invoiceDate(invoice.invoiceDate))}
+              </td>
+              <td style="padding: 10px 8px; border-bottom: 1px solid #eeeeee; font-size: 14px; color: #666666; text-align: right;">
+                ${money(invoice.total)}
+              </td>
+              <td style="padding: 10px 8px; border-bottom: 1px solid #eeeeee; font-size: 14px; color: #666666; text-align: right;">
+                ${
+                  invoice.amountPaid > 0 ? money(invoice.amountPaid) : '&mdash;'
+                }
+              </td>
+              <td style="padding: 10px 8px; border-bottom: 1px solid #eeeeee; font-size: 14px; color: #333333; text-align: right; font-weight: 600;">
+                ${money(invoice.balanceDue)}
+              </td>
+            </tr>`
+        )
+        .join('');
+
+      const htmlContent = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        </head>
+        <body style="margin: 0; padding: 0; font-family: Arial, sans-serif; background-color: #f4f4f4;">
+          <table role="presentation" style="width: 100%; border-collapse: collapse;">
+            <tr>
+              <td style="padding: 40px 20px; text-align: center;">
+                <table role="presentation" style="max-width: 640px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+                  <!-- Header -->
+                  <tr>
+                    <td style="padding: 40px 40px 30px; text-align: center; background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%); border-radius: 8px 8px 0 0;">
+                      ${logoImg}
+                      <h1 style="margin: 20px 0 0; color: #ffffff; font-size: 28px; font-weight: 600;">Statement of Account</h1>
+                    </td>
+                  </tr>
+
+                  <!-- Content -->
+                  <tr>
+                    <td style="padding: 40px 40px 20px; text-align: left;">
+                      <p style="margin: 0 0 20px; font-size: 16px; line-height: 1.6; color: #333333;">
+                        Hello ${escapeHtml(statement.customerName)},
+                      </p>
+                      <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #333333;">
+                        Thank you for your business. Here is a summary of the
+                        ${
+                          statement.invoices.length === 1
+                            ? 'invoice'
+                            : `${statement.invoices.length} invoices`
+                        }
+                        currently outstanding on your account. Each one is attached to this email as a PDF.
+                      </p>
+
+                      <table role="presentation" style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+                        <thead>
+                          <tr>
+                            <th style="padding: 10px 8px; border-bottom: 2px solid #1976d2; font-size: 13px; color: #1976d2; text-align: left; text-transform: uppercase; letter-spacing: 0.5px;">Invoice</th>
+                            <th style="padding: 10px 8px; border-bottom: 2px solid #1976d2; font-size: 13px; color: #1976d2; text-align: left; text-transform: uppercase; letter-spacing: 0.5px;">Date</th>
+                            <th style="padding: 10px 8px; border-bottom: 2px solid #1976d2; font-size: 13px; color: #1976d2; text-align: right; text-transform: uppercase; letter-spacing: 0.5px;">Amount</th>
+                            <th style="padding: 10px 8px; border-bottom: 2px solid #1976d2; font-size: 13px; color: #1976d2; text-align: right; text-transform: uppercase; letter-spacing: 0.5px;">Paid</th>
+                            <th style="padding: 10px 8px; border-bottom: 2px solid #1976d2; font-size: 13px; color: #1976d2; text-align: right; text-transform: uppercase; letter-spacing: 0.5px;">Balance</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          ${rows}
+                        </tbody>
+                      </table>
+
+                      <!-- Total owing -->
+                      <table role="presentation" style="width: 100%; border-collapse: collapse; background-color: #f1f7fd; border-radius: 6px;">
+                        <tr>
+                          <td style="padding: 18px 20px; font-size: 16px; color: #333333; font-weight: 600;">
+                            Total owing to GT Automotives
+                          </td>
+                          <td style="padding: 18px 20px; font-size: 22px; color: #1565c0; font-weight: 700; text-align: right; white-space: nowrap;">
+                            ${money(statement.totalOwing)}
+                          </td>
+                        </tr>
+                      </table>
+
+                      <p style="margin: 24px 0 0; font-size: 16px; line-height: 1.6; color: #333333;">
+                        If you have any questions about this statement, please let us know &mdash; we are happy to help.
+                      </p>
+                    </td>
+                  </tr>
+
+                  <!-- Footer -->
+                  <tr>
+                    <td style="padding: 30px 40px; background-color: #f8f9fa; border-radius: 0 0 8px 8px; text-align: center;">
+                      <p style="margin: 0 0 10px; font-size: 14px; color: #666666;">
+                        <strong style="color: #1976d2;">GT Automotives</strong><br>
+                        473 3rd Ave<br>
+                        Prince George, BC V2L 3C1<br>
+                        Phone: 250-570-2333 / 250-986-9191<br>
+                        Email: gt-automotives@outlook.com
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </body>
+        </html>
+      `;
+
+      const sendSmtpEmail: SendSmtpEmail = {
+        sender: { name: this.senderName, email: this.senderEmail },
+        to: to.map((email) => ({ email })),
+        subject,
+        htmlContent,
+        attachment: statement.attachments,
+      };
+
+      const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
+      const messageId = (response as any)?.messageId || 'unknown';
+
+      this.logger.log(
+        `[EMAIL] Invoice statement sent successfully. Message ID: ${messageId}`
+      );
+
+      try {
+        await this.prisma.emailLog.create({
+          data: {
+            type: EmailType.INVOICE_DELIVERY,
+            to: to.join(', '),
+            from: this.senderEmail,
+            subject,
+            status: EmailStatus.SENT,
+            sentAt: new Date(),
+          },
+        });
+      } catch (dbError) {
+        this.logger.error(
+          '[EMAIL] Failed to log invoice statement to database:',
+          dbError
+        );
+      }
+
+      return { success: true, messageId };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `[EMAIL] Failed to send invoice statement: ${errorMessage}`,
+        error
+      );
+      return { success: false };
+    }
+  }
+
+  /**
    * Send quotation email with PDF attachment
    */
   /**

--- a/server/src/invoices/invoices-statement.service.spec.ts
+++ b/server/src/invoices/invoices-statement.service.spec.ts
@@ -1,0 +1,223 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { InvoicesService } from './invoices.service';
+
+/**
+ * Unit tests for the statement email — one message covering everything a
+ * customer owes, rather than one email per invoice.
+ *
+ * The service is built directly with mocked collaborators (no Nest DI). What is
+ * worth pinning here is the money and the scoping: the total the customer is
+ * asked for, and the guarantee that a statement never carries another
+ * customer's invoice.
+ */
+describe('InvoicesService — statement email', () => {
+  let service: InvoicesService;
+  let findWithDetails: jest.Mock;
+  let findCustomerById: jest.Mock;
+  let updateCustomer: jest.Mock;
+  let generateInvoicePdf: jest.Mock;
+  let sendInvoiceStatementEmail: jest.Mock;
+  let auditCreate: jest.Mock;
+
+  const customer = {
+    id: 'cust-1',
+    firstName: 'Dale',
+    lastName: 'Cooper',
+    businessName: 'Northern Fleet Ltd',
+    email: 'fleet@northern.ca',
+    additionalEmails: [],
+  };
+
+  const invoice = (overrides: any = {}) => ({
+    id: 'inv-1',
+    invoiceNumber: '1001',
+    customerId: 'cust-1',
+    total: 100,
+    amountPaid: 0,
+    invoiceDate: new Date('2026-08-01T00:00:00.000Z'),
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    signatureBlobName: null,
+    signatureContainerName: null,
+    ...overrides,
+  });
+
+  const invoicesById: Record<string, any> = {
+    'inv-1': invoice(),
+    'inv-2': invoice({
+      id: 'inv-2',
+      invoiceNumber: '1002',
+      total: 250,
+      amountPaid: 50,
+    }),
+    'inv-3': invoice({ id: 'inv-3', invoiceNumber: '1003', total: 75 }),
+    // Belongs to someone else entirely.
+    'inv-other': invoice({
+      id: 'inv-other',
+      invoiceNumber: '9999',
+      customerId: 'cust-2',
+    }),
+  };
+
+  beforeEach(() => {
+    findWithDetails = jest.fn(async (id: string) => invoicesById[id] ?? null);
+    findCustomerById = jest.fn().mockResolvedValue(customer);
+    updateCustomer = jest.fn().mockResolvedValue(customer);
+    generateInvoicePdf = jest.fn().mockResolvedValue('cGRm');
+    sendInvoiceStatementEmail = jest
+      .fn()
+      .mockResolvedValue({ success: true, messageId: 'msg-1' });
+    auditCreate = jest.fn();
+
+    service = new InvoicesService(
+      { findWithDetails } as any,
+      { create: auditCreate } as any,
+      { findById: findCustomerById, update: updateCustomer } as any,
+      {} as any,
+      { generateInvoicePdf } as any,
+      { sendInvoiceStatementEmail } as any,
+      {} as any,
+      {} as any
+    );
+  });
+
+  const send = (ids = ['inv-1', 'inv-2', 'inv-3'], opts: any = {}) =>
+    service.sendInvoiceStatementEmail(
+      'cust-1',
+      ids,
+      'user-1',
+      opts.emails,
+      opts.saveToCustomer
+    );
+
+  it('sends one email rather than one per invoice', async () => {
+    await send();
+
+    expect(sendInvoiceStatementEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('owes the sum of the balances, not the sum of the totals', async () => {
+    const result = await send();
+
+    // 100 + (250 - 50) + 75
+    expect(result.totalOwing).toBe(375);
+    const [, statement] = sendInvoiceStatementEmail.mock.calls[0];
+    expect(statement.totalOwing).toBe(375);
+  });
+
+  it('lists every invoice with what is still owing on it', async () => {
+    await send();
+
+    const [, statement] = sendInvoiceStatementEmail.mock.calls[0];
+    expect(statement.invoices).toEqual([
+      expect.objectContaining({
+        invoiceNumber: '1001',
+        total: 100,
+        amountPaid: 0,
+        balanceDue: 100,
+      }),
+      expect.objectContaining({
+        invoiceNumber: '1002',
+        total: 250,
+        amountPaid: 50,
+        balanceDue: 200,
+      }),
+      expect.objectContaining({
+        invoiceNumber: '1003',
+        balanceDue: 75,
+      }),
+    ]);
+  });
+
+  it('attaches every invoice as its own PDF', async () => {
+    await send();
+
+    const [, statement] = sendInvoiceStatementEmail.mock.calls[0];
+    expect(statement.attachments.map((a: any) => a.name)).toEqual([
+      'Invoice-1001.pdf',
+      'Invoice-1002.pdf',
+      'Invoice-1003.pdf',
+    ]);
+    expect(generateInvoicePdf).toHaveBeenCalledTimes(3);
+  });
+
+  it('addresses the statement to the business name when there is one', async () => {
+    await send();
+
+    const [, statement] = sendInvoiceStatementEmail.mock.calls[0];
+    expect(statement.customerName).toBe('Northern Fleet Ltd');
+  });
+
+  // A statement goes to one customer. Carrying someone else's invoice would
+  // disclose their business to the wrong person.
+  it('refuses an invoice belonging to another customer', async () => {
+    await expect(send(['inv-1', 'inv-other'])).rejects.toBeInstanceOf(
+      BadRequestException
+    );
+    expect(sendInvoiceStatementEmail).not.toHaveBeenCalled();
+  });
+
+  it('refuses an invoice that does not exist', async () => {
+    await expect(send(['inv-1', 'nope'])).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+    expect(sendInvoiceStatementEmail).not.toHaveBeenCalled();
+  });
+
+  it('refuses to send nothing', async () => {
+    await expect(send([])).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('falls back to the customer email when no recipient is chosen', async () => {
+    await send();
+
+    expect(sendInvoiceStatementEmail.mock.calls[0][0]).toEqual([
+      'fleet@northern.ca',
+    ]);
+  });
+
+  it('refuses when there is no address to send to at all', async () => {
+    findCustomerById.mockResolvedValue({ ...customer, email: null });
+
+    await expect(send()).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('saves a newly typed address to the customer when asked', async () => {
+    await send(['inv-1'], {
+      emails: ['fleet@northern.ca', 'accounts@northern.ca'],
+      saveToCustomer: true,
+    });
+
+    expect(updateCustomer).toHaveBeenCalledWith('cust-1', {
+      email: 'fleet@northern.ca',
+      additionalEmails: ['accounts@northern.ca'],
+    });
+  });
+
+  it('leaves the customer alone when not asked to save', async () => {
+    await send(['inv-1'], { emails: ['someone@else.ca'] });
+
+    expect(updateCustomer).not.toHaveBeenCalled();
+  });
+
+  it('reports a send failure rather than claiming success', async () => {
+    sendInvoiceStatementEmail.mockResolvedValue({ success: false });
+
+    await expect(send()).rejects.toBeInstanceOf(BadRequestException);
+    expect(auditCreate).not.toHaveBeenCalled();
+  });
+
+  it('audits what was sent, to whom, and for how much', async () => {
+    await send();
+
+    expect(auditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'SEND_INVOICE_STATEMENT_EMAIL',
+        entityId: 'cust-1',
+        details: expect.objectContaining({
+          invoiceNumbers: ['1001', '1002', '1003'],
+          totalOwing: 375,
+        }),
+      })
+    );
+  });
+});

--- a/server/src/invoices/invoices-statement.service.spec.ts
+++ b/server/src/invoices/invoices-statement.service.spec.ts
@@ -56,6 +56,11 @@ describe('InvoicesService — statement email', () => {
       invoiceNumber: '9999',
       customerId: 'cust-2',
     }),
+    'inv-draft': invoice({
+      id: 'inv-draft',
+      invoiceNumber: '1004',
+      status: 'DRAFT',
+    }),
   };
 
   beforeEach(() => {
@@ -151,6 +156,15 @@ describe('InvoicesService — statement email', () => {
   // disclose their business to the wrong person.
   it('refuses an invoice belonging to another customer', async () => {
     await expect(send(['inv-1', 'inv-other'])).rejects.toBeInstanceOf(
+      BadRequestException
+    );
+    expect(sendInvoiceStatementEmail).not.toHaveBeenCalled();
+  });
+
+  // A statement asks for money. A draft is not a finalised invoice, so it would
+  // be asking against figures the shop has not committed to.
+  it('refuses a draft invoice', async () => {
+    await expect(send(['inv-1', 'inv-draft'])).rejects.toBeInstanceOf(
       BadRequestException
     );
     expect(sendInvoiceStatementEmail).not.toHaveBeenCalled();

--- a/server/src/invoices/invoices.controller.ts
+++ b/server/src/invoices/invoices.controller.ts
@@ -223,6 +223,33 @@ export class InvoicesController {
     );
   }
 
+  /**
+   * One statement email for everything a customer owes, rather than one email
+   * per invoice. Body carries the invoice ids so the user can drop any before
+   * sending; the service checks every one belongs to this customer.
+   */
+  @Post('send-statement')
+  @UseGuards(RoleGuard)
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF', 'ACCOUNTANT')
+  sendStatementEmail(
+    @Body()
+    body: {
+      customerId: string;
+      invoiceIds: string[];
+      emails?: string[];
+      saveToCustomer?: boolean;
+    },
+    @CurrentUser() user: any
+  ) {
+    return this.invoicesService.sendInvoiceStatementEmail(
+      body.customerId,
+      body.invoiceIds,
+      user.id,
+      body.emails,
+      body.saveToCustomer
+    );
+  }
+
   @Delete(':id')
   @UseGuards(RoleGuard)
   @Roles('ADMIN')

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -1236,6 +1236,15 @@ export class InvoicesService {
           `Invoice ${invoice.invoiceNumber} does not belong to this customer`
         );
       }
+      // A statement asks the customer for money. A draft is not a finalised
+      // invoice, so asking for it would be asking against figures the shop has
+      // not committed to. Enforced here and not only in the UI, because the
+      // endpoint takes invoice ids straight from the caller.
+      if (invoice.status === 'DRAFT') {
+        throw new BadRequestException(
+          `Invoice ${invoice.invoiceNumber} is still a draft and cannot be sent on a statement`
+        );
+      }
       invoices.push(invoice);
     }
 

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -1147,6 +1147,196 @@ export class InvoicesService {
     return this.serviceRepository.delete(id);
   }
 
+  /**
+   * Fold recipients the user typed into the customer's address book.
+   *
+   * A customer with no address on file takes the first one as primary; the rest
+   * become additional addresses. Shared by the per-invoice send and the
+   * statement send so the two cannot drift on what "save to customer" means.
+   */
+  private async saveRecipientsToCustomer(
+    customer: {
+      id: string;
+      email?: string | null;
+      additionalEmails?: string[];
+    },
+    recipients: string[]
+  ) {
+    const knownEmails = [
+      customer.email,
+      ...(customer.additionalEmails ?? []),
+    ].filter((e): e is string => !!e);
+    let primary = customer.email ?? undefined;
+    const additional = [...(customer.additionalEmails ?? [])];
+
+    for (const email of recipients) {
+      if (knownEmails.includes(email)) continue;
+      if (!primary) {
+        primary = email;
+      } else {
+        additional.push(email);
+      }
+      knownEmails.push(email);
+    }
+
+    const dedupedAdditional = Array.from(new Set(additional)).filter(
+      (e) => e !== primary
+    );
+
+    if (
+      primary !== (customer.email ?? undefined) ||
+      dedupedAdditional.length !== (customer.additionalEmails ?? []).length
+    ) {
+      await this.customerRepository.update(customer.id, {
+        email: primary,
+        additionalEmails: dedupedAdditional,
+      });
+    }
+  }
+
+  /**
+   * Email one statement covering everything a customer owes.
+   *
+   * Sending a customer with seven outstanding invoices seven separate emails
+   * makes them add the balances up themselves and makes us look disorganised,
+   * so this is one message: every invoice listed with its balance, the total
+   * owing stated once, and each invoice attached as its own PDF.
+   *
+   * The PDFs are rendered one at a time. Each goes through Puppeteer, and
+   * firing seven Chromium renders at once at a 1.75GB app service is how a slow
+   * send becomes a failed one.
+   */
+  async sendInvoiceStatementEmail(
+    customerId: string,
+    invoiceIds: string[],
+    userId: string,
+    emails?: string[],
+    saveToCustomer?: boolean
+  ) {
+    if (!invoiceIds || invoiceIds.length === 0) {
+      throw new BadRequestException('No invoices selected');
+    }
+
+    const customer = await this.customerRepository.findById(customerId);
+    if (!customer) {
+      throw new NotFoundException(`Customer with ID "${customerId}" not found`);
+    }
+
+    // Loaded individually so each carries the relations the PDF template needs.
+    const invoices = [];
+    for (const invoiceId of invoiceIds) {
+      const invoice = await this.invoiceRepository.findWithDetails(invoiceId);
+      if (!invoice) {
+        throw new NotFoundException(`Invoice with ID "${invoiceId}" not found`);
+      }
+      // A statement is addressed to one customer; sending it invoices that
+      // belong to someone else would disclose another customer's business.
+      if (invoice.customerId !== customerId) {
+        throw new BadRequestException(
+          `Invoice ${invoice.invoiceNumber} does not belong to this customer`
+        );
+      }
+      invoices.push(invoice);
+    }
+
+    const providedEmails = Array.from(
+      new Set((emails ?? []).map((e) => e.trim()).filter((e) => e !== ''))
+    );
+    const recipients =
+      providedEmails.length > 0
+        ? providedEmails
+        : customer.email
+        ? [customer.email]
+        : [];
+
+    if (recipients.length === 0) {
+      throw new BadRequestException(
+        'No email address provided and customer does not have an email address'
+      );
+    }
+
+    if (saveToCustomer) {
+      await this.saveRecipientsToCustomer(customer, recipients);
+    }
+
+    try {
+      const rows = [];
+      const attachments = [];
+
+      for (const invoice of invoices) {
+        // Puppeteer fetches the signature over the network, so it needs a SAS
+        // URL — the raw blob URL is private and renders as a broken image.
+        const pdfBase64 = await this.pdfService.generateInvoicePdf(
+          await this.withSignatureUrl(invoice)
+        );
+        attachments.push({
+          name: `Invoice-${invoice.invoiceNumber}.pdf`,
+          content: pdfBase64,
+        });
+
+        const total = Number(invoice.total) || 0;
+        const amountPaid = Number((invoice as any).amountPaid ?? 0) || 0;
+        rows.push({
+          invoiceNumber: invoice.invoiceNumber,
+          invoiceDate: (
+            invoice.invoiceDate ?? invoice.createdAt
+          )?.toISOString(),
+          total,
+          amountPaid,
+          // Never negative: an overpaid invoice reads as nothing owing rather
+          // than as a credit subsidising the rest of the statement.
+          balanceDue: Math.max(0, Math.round((total - amountPaid) * 100) / 100),
+        });
+      }
+
+      const totalOwing =
+        Math.round(rows.reduce((sum, row) => sum + row.balanceDue, 0) * 100) /
+        100;
+
+      const customerName =
+        customer.businessName ||
+        [customer.firstName, customer.lastName].filter(Boolean).join(' ') ||
+        'there';
+
+      const emailResult = await this.emailService.sendInvoiceStatementEmail(
+        recipients,
+        { customerName, invoices: rows, totalOwing, attachments }
+      );
+
+      if (!emailResult.success) {
+        throw new Error('Email service returned failure status');
+      }
+
+      await this.auditRepository.create({
+        userId,
+        action: 'SEND_INVOICE_STATEMENT_EMAIL',
+        entityType: 'Customer',
+        entityId: customerId,
+        details: {
+          emails: recipients,
+          invoiceNumbers: invoices.map((invoice) => invoice.invoiceNumber),
+          totalOwing,
+          messageId: emailResult.messageId,
+          emailsSavedToCustomer: !!saveToCustomer,
+        },
+      });
+
+      return {
+        success: true,
+        message: 'Statement email sent successfully',
+        emailUsed: recipients.join(', '),
+        invoiceCount: invoices.length,
+        totalOwing,
+      };
+    } catch (error) {
+      throw new BadRequestException(
+        `Failed to send statement email: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+      );
+    }
+  }
+
   async sendInvoiceEmail(
     invoiceId: string,
     userId: string,
@@ -1182,38 +1372,8 @@ export class InvoicesService {
       );
     }
 
-    // If saveToCustomer is true and customer exists, persist any new emails back to the customer
     if (saveToCustomer && customer) {
-      const knownEmails = [
-        customer.email,
-        ...(customer.additionalEmails ?? []),
-      ].filter((e): e is string => !!e);
-      let primary = customer.email ?? undefined;
-      const additional = [...(customer.additionalEmails ?? [])];
-
-      for (const email of recipients) {
-        if (knownEmails.includes(email)) continue;
-        if (!primary) {
-          primary = email;
-        } else {
-          additional.push(email);
-        }
-        knownEmails.push(email);
-      }
-
-      const dedupedAdditional = Array.from(new Set(additional)).filter(
-        (e) => e !== primary
-      );
-
-      if (
-        primary !== (customer.email ?? undefined) ||
-        dedupedAdditional.length !== (customer.additionalEmails ?? []).length
-      ) {
-        await this.customerRepository.update(customer.id, {
-          email: primary,
-          additionalEmails: dedupedAdditional,
-        });
-      }
+      await this.saveRecipientsToCustomer(customer, recipients);
     }
 
     try {


### PR DESCRIPTION
Closes [GA-61](https://gt-automotives.atlassian.net/browse/GA-61).

## Problem

Chasing a fleet customer with seven outstanding invoices meant seven trips through the single-invoice email dialog — and the customer then received seven separate emails, none of which said what they actually owed. They had to add the balances up themselves, and it made the shop look disorganised.

## What this does

**One email.** A new statement template lists every outstanding invoice with its date, amount, anything already paid and the balance still owing; states the **total owing to GT Automotives** once, in a highlighted panel; and closes by inviting the customer to ask if they have questions. Every invoice is still attached as its own PDF, so nothing is lost against the per-invoice email it replaces.

Subject line is `Statement of Account (N invoices) - GT Automotives`, falling back to the plain invoice subject when only one is selected.

The dialog on the customer screen lets staff untick any invoice before sending, edit or add recipients, and save new addresses to the customer profile — the same recipient handling as the single-invoice flow.

## Decisions worth reviewing

**The total is the sum of balances due, not invoice totals.** A part-paid invoice contributes only what is still owing; an overpaid one contributes zero rather than a credit that quietly reduces the rest of the statement.

**Drafts are excluded from statements.** A statement asks the customer for money, and a draft is not a finalised invoice — sending one asks for payment against figures the shop has not committed to. Bulk *payment* still includes drafts, which is the right split: someone settling up in the bay may well be paying one before it is finalised, but nobody should be emailed about it. Enforced on the server as well as in the UI, since the endpoint takes invoice ids straight from the caller.

**The server checks every invoice belongs to the named customer.** A statement is addressed to one person, so carrying someone else's invoice would disclose their business to the wrong customer. Covered by a test.

**No partial-failure handling, deliberately.** With N separate sends the client needed per-invoice outcomes and a retry-failed button. One email either goes or it does not, so a failure now says so plainly and leaves Send available — a safe retry rather than a way to duplicate what already arrived.

**PDFs render one at a time.** Each goes through Puppeteer, and firing seven Chromium renders at once at a 1.75GB app service turns a slow send into a failed one.

## Also in this branch

- Saving typed-in recipient addresses back to the customer is now one shared helper rather than the same block duplicated across two send paths.
- `reflect-metadata` in `test-setup.ts` — the DTOs in `@gt-automotive/data` evaluate class-validator decorators at import, so without it any spec reaching the shared library failed to load at all.
- The customer screen's outstanding-invoice section now gates, counts and lists on the same set its bulk actions operate on. It previously gated on PENDING/DRAFT while the buttons acted on PENDING/DRAFT/PARTIALLY_PAID, so a customer whose invoices were all part-paid could reach neither button.

## Verification

- `tsc --noEmit` clean on `server` and `apps/webApp`
- 437 server tests pass, including 15 for the statement (total arithmetic, cross-customer refusal, draft refusal, attachment set, address saving, failure and audit)
- 163 webApp tests pass, including 8 for the dialog

Two of those webApp tests exist because `/review` caught a bug the original suite could not: the dialog's reset effect depended on props the parent re-creates on every render, so the confirmation was wiped and Send re-armed the instant a send completed. The tests now use a parent that behaves like `CustomerDetailsDialog`; both were confirmed to fail against the bug and pass with the fix.

## Note

Related to [GA-33](https://gt-automotives.atlassian.net/browse/GA-33), which merges invoices into a single combined *invoice document*. This is a statement covering separate invoices, and the two remain independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)