### PR TITLE
feat(payroll): accrue vacation pay at 4% on every pay stub (GA-62)

### DIFF
--- a/apps/webApp/src/app/components/pay-stubs/PayStubDialog.tsx
+++ b/apps/webApp/src/app/components/pay-stubs/PayStubDialog.tsx
@@ -19,7 +19,9 @@ import {
 import { Calculate as CalculateIcon } from '@mui/icons-material';
 import { endOfMonth, format, startOfMonth } from 'date-fns';
 import {
+  calculateVacationPay,
   CreatePayStubDto,
+  DEFAULT_VACATION_PAY_RATE,
   PayPeriodsPerYear,
   PayrollHoursDto,
   PayStubDeductionEstimateDto,
@@ -75,6 +77,9 @@ const emptyForm = {
   payRate: '',
   regularHours: '',
   regularAmount: '',
+  vacationPayRate: String(DEFAULT_VACATION_PAY_RATE),
+  vacationPayAmount: '',
+  vacationPayHeld: '',
   payPeriodsPerYear: 24 as PayPeriodsPerYear,
   eiAmount: '',
   cppAmount: '',
@@ -141,6 +146,9 @@ export function PayStubDialog({
   const [grossOverridden, setGrossOverridden] = useState(false);
   const grossOverriddenRef = useRef(grossOverridden);
   grossOverriddenRef.current = grossOverridden;
+  // Vacation figures are derived from the rate until typed over, same as gross.
+  const [vacationOverridden, setVacationOverridden] = useState(false);
+  const [vacationHeldOverridden, setVacationHeldOverridden] = useState(false);
   // Position comes from the employee's compensation record until typed over.
   const [positionOverridden, setPositionOverridden] = useState(false);
   const [carriedPosition, setCarriedPosition] = useState(false);
@@ -163,6 +171,9 @@ export function PayStubDialog({
         payRate: payStub.payRate != null ? String(payStub.payRate) : '',
         regularHours: String(payStub.regularHours),
         regularAmount: String(payStub.regularAmount),
+        vacationPayRate: String(payStub.vacationPayRate),
+        vacationPayAmount: String(payStub.vacationPayAmount),
+        vacationPayHeld: String(payStub.vacationPayHeld),
         eiAmount: String(payStub.eiAmount),
         cppAmount: String(payStub.cppAmount),
         incomeTaxAmount: String(payStub.incomeTaxAmount),
@@ -176,6 +187,10 @@ export function PayStubDialog({
         incomeTaxAmount: true,
       });
       setGrossOverridden(true);
+      // An issued stub's figures are what was actually paid, so reopening the
+      // form must not recalculate them out from under the accountant.
+      setVacationOverridden(true);
+      setVacationHeldOverridden(true);
       setPositionOverridden(true);
     } else {
       setForm({
@@ -186,6 +201,8 @@ export function PayStubDialog({
       });
       setOverrides(noOverrides);
       setGrossOverridden(false);
+      setVacationOverridden(false);
+      setVacationHeldOverridden(false);
       setPositionOverridden(false);
     }
 
@@ -280,6 +297,13 @@ export function PayStubDialog({
             result.position && !positionOverridden
               ? result.position
               : prev.position,
+          // This employee's own entitlement — 6% after five years — rather than
+          // the statutory minimum the form defaults to. Undefined means none is
+          // recorded, so the default stands.
+          vacationPayRate:
+            result.vacationPayRate == null
+              ? prev.vacationPayRate
+              : String(result.vacationPayRate),
         }));
         setCarriedPosition(Boolean(result.position) && !positionOverridden);
       }
@@ -300,7 +324,23 @@ export function PayStubDialog({
     loadHours();
   }, [loadHours]);
 
-  const grossPay = toNumber(form.regularAmount);
+  const regularAmount = toNumber(form.regularAmount);
+
+  /**
+   * Vacation follows the earnings until the accountant types over it, the same
+   * way gross follows rate × hours. The held line follows the accrual, since
+   * banking the whole of it is the normal case.
+   */
+  const vacationPayAmount = vacationOverridden
+    ? toNumber(form.vacationPayAmount)
+    : calculateVacationPay(regularAmount, toNumber(form.vacationPayRate));
+  const vacationPayHeld = vacationHeldOverridden
+    ? toNumber(form.vacationPayHeld)
+    : vacationPayAmount;
+
+  // Vacation pay is insurable and pensionable, so the CRA estimate has to see
+  // it — deducting on the earnings alone under-withholds on every stub.
+  const grossPay = round2(regularAmount + vacationPayAmount);
 
   /**
    * Recalculate the statutory deductions whenever the inputs they depend on
@@ -369,12 +409,14 @@ export function PayStubDialog({
 
   const hasOverride = Object.values(overrides).some(Boolean);
 
-  const totalWithholding =
+  const totalWithholding = round2(
     toNumber(form.eiAmount) +
-    toNumber(form.cppAmount) +
-    toNumber(form.incomeTaxAmount) +
-    toNumber(form.otherDeductions);
-  const netPay = grossPay - totalWithholding;
+      toNumber(form.cppAmount) +
+      toNumber(form.incomeTaxAmount) +
+      toNumber(form.otherDeductions) +
+      vacationPayHeld
+  );
+  const netPay = round2(grossPay - totalWithholding);
 
   const canSave =
     Boolean(form.employeeId) &&
@@ -383,6 +425,7 @@ export function PayStubDialog({
     Boolean(form.payDate) &&
     form.regularAmount.trim() !== '' &&
     netPay >= 0 &&
+    vacationPayHeld <= vacationPayAmount &&
     !saving;
 
   const handleSave = async () => {
@@ -397,7 +440,10 @@ export function PayStubDialog({
         position: form.position || undefined,
         payRate: form.payRate ? toNumber(form.payRate) : undefined,
         regularHours: toNumber(form.regularHours),
-        regularAmount: toNumber(form.regularAmount),
+        regularAmount: regularAmount,
+        vacationPayRate: toNumber(form.vacationPayRate),
+        vacationPayAmount,
+        vacationPayHeld,
         eiAmount: toNumber(form.eiAmount),
         cppAmount: toNumber(form.cppAmount),
         incomeTaxAmount: toNumber(form.incomeTaxAmount),
@@ -605,7 +651,7 @@ export function PayStubDialog({
               required
               size="small"
               type="number"
-              label="Gross Pay"
+              label="Regular Earnings"
               value={form.regularAmount}
               onChange={(event) => {
                 setGrossOverridden(true);
@@ -640,6 +686,103 @@ export function PayStubDialog({
                   ) : undefined,
               }}
             />
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Vacation Pay Rate"
+              value={form.vacationPayRate}
+              onChange={(event) => {
+                // A new rate means a new accrual. Leaving a typed-over amount
+                // in place would print "Vacation Pay (6%) $122.88" against
+                // $3,072 of earnings — a rate the figure beside it contradicts.
+                setVacationOverridden(false);
+                setVacationHeldOverridden(false);
+                setForm((prev) => ({
+                  ...prev,
+                  vacationPayRate: event.target.value,
+                  vacationPayAmount: '',
+                  vacationPayHeld: '',
+                }));
+              }}
+              helperText={`${DEFAULT_VACATION_PAY_RATE}% statutory minimum, 6% after 5 years`}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">%</InputAdornment>,
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Vacation Pay Earned"
+              value={
+                vacationOverridden
+                  ? form.vacationPayAmount
+                  : vacationPayAmount === 0
+                  ? ''
+                  : String(vacationPayAmount)
+              }
+              onChange={(event) => {
+                setVacationOverridden(true);
+                setField('vacationPayAmount', event.target.value);
+              }}
+              helperText={
+                vacationOverridden
+                  ? 'Entered by hand'
+                  : 'Rate × regular earnings'
+              }
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+                endAdornment: vacationOverridden ? (
+                  <InputAdornment position="end">
+                    <Tooltip title="Use the calculated accrual">
+                      <IconButton
+                        size="small"
+                        edge="end"
+                        onClick={() => {
+                          // Held follows the accrual again too. Restoring one
+                          // without the other leaves the difference silently
+                          // paid out.
+                          setVacationOverridden(false);
+                          setVacationHeldOverridden(false);
+                          setForm((prev) => ({
+                            ...prev,
+                            vacationPayAmount: '',
+                            vacationPayHeld: '',
+                          }));
+                        }}
+                      >
+                        <CalculateIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ) : undefined,
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 4 }}>
+            <Box
+              sx={{
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography variant="caption" color="text.secondary">
+                Gross Pay
+              </Typography>
+              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                {money(grossPay)}
+              </Typography>
+            </Box>
           </Grid>
 
           <Grid size={12}>
@@ -785,6 +928,54 @@ export function PayStubDialog({
                 startAdornment: (
                   <InputAdornment position="start">$</InputAdornment>
                 ),
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 3 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              label="Vacation Pay Held"
+              value={
+                vacationHeldOverridden
+                  ? form.vacationPayHeld
+                  : vacationPayHeld === 0
+                  ? ''
+                  : String(vacationPayHeld)
+              }
+              onChange={(event) => {
+                setVacationHeldOverridden(true);
+                setField('vacationPayHeld', event.target.value);
+              }}
+              error={vacationPayHeld > vacationPayAmount}
+              helperText={
+                vacationPayHeld > vacationPayAmount
+                  ? 'Cannot hold back more vacation than was earned'
+                  : vacationHeldOverridden
+                  ? 'Entered by hand — the rest is paid out'
+                  : 'Banked, so net pay is unchanged'
+              }
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">$</InputAdornment>
+                ),
+                endAdornment: vacationHeldOverridden ? (
+                  <InputAdornment position="end">
+                    <Tooltip title="Hold the whole accrual">
+                      <IconButton
+                        size="small"
+                        edge="end"
+                        onClick={() => {
+                          setVacationHeldOverridden(false);
+                          setField('vacationPayHeld', '');
+                        }}
+                      >
+                        <CalculateIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                ) : undefined,
               }}
             />
           </Grid>

--- a/apps/webApp/src/app/pages/accountant/PayStubs.tsx
+++ b/apps/webApp/src/app/pages/accountant/PayStubs.tsx
@@ -212,6 +212,7 @@ export function PayStubs() {
                 <TableCell>Pay Date</TableCell>
                 <TableCell align="right">Hours</TableCell>
                 <TableCell align="right">Gross</TableCell>
+                <TableCell align="right">Vacation</TableCell>
                 <TableCell align="right">Withholding</TableCell>
                 <TableCell align="right">Net Pay</TableCell>
                 <TableCell align="center">Actions</TableCell>
@@ -230,6 +231,16 @@ export function PayStubs() {
                   </TableCell>
                   <TableCell align="right">
                     {formatCurrency(stub.grossPay)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(stub.vacationPayAmount)}
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block' }}
+                    >
+                      {formatCurrency(stub.ytdVacationPayAmount)} YTD
+                    </Typography>
                   </TableCell>
                   <TableCell align="right">
                     {formatCurrency(stub.totalWithholding)}

--- a/apps/webApp/src/app/pages/admin/settings/CompensationSettings.tsx
+++ b/apps/webApp/src/app/pages/admin/settings/CompensationSettings.tsx
@@ -13,7 +13,11 @@ import {
   Typography,
 } from '@mui/material';
 import { Save, WorkspacePremium } from '@mui/icons-material';
-import { PayType, UpsertEmployeeCompensationDto } from '@gt-automotive/data';
+import {
+  DEFAULT_VACATION_PAY_RATE,
+  PayType,
+  UpsertEmployeeCompensationDto,
+} from '@gt-automotive/data';
 import { NumberInput } from '../../../components/common';
 import { User, userService } from '../../../requests/user.requests';
 import { timeClockService } from '../../../requests/time-clock.requests';
@@ -34,6 +38,9 @@ export function CompensationSettings() {
   const [payType, setPayType] = useState<PayType>(PayType.HOURLY);
   const [hourlyRate, setHourlyRate] = useState('');
   const [annualSalary, setAnnualSalary] = useState('');
+  // Blank means the statutory minimum applies — only an entitlement above it
+  // needs recording here.
+  const [vacationPayRate, setVacationPayRate] = useState('');
   // Job title for this employee's pay stubs. Kept with pay because it is set
   // by the same person at the same moment, and it is what a stub prints.
   const [position, setPosition] = useState('');
@@ -80,11 +87,13 @@ export function CompensationSettings() {
           setPosition(compensation.position || '');
           setHourlyRate(compensation.hourlyRate?.toString() || '');
           setAnnualSalary(compensation.annualSalary?.toString() || '');
+          setVacationPayRate(compensation.vacationPayRate?.toString() || '');
         } else {
           setPayType(PayType.HOURLY);
           setPosition('');
           setHourlyRate('');
           setAnnualSalary('');
+          setVacationPayRate('');
         }
       } catch (err: any) {
         setError(err.message || 'Failed to load compensation');
@@ -102,6 +111,10 @@ export function CompensationSettings() {
       hourlyRate: payType === PayType.HOURLY ? Number(hourlyRate) : undefined,
       annualSalary:
         payType === PayType.SALARIED ? Number(annualSalary) : undefined,
+      // Left off entirely when blank, so the pay stub falls back to the
+      // statutory minimum rather than being told the rate is zero.
+      vacationPayRate:
+        vacationPayRate.trim() === '' ? undefined : Number(vacationPayRate),
     };
 
     try {
@@ -232,7 +245,7 @@ export function CompensationSettings() {
                 }}
               />
             </Grid>
-            <Grid size={{ xs: 12, md: 4 }}>
+            <Grid size={{ xs: 12, md: 3 }}>
               <TextField
                 fullWidth
                 label="Position"
@@ -240,6 +253,19 @@ export function CompensationSettings() {
                 onChange={(event) => setPosition(event.target.value)}
                 placeholder="e.g. Tire Technician"
                 helperText="Optional — printed on this employee's pay stubs"
+              />
+            </Grid>
+            <Grid size={{ xs: 12, md: 2 }}>
+              <NumberInput
+                fullWidth
+                allowDecimals
+                min={0}
+                label="Vacation Pay %"
+                value={vacationPayRate}
+                onChange={(v) =>
+                  setVacationPayRate(v === undefined ? '' : String(v))
+                }
+                helperText={`Blank = ${DEFAULT_VACATION_PAY_RATE}% minimum`}
               />
             </Grid>
             <Grid size={{ xs: 12, md: 2 }}>

--- a/apps/webApp/src/app/pages/staff/MyPayStubs.tsx
+++ b/apps/webApp/src/app/pages/staff/MyPayStubs.tsx
@@ -100,6 +100,7 @@ export function MyPayStubs() {
                 <TableCell>Pay Date</TableCell>
                 <TableCell align="right">Hours</TableCell>
                 <TableCell align="right">Gross</TableCell>
+                <TableCell align="right">Vacation</TableCell>
                 <TableCell align="right">Withholding</TableCell>
                 <TableCell align="right">Net Pay</TableCell>
                 <TableCell align="center">Actions</TableCell>
@@ -117,6 +118,18 @@ export function MyPayStubs() {
                   </TableCell>
                   <TableCell align="right">
                     {formatCurrency(stub.grossPay)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {/* Earned this period, with the running bank underneath —
+                        the figure people actually want from this column. */}
+                    {formatCurrency(stub.vacationPayAmount)}
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block' }}
+                    >
+                      {formatCurrency(stub.ytdVacationPayAmount)} YTD
+                    </Typography>
                   </TableCell>
                   <TableCell align="right">
                     {formatCurrency(stub.totalWithholding)}

--- a/libs/data/src/lib/pay-stub.dto.ts
+++ b/libs/data/src/lib/pay-stub.dto.ts
@@ -66,6 +66,40 @@ export class CreatePayStubDto {
   @Type(() => Number)
   regularAmount!: number;
 
+  /**
+   * Vacation pay percentage for this stub. Omit to use the employee's recorded
+   * rate, falling back to the statutory minimum.
+   */
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  vacationPayRate?: number;
+
+  /**
+   * Vacation earned this period. Omit to accrue the rate on `regularAmount`.
+   *
+   * Accepted as an override for the same reason the statutory deductions are:
+   * a stub records what was actually paid and withheld, not what a formula
+   * thinks it should have been.
+   */
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  vacationPayAmount?: number;
+
+  /**
+   * Vacation held back this period. Omit to hold the whole accrual, which is
+   * the normal case — the money is banked rather than paid out this cheque, so
+   * the pair nets to zero. Send a smaller figure to pay some of it out.
+   */
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  vacationPayHeld?: number;
+
   @IsOptional()
   @IsNumber()
   @Min(0)
@@ -134,6 +168,11 @@ export class PayStubDeductionEstimateRequestDto {
   @IsDateString()
   payDate!: string;
 
+  /**
+   * The period's full gross, *including* any vacation accrual. Vacation pay is
+   * insurable and pensionable, so estimating on the earnings alone
+   * under-withholds EI, CPP and tax on every stub that accrues it.
+   */
   @IsNumber()
   @Min(0)
   @Type(() => Number)
@@ -222,7 +261,15 @@ export interface PayStubDto {
 
   regularHours: number;
   regularAmount: number;
+  /** Regular earnings plus the vacation accrual. */
   grossPay: number;
+
+  /** Percentage this stub accrued vacation at, e.g. 4. */
+  vacationPayRate: number;
+  /** Vacation earned this period, included in `grossPay`. */
+  vacationPayAmount: number;
+  /** The same amount held back, included in `totalWithholding`. */
+  vacationPayHeld: number;
 
   eiAmount: number;
   cppAmount: number;
@@ -235,6 +282,9 @@ export interface PayStubDto {
   ytdHours: number;
   ytdRegularAmount: number;
   ytdGrossPay: number;
+  /** Vacation earned so far this year — what the employee has banked. */
+  ytdVacationPayAmount: number;
+  ytdVacationPayHeld: number;
   ytdEiAmount: number;
   ytdCppAmount: number;
   ytdIncomeTaxAmount: number;

--- a/libs/data/src/lib/time-clock.dto.ts
+++ b/libs/data/src/lib/time-clock.dto.ts
@@ -5,6 +5,7 @@ import {
   IsNumber,
   IsOptional,
   IsString,
+  Min,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import {
@@ -49,6 +50,17 @@ export class UpsertEmployeeCompensationDto {
   @IsNumber()
   @Type(() => Number)
   expectedWeeklyHours?: number;
+
+  /**
+   * Vacation pay percentage. Leave unset for the statutory minimum (see
+   * DEFAULT_VACATION_PAY_RATE) — this is only for an entitlement above it,
+   * such as 6% after five years' service.
+   */
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  vacationPayRate?: number;
 
   @IsOptional()
   @IsDateString()
@@ -177,6 +189,8 @@ export interface EmployeeCompensationDto {
   hourlyRate?: number;
   annualSalary?: number;
   expectedWeeklyHours?: number;
+  /** Null/undefined means the statutory minimum applies. */
+  vacationPayRate?: number;
   effectiveFrom: string;
   effectiveTo?: string;
   isActive: boolean;
@@ -309,6 +323,12 @@ export interface PayrollHoursDto {
   hasCompensation: boolean;
   /** Job title from the compensation record, for the pay stub. */
   position?: string;
+  /**
+   * Vacation pay percentage from the compensation record, so the pay stub form
+   * can accrue at this employee's own rate. Undefined means none is recorded
+   * and the statutory minimum applies.
+   */
+  vacationPayRate?: number;
   /** Zero for salaried employees — read `salaryPay` instead. */
   hourlyRate: number;
   /** Annual salary prorated across the period; zero for hourly employees. */

--- a/libs/data/src/lib/utils/index.ts
+++ b/libs/data/src/lib/utils/index.ts
@@ -4,3 +4,4 @@ export * from './decorator-utils';
 export * from './mapped-types';
 export * from './invoice-print-sections';
 export * from './invoice-balance';
+export * from './vacation-pay';

--- a/libs/data/src/lib/utils/vacation-pay.spec.ts
+++ b/libs/data/src/lib/utils/vacation-pay.spec.ts
@@ -1,0 +1,66 @@
+import {
+  calculateVacationPay,
+  DEFAULT_VACATION_PAY_RATE,
+  resolveVacationPayRate,
+} from './vacation-pay';
+
+describe('calculateVacationPay', () => {
+  it('accrues the statutory minimum by default', () => {
+    expect(calculateVacationPay(3072)).toBe(122.88);
+  });
+
+  it('accrues a higher entitlement when one is given', () => {
+    // 6% after five consecutive years of employment.
+    expect(calculateVacationPay(3072, 6)).toBe(184.32);
+  });
+
+  it('rounds to whole cents', () => {
+    // 4% of 1234.56 is 49.3824 — a pay stub cannot print a third of a cent.
+    expect(calculateVacationPay(1234.56)).toBe(49.38);
+  });
+
+  it('accrues nothing on nothing', () => {
+    expect(calculateVacationPay(0)).toBe(0);
+  });
+
+  it('accrues nothing at a zero rate', () => {
+    // Someone paid their vacation another way.
+    expect(calculateVacationPay(3072, 0)).toBe(0);
+  });
+
+  it('never returns a negative accrual', () => {
+    expect(calculateVacationPay(-100)).toBe(0);
+  });
+
+  it('treats unusable input as no accrual rather than NaN', () => {
+    expect(calculateVacationPay(Number.NaN)).toBe(0);
+    expect(calculateVacationPay(3072, Number.NaN)).toBe(0);
+  });
+});
+
+describe('resolveVacationPayRate', () => {
+  it('falls back to the statutory minimum when no rate is recorded', () => {
+    expect(resolveVacationPayRate(null)).toBe(DEFAULT_VACATION_PAY_RATE);
+    expect(resolveVacationPayRate(undefined)).toBe(DEFAULT_VACATION_PAY_RATE);
+  });
+
+  it("uses the employee's own rate when there is one", () => {
+    expect(resolveVacationPayRate(6)).toBe(6);
+  });
+
+  // The rate arrives as a Prisma Decimal on the server and a number in the
+  // browser; both have to land on the same figure.
+  it('accepts a decimal that arrives as a string', () => {
+    expect(resolveVacationPayRate('4.50')).toBe(4.5);
+  });
+
+  it('honours an explicit zero instead of treating it as unset', () => {
+    expect(resolveVacationPayRate(0)).toBe(0);
+  });
+
+  it('falls back rather than producing NaN from unusable input', () => {
+    expect(resolveVacationPayRate('not a rate')).toBe(
+      DEFAULT_VACATION_PAY_RATE
+    );
+  });
+});

--- a/libs/data/src/lib/utils/vacation-pay.ts
+++ b/libs/data/src/lib/utils/vacation-pay.ts
@@ -1,0 +1,54 @@
+/**
+ * Vacation pay accrual.
+ *
+ * Shared by the pay stub form and the server that stores the figure, so the
+ * amount the accountant is shown before saving is the same one that lands on
+ * the stub. Duplicating the arithmetic is how the two quietly drift a cent
+ * apart on a legal wage statement.
+ */
+
+import { roundToCents } from './invoice-balance';
+
+/**
+ * BC's Employment Standards Act minimum: 4% of gross earnings, rising to 6%
+ * after five consecutive years of employment. Employees entitled to more carry
+ * their own rate on their compensation record.
+ */
+export const DEFAULT_VACATION_PAY_RATE = 4;
+
+/**
+ * Vacation earned on a period's earnings.
+ *
+ * The base is the period's regular earnings *before* the vacation line itself —
+ * vacation does not accrue on vacation, and passing gross pay here would
+ * compound it every period.
+ */
+export function calculateVacationPay(
+  baseEarnings: number,
+  ratePercent: number = DEFAULT_VACATION_PAY_RATE
+): number {
+  const base = Number(baseEarnings) || 0;
+  const rate = Number(ratePercent) || 0;
+  if (base <= 0 || rate <= 0) return 0;
+  return roundToCents((base * rate) / 100);
+}
+
+/**
+ * The rate to apply for an employee: their own if one is recorded, otherwise
+ * the statutory minimum.
+ *
+ * `null`/`undefined` means "not set", which is the common case — only an
+ * employee entitled to above the minimum needs a value. An explicit 0 is
+ * honoured, so vacation can be switched off for someone paid it another way.
+ *
+ * Typed loosely because the rate arrives as a Prisma `Decimal` on the server
+ * and a plain number in the browser; both coerce correctly, and anything that
+ * does not falls back to the minimum rather than producing NaN vacation pay.
+ */
+export function resolveVacationPayRate(employeeRate?: unknown): number {
+  if (employeeRate === null || employeeRate === undefined) {
+    return DEFAULT_VACATION_PAY_RATE;
+  }
+  const rate = Number(employeeRate);
+  return Number.isFinite(rate) ? rate : DEFAULT_VACATION_PAY_RATE;
+}

--- a/libs/database/src/lib/prisma/migrations/20260807211039_add_pay_stub_vacation_pay/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260807211039_add_pay_stub_vacation_pay/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "public"."EmployeeCompensation" ADD COLUMN     "vacationPayRate" DECIMAL(5,2);
+
+-- AlterTable
+ALTER TABLE "public"."PayStub" ADD COLUMN     "vacationPayAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+ADD COLUMN     "vacationPayHeld" DECIMAL(10,2) NOT NULL DEFAULT 0,
+ADD COLUMN     "vacationPayRate" DECIMAL(5,2) NOT NULL DEFAULT 0,
+ADD COLUMN     "ytdVacationPayAmount" DECIMAL(10,2) NOT NULL DEFAULT 0,
+ADD COLUMN     "ytdVacationPayHeld" DECIMAL(10,2) NOT NULL DEFAULT 0;

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -36,10 +36,10 @@ model User {
   tireSales            TireSale[]             @relation("TireSales") // Tire sales made by this user (for commission tracking)
   inspectionsCreated   Inspection[]           @relation("InspectionCreatedBy")
   inspectionsFinalized Inspection[]           @relation("InspectionFinalizedBy")
-  roEmployees          ROEmployee[]           // Repair orders assigned to this employee
+  roEmployees          ROEmployee[] // Repair orders assigned to this employee
   roServices           ROService[]            @relation("ROServiceCompletedBy") // Service items completed by this user
-  roMedia              ROMedia[]              // Photos uploaded by this user
-  payStubs             PayStub[]              // Pay stubs issued to this employee
+  roMedia              ROMedia[] // Photos uploaded by this user
+  payStubs             PayStub[] // Pay stubs issued to this employee
 }
 
 model Role {
@@ -75,29 +75,29 @@ model RolePermission {
 }
 
 model Customer {
-  id              String           @id @default(cuid())
-  firstName       String
-  lastName        String
-  email           String?
-  additionalEmails String[]        @default([]) // Extra emails (e.g. spouse, business) for invoice sending
-  pstExempt       Boolean          @default(false) // When true, invoices for this customer are charged 0% PST
-  pstNumber       String?          // PST exemption / registration number, printed on invoices when pstExempt
-  fleetDiscount   Boolean          @default(false) // When true, a 10% discount on SERVICE items is auto-added to invoices
-  phone           String?
-  address         String?
-  businessName    String?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
-  appointments    Appointment[]
-  invoices        Invoice[]
-  inspections     Inspection[]
-  vehicles        Vehicle[]
-  repairOrders    RepairOrder[]
-  smsMessages     SmsMessage[]
-  smsPreference   SmsPreference?
-  emailLogs       EmailLog[] // Email logs related to this customer
-  bookingRequests BookingRequest[] // Booking requests converted to this customer
-  tireSales       TireSale[] // Tire sales to this customer
+  id               String           @id @default(cuid())
+  firstName        String
+  lastName         String
+  email            String?
+  additionalEmails String[]         @default([]) // Extra emails (e.g. spouse, business) for invoice sending
+  pstExempt        Boolean          @default(false) // When true, invoices for this customer are charged 0% PST
+  pstNumber        String? // PST exemption / registration number, printed on invoices when pstExempt
+  fleetDiscount    Boolean          @default(false) // When true, a 10% discount on SERVICE items is auto-added to invoices
+  phone            String?
+  address          String?
+  businessName     String?
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
+  appointments     Appointment[]
+  invoices         Invoice[]
+  inspections      Inspection[]
+  vehicles         Vehicle[]
+  repairOrders     RepairOrder[]
+  smsMessages      SmsMessage[]
+  smsPreference    SmsPreference?
+  emailLogs        EmailLog[] // Email logs related to this customer
+  bookingRequests  BookingRequest[] // Booking requests converted to this customer
+  tireSales        TireSale[] // Tire sales to this customer
 }
 
 model Vehicle {
@@ -238,29 +238,29 @@ model Company {
 }
 
 model Invoice {
-  id             String          @id @default(cuid())
-  invoiceNumber  String          @unique @default(cuid())
-  customerId     String
-  vehicleId      String?
-  companyId      String
-  appointmentId  String?         @unique // Link back to appointment if auto-generated
-  subtotal       Decimal         @db.Decimal(10, 2)
-  taxRate        Decimal         @db.Decimal(5, 4)
-  taxAmount      Decimal         @db.Decimal(10, 2)
-  total          Decimal         @db.Decimal(10, 2)
-  status         InvoiceStatus
-  paymentMethod  PaymentMethod?
-  amountPaid     Decimal         @default(0) @db.Decimal(10, 2) // Cached sum of InvoicePayment rows
-  notes          String?
-  invoiceDate    DateTime        @default(now())
-  createdBy      String
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  paidAt         DateTime?
-  gstAmount      Decimal?        @db.Decimal(10, 2)
-  gstRate        Decimal?        @db.Decimal(5, 4)
-  pstAmount      Decimal?        @db.Decimal(10, 2)
-  pstRate        Decimal?        @db.Decimal(5, 4)
+  id                     String                @id @default(cuid())
+  invoiceNumber          String                @unique @default(cuid())
+  customerId             String
+  vehicleId              String?
+  companyId              String
+  appointmentId          String?               @unique // Link back to appointment if auto-generated
+  subtotal               Decimal               @db.Decimal(10, 2)
+  taxRate                Decimal               @db.Decimal(5, 4)
+  taxAmount              Decimal               @db.Decimal(10, 2)
+  total                  Decimal               @db.Decimal(10, 2)
+  status                 InvoiceStatus
+  paymentMethod          PaymentMethod?
+  amountPaid             Decimal               @default(0) @db.Decimal(10, 2) // Cached sum of InvoicePayment rows
+  notes                  String?
+  invoiceDate            DateTime              @default(now())
+  createdBy              String
+  createdAt              DateTime              @default(now())
+  updatedAt              DateTime              @updatedAt
+  paidAt                 DateTime?
+  gstAmount              Decimal?              @db.Decimal(10, 2)
+  gstRate                Decimal?              @db.Decimal(5, 4)
+  pstAmount              Decimal?              @db.Decimal(10, 2)
+  pstRate                Decimal?              @db.Decimal(5, 4)
   // Customer signature captured at handover. Always optional — an unsigned
   // invoice prints a blank signature line for a wet signature. The image lives
   // in Azure Blob; that account forbids public blob access, so it is served via
@@ -271,27 +271,27 @@ model Invoice {
   // blob URL (re-signed as a SAS URL on read); in development, where Azure is
   // not configured, it is an inline data URL so the pad still works locally.
   signatureUrl           String?
-  signatureSignedByName  String?   // Printed name, shown under the signature
+  signatureSignedByName  String? // Printed name, shown under the signature
   signatureSignedAt      DateTime?
-  signatureCapturedBy    String?   // User id of the staff member who witnessed it
+  signatureCapturedBy    String? // User id of the staff member who witnessed it
   // Combined-invoice consolidation: a parent invoice rolls up several pending children
-  combinedInvoiceId String?
-  customer       Customer        @relation(fields: [customerId], references: [id])
-  vehicle        Vehicle?        @relation(fields: [vehicleId], references: [id])
-  company        Company         @relation(fields: [companyId], references: [id])
-  appointment    Appointment?    @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
-  items          InvoiceItem[]
-  declinedItems  InvoiceDeclinedItem[] // Work the customer declined; never billed
-  payments       InvoicePayment[] // Payment ledger (supports partial/split payments)
-  inspections    Inspection[]
-  squarePayments SquarePayment[] // Square payments for this invoice
-  emailLogs      EmailLog[] // Email logs related to this invoice
-  tireSale       TireSale?     // Tire sale that generated this invoice (one-to-one)
-  repairOrder    RepairOrder?  @relation(fields: [repairOrderId], references: [id], onDelete: SetNull)
-  repairOrderId  String?       @unique // Link to repair order that generated this invoice
-  carfaxSync     CarfaxSync?   // CARFAX Service Data Transfer record for this invoice
-  combinedInvoice      Invoice?  @relation("CombinedInvoice", fields: [combinedInvoiceId], references: [id], onDelete: SetNull)
-  consolidatedInvoices Invoice[] @relation("CombinedInvoice")
+  combinedInvoiceId      String?
+  customer               Customer              @relation(fields: [customerId], references: [id])
+  vehicle                Vehicle?              @relation(fields: [vehicleId], references: [id])
+  company                Company               @relation(fields: [companyId], references: [id])
+  appointment            Appointment?          @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
+  items                  InvoiceItem[]
+  declinedItems          InvoiceDeclinedItem[] // Work the customer declined; never billed
+  payments               InvoicePayment[] // Payment ledger (supports partial/split payments)
+  inspections            Inspection[]
+  squarePayments         SquarePayment[] // Square payments for this invoice
+  emailLogs              EmailLog[] // Email logs related to this invoice
+  tireSale               TireSale? // Tire sale that generated this invoice (one-to-one)
+  repairOrder            RepairOrder?          @relation(fields: [repairOrderId], references: [id], onDelete: SetNull)
+  repairOrderId          String?               @unique // Link to repair order that generated this invoice
+  carfaxSync             CarfaxSync? // CARFAX Service Data Transfer record for this invoice
+  combinedInvoice        Invoice?              @relation("CombinedInvoice", fields: [combinedInvoiceId], references: [id], onDelete: SetNull)
+  consolidatedInvoices   Invoice[]             @relation("CombinedInvoice")
 
   @@index([customerId])
   @@index([status])
@@ -773,8 +773,8 @@ model Payment {
 }
 
 model EmployeeCompensation {
-  id         String @id @default(cuid())
-  employeeId String
+  id                  String    @id @default(cuid())
+  employeeId          String
   // Job title as it should read on a pay stub ("Tire Technician"), which the
   // permission role (STAFF, ACCOUNTANT) does not capture. Optional: an employee
   // can be paid without one, and the stub simply omits the line.
@@ -783,6 +783,10 @@ model EmployeeCompensation {
   hourlyRate          Decimal?  @db.Decimal(10, 2)
   annualSalary        Decimal?  @db.Decimal(10, 2)
   expectedWeeklyHours Decimal?  @db.Decimal(5, 2)
+  // Vacation pay percentage for this employee. Null means the statutory
+  // minimum (see DEFAULT_VACATION_PAY_RATE) — set it only to record an
+  // entitlement above that, such as 6% after five years' service.
+  vacationPayRate     Decimal?  @db.Decimal(5, 2)
   effectiveFrom       DateTime  @default(now())
   effectiveTo         DateTime?
   isActive            Boolean   @default(true)
@@ -913,14 +917,30 @@ model PayStub {
   companyPhone              String?
   companyEmail              String?
   employeeName              String
-  position       String?
-  payRate        Decimal? @db.Decimal(10, 2)
-  payType        PayType  @default(HOURLY)
+  position                  String?
+  payRate                   Decimal? @db.Decimal(10, 2)
+  payType                   PayType  @default(HOURLY)
 
-  // Current-period earnings.
+  // Current-period earnings. grossPay is regularAmount plus the vacation
+  // accrual below.
   regularHours  Decimal @default(0) @db.Decimal(10, 2)
   regularAmount Decimal @default(0) @db.Decimal(10, 2)
   grossPay      Decimal @default(0) @db.Decimal(10, 2)
+
+  // Vacation pay, accrued at a percentage of the period's regular earnings —
+  // 4% is the BC Employment Standards minimum, 6% after five years' service.
+  //
+  // It appears twice and nets to zero: earned as vacationPayAmount, then held
+  // back as vacationPayHeld because the money is banked rather than paid out
+  // this cheque. The pair is what makes the vacation owing visible on the stub
+  // and in the year-to-date columns without changing what the employee is paid.
+  //
+  // The rate is stored per stub, like payRate and the company details, so
+  // reprinting an old stub reproduces the percentage it was issued under even
+  // after the employee moves to a higher rate.
+  vacationPayRate   Decimal @default(0) @db.Decimal(5, 2)
+  vacationPayAmount Decimal @default(0) @db.Decimal(10, 2)
+  vacationPayHeld   Decimal @default(0) @db.Decimal(10, 2)
 
   // Current-period withholdings. Income tax and "other" default to zero and are
   // omitted from the printed stub when zero — the business's current stubs
@@ -935,15 +955,19 @@ model PayStub {
   netPay               Decimal @default(0) @db.Decimal(10, 2)
 
   // Year-to-date totals through and including this stub.
-  ytdHours           Decimal @default(0) @db.Decimal(10, 2)
-  ytdRegularAmount   Decimal @default(0) @db.Decimal(10, 2)
-  ytdGrossPay        Decimal @default(0) @db.Decimal(10, 2)
-  ytdEiAmount        Decimal @default(0) @db.Decimal(10, 2)
-  ytdCppAmount       Decimal @default(0) @db.Decimal(10, 2)
-  ytdIncomeTaxAmount Decimal @default(0) @db.Decimal(10, 2)
-  ytdOtherDeductions Decimal @default(0) @db.Decimal(10, 2)
-  ytdWithholding     Decimal @default(0) @db.Decimal(10, 2)
-  ytdNetPay          Decimal @default(0) @db.Decimal(10, 2)
+  ytdHours             Decimal @default(0) @db.Decimal(10, 2)
+  ytdRegularAmount     Decimal @default(0) @db.Decimal(10, 2)
+  ytdGrossPay          Decimal @default(0) @db.Decimal(10, 2)
+  // Vacation earned and banked so far this year. ytdVacationPayAmount is what
+  // the business owes the employee in vacation, less anything already paid out.
+  ytdVacationPayAmount Decimal @default(0) @db.Decimal(10, 2)
+  ytdVacationPayHeld   Decimal @default(0) @db.Decimal(10, 2)
+  ytdEiAmount          Decimal @default(0) @db.Decimal(10, 2)
+  ytdCppAmount         Decimal @default(0) @db.Decimal(10, 2)
+  ytdIncomeTaxAmount   Decimal @default(0) @db.Decimal(10, 2)
+  ytdOtherDeductions   Decimal @default(0) @db.Decimal(10, 2)
+  ytdWithholding       Decimal @default(0) @db.Decimal(10, 2)
+  ytdNetPay            Decimal @default(0) @db.Decimal(10, 2)
 
   notes       String?
   generatedBy String
@@ -1665,33 +1689,33 @@ enum CommissionStatus {
 // ============================================
 
 model RepairOrder {
-  id              String      @id @default(cuid())
-  roNumber        String      @unique // e.g. RO-202606-0001
-  appointmentId   String      @unique // 1:1 with Appointment
+  id              String    @id @default(cuid())
+  roNumber        String    @unique // e.g. RO-202606-0001
+  appointmentId   String    @unique // 1:1 with Appointment
   customerId      String
   vehicleId       String?
-  quotationId     String?     @unique // Quotation generated from this RO's quotation-flagged items (1:1)
-  noVehicle       Boolean     @default(false) // Intentionally no vehicle (loose tires, battery, or other counter service)
-  status          ROStatus    @default(OPEN)
-  customerConcern String?     // What the customer reported
-  technicianNotes String?     // Overall technician notes
-  mileageIn       Int?        // Odometer on arrival
-  mileageOut      Int?        // Odometer on departure
-  estimatedCost   Decimal?    @db.Decimal(10, 2)
-  openedAt        DateTime    @default(now())
+  quotationId     String?   @unique // Quotation generated from this RO's quotation-flagged items (1:1)
+  noVehicle       Boolean   @default(false) // Intentionally no vehicle (loose tires, battery, or other counter service)
+  status          ROStatus  @default(OPEN)
+  customerConcern String? // What the customer reported
+  technicianNotes String? // Overall technician notes
+  mileageIn       Int? // Odometer on arrival
+  mileageOut      Int? // Odometer on departure
+  estimatedCost   Decimal?  @db.Decimal(10, 2)
+  openedAt        DateTime  @default(now())
   closedAt        DateTime?
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
-  appointment  Appointment   @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
-  customer     Customer      @relation(fields: [customerId], references: [id])
-  vehicle      Vehicle?      @relation(fields: [vehicleId], references: [id])
-  quotation    Quotation?    @relation(fields: [quotationId], references: [id])
-  employees    ROEmployee[]
-  services     ROService[]
-  inspections  Inspection[]
-  media        ROMedia[]
-  invoice      Invoice?
+  appointment Appointment  @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
+  customer    Customer     @relation(fields: [customerId], references: [id])
+  vehicle     Vehicle?     @relation(fields: [vehicleId], references: [id])
+  quotation   Quotation?   @relation(fields: [quotationId], references: [id])
+  employees   ROEmployee[]
+  services    ROService[]
+  inspections Inspection[]
+  media       ROMedia[]
+  invoice     Invoice?
 
   @@index([customerId])
   @@index([vehicleId])
@@ -1701,11 +1725,11 @@ model RepairOrder {
 }
 
 model ROEmployee {
-  id            String      @id @default(cuid())
+  id            String   @id @default(cuid())
   repairOrderId String
   userId        String
-  role          String?     // "Lead", "Assistant"
-  assignedAt    DateTime    @default(now())
+  role          String? // "Lead", "Assistant"
+  assignedAt    DateTime @default(now())
 
   repairOrder RepairOrder @relation(fields: [repairOrderId], references: [id], onDelete: Cascade)
   user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -1717,26 +1741,26 @@ model ROEmployee {
 }
 
 model ROService {
-  id              String          @id @default(cuid())
-  repairOrderId   String
-  description     String
-  type            ROServiceType   @default(LABOR)
-  quantity        Decimal         @default(1) @db.Decimal(10, 2)
-  unitPrice       Decimal         @default(0) @db.Decimal(10, 2)
-  total           Decimal         @default(0) @db.Decimal(10, 2)
-  technicianNotes String?
-  status          ROServiceStatus @default(PENDING)
+  id               String            @id @default(cuid())
+  repairOrderId    String
+  description      String
+  type             ROServiceType     @default(LABOR)
+  quantity         Decimal           @default(1) @db.Decimal(10, 2)
+  unitPrice        Decimal           @default(0) @db.Decimal(10, 2)
+  total            Decimal           @default(0) @db.Decimal(10, 2)
+  technicianNotes  String?
+  status           ROServiceStatus   @default(PENDING)
   // Customer's approve/decline decision for this line item (independent of work completion)
   customerApproval ROServiceApproval @default(PENDING)
   // When true, this item should be quoted (via a quotation) rather than billed on the RO invoice
-  isQuotation     Boolean         @default(false)
+  isQuotation      Boolean           @default(false)
   // Set when this line is the fee auto-added from a completed inspection, so it
   // can be kept in sync (and not duplicated) with that inspection.
-  inspectionId    String?
-  completedById   String?
-  completedAt     DateTime?
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
+  inspectionId     String?
+  completedById    String?
+  completedAt      DateTime?
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
 
   repairOrder RepairOrder @relation(fields: [repairOrderId], references: [id], onDelete: Cascade)
   completedBy User?       @relation("ROServiceCompletedBy", fields: [completedById], references: [id])
@@ -1819,9 +1843,9 @@ enum ROMediaType {
 // See .claude/docs/carfax-integration.md
 // ============================================================================
 model CarfaxSync {
-  id        String           @id @default(cuid())
-  invoiceId String           @unique
-  invoice   Invoice          @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  id        String  @id @default(cuid())
+  invoiceId String  @unique
+  invoice   Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
 
   // Snapshot of what was/should be reported (anonymous - no customer PII)
   vin         String?
@@ -1835,8 +1859,8 @@ model CarfaxSync {
   lastError  String?
 
   sentAt    DateTime?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@index([status])
   @@index([createdAt])

--- a/server/src/pay-stubs/pay-stubs.service.spec.ts
+++ b/server/src/pay-stubs/pay-stubs.service.spec.ts
@@ -109,8 +109,11 @@ describe('PayStubsService', () => {
     it('derives withholding total and net pay rather than trusting the client', async () => {
       const result = await service.create(baseDto as any, accountant.id);
 
-      expect(result.grossPay).toBe(3072);
-      expect(result.totalWithholding).toBe(217.04);
+      // Gross carries the 4% vacation accrual, and withholding carries the
+      // matching held line, so net comes out exactly where it would have
+      // without either.
+      expect(result.grossPay).toBe(3194.88);
+      expect(result.totalWithholding).toBe(339.92);
       expect(result.netPay).toBe(2854.96);
     });
 
@@ -150,12 +153,14 @@ describe('PayStubsService', () => {
         {
           regularHours: 128,
           regularAmount: 3072,
-          grossPay: 3072,
+          grossPay: 3194.88,
+          vacationPayAmount: 122.88,
+          vacationPayHeld: 122.88,
           eiAmount: 50.08,
           cppAmount: 166.96,
           incomeTaxAmount: 0,
           otherDeductions: 0,
-          totalWithholding: 217.04,
+          totalWithholding: 339.92,
           netPay: 2854.96,
         },
       ]);
@@ -171,10 +176,12 @@ describe('PayStubsService', () => {
       );
 
       expect(result.ytdHours).toBe(256);
-      expect(result.ytdGrossPay).toBe(6144);
+      expect(result.ytdGrossPay).toBe(6389.76);
+      expect(result.ytdVacationPayAmount).toBe(245.76);
+      expect(result.ytdVacationPayHeld).toBe(245.76);
       expect(result.ytdEiAmount).toBe(100.16);
       expect(result.ytdCppAmount).toBe(333.92);
-      expect(result.ytdWithholding).toBe(434.08);
+      expect(result.ytdWithholding).toBe(679.84);
       expect(result.ytdNetPay).toBe(5709.92);
     });
 
@@ -245,7 +252,11 @@ describe('PayStubsService', () => {
         return rows;
       };
 
-      /** $1,000 gross, no deductions, so the running totals are easy to read. */
+      /**
+       * $1,000 gross, no deductions and no vacation accrual, so the running
+       * totals are easy to read. These tests are about the chain, not the
+       * arithmetic within a stub.
+       */
       const stubFor = (payDate: string) => ({
         ...baseDto,
         payDate,
@@ -253,6 +264,7 @@ describe('PayStubsService', () => {
         periodEnd: payDate,
         regularHours: 40,
         regularAmount: 1000,
+        vacationPayRate: 0,
         eiAmount: 0,
         cppAmount: 0,
       });
@@ -753,6 +765,261 @@ describe('PayStubsService', () => {
           newValue: expect.objectContaining({ grossPay: 3500 }),
         })
       );
+    });
+  });
+
+  /**
+   * Vacation pay is accrued and banked rather than paid out: it is added to
+   * gross as an earning and taken straight back out as a deduction, so the
+   * cheque is unchanged while the stub records what the employee has earned and
+   * what the business owes them.
+   */
+  describe('vacation pay', () => {
+    const dataOf = (mock: any) => mock.mock.calls[0][0].data;
+
+    it('accrues 4% of the period earnings and holds it back', async () => {
+      const result = await service.create(baseDto as any, accountant.id);
+
+      expect(result.vacationPayRate).toBe(4);
+      expect(result.vacationPayAmount).toBe(122.88);
+      expect(result.vacationPayHeld).toBe(122.88);
+    });
+
+    it('leaves net pay exactly where it would be without the accrual', async () => {
+      const withVacation = await service.create(baseDto as any, accountant.id);
+      const without = await service.create(
+        { ...baseDto, vacationPayRate: 0 } as any,
+        accountant.id
+      );
+
+      expect(withVacation.netPay).toBe(without.netPay);
+    });
+
+    it('accrues on the earnings, not on the gross it produces', async () => {
+      // 4% of 3072, never 4% of 3194.88 — vacation does not compound on
+      // vacation, which it would if the base were taken after the accrual.
+      const result = await service.create(baseDto as any, accountant.id);
+
+      expect(result.vacationPayAmount).toBe(3072 * 0.04);
+    });
+
+    it("uses the employee's own rate when one is recorded", async () => {
+      // 6% after five years of service.
+      prisma.employeeCompensation.findFirst.mockResolvedValue({
+        payType: 'HOURLY',
+        hourlyRate: 24,
+        vacationPayRate: 6,
+      });
+
+      const result = await service.create(baseDto as any, accountant.id);
+
+      expect(result.vacationPayRate).toBe(6);
+      expect(result.vacationPayAmount).toBe(184.32);
+    });
+
+    it('falls back to the statutory minimum when no rate is recorded', async () => {
+      prisma.employeeCompensation.findFirst.mockResolvedValue({
+        payType: 'HOURLY',
+        hourlyRate: 24,
+        vacationPayRate: null,
+      });
+
+      const result = await service.create(baseDto as any, accountant.id);
+
+      expect(result.vacationPayRate).toBe(4);
+    });
+
+    it('honours a rate of zero rather than treating it as unset', async () => {
+      // Someone paid their vacation another way still gets a stub that says so.
+      prisma.employeeCompensation.findFirst.mockResolvedValue({
+        payType: 'HOURLY',
+        hourlyRate: 24,
+        vacationPayRate: 0,
+      });
+
+      const result = await service.create(baseDto as any, accountant.id);
+
+      expect(result.vacationPayAmount).toBe(0);
+      expect(result.grossPay).toBe(3072);
+    });
+
+    it('stores an amount the accountant typed over', async () => {
+      const result = await service.create(
+        { ...baseDto, vacationPayAmount: 150 } as any,
+        accountant.id
+      );
+
+      expect(result.vacationPayAmount).toBe(150);
+      expect(result.vacationPayHeld).toBe(150);
+      expect(result.grossPay).toBe(3222);
+    });
+
+    it('refuses to hold back more vacation than was earned', async () => {
+      // A typo of 1228.80 for 122.88 clears the net-pay check, short-pays the
+      // employee by a thousand dollars and inflates the vacation owed to them.
+      await expect(
+        service.create(
+          { ...baseDto, vacationPayHeld: 1228.8 } as any,
+          accountant.id
+        )
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(prisma.payStub.create).not.toHaveBeenCalled();
+    });
+
+    it('pays some of the accrual out when less is held than earned', async () => {
+      const result = await service.create(
+        { ...baseDto, vacationPayHeld: 22.88 } as any,
+        accountant.id
+      );
+
+      // $100 of the accrual reaches the employee, so net is $100 higher.
+      expect(result.vacationPayAmount).toBe(122.88);
+      expect(result.vacationPayHeld).toBe(22.88);
+      expect(result.netPay).toBe(2954.96);
+    });
+
+    it('freezes the rate on the stub, so a later change cannot rewrite it', async () => {
+      await service.create(baseDto as any, accountant.id);
+
+      expect(dataOf(prisma.payStub.create).vacationPayRate).toBe(4);
+    });
+
+    describe('amendments', () => {
+      const storedStub = (overrides: any = {}) => ({
+        id: 'stub-1',
+        employeeId: 'emp-1',
+        periodStart: new Date(Date.UTC(2026, 0, 5)),
+        periodEnd: new Date(Date.UTC(2026, 0, 31)),
+        payDate: new Date(Date.UTC(2026, 0, 31)),
+        createdAt: new Date(Date.UTC(2026, 0, 31)),
+        companyName: 'GT Automotive',
+        employeeName: 'Rohit Toora',
+        payType: 'HOURLY',
+        regularHours: 128,
+        regularAmount: 3072,
+        grossPay: 3194.88,
+        vacationPayRate: 4,
+        vacationPayAmount: 122.88,
+        vacationPayHeld: 122.88,
+        eiAmount: 50.08,
+        cppAmount: 166.96,
+        incomeTaxAmount: 0,
+        otherDeductions: 0,
+        totalWithholding: 339.92,
+        netPay: 2854.96,
+        employee,
+        ...overrides,
+      });
+
+      beforeEach(() => {
+        prisma.payStub.findUnique.mockResolvedValue(storedStub());
+        prisma.payStub.findMany.mockResolvedValue([]);
+        prisma.payStub.update = jest.fn(({ where, data }: any) => ({
+          ...storedStub(),
+          id: where.id,
+          ...data,
+        }));
+      });
+
+      it('re-accrues when the earnings are corrected', async () => {
+        await service.update(
+          'stub-1',
+          { regularAmount: 4000 } as any,
+          accountant.id
+        );
+
+        // Leaving the old $122.88 would quietly break the 4% the stub still
+        // claims to apply.
+        const { data } = prisma.payStub.update.mock.calls[0][0];
+        expect(data.vacationPayAmount).toBe(160);
+        expect(data.vacationPayHeld).toBe(160);
+        expect(data.grossPay).toBe(4160);
+      });
+
+      it('re-accrues when the rate is corrected', async () => {
+        await service.update(
+          'stub-1',
+          { vacationPayRate: 6 } as any,
+          accountant.id
+        );
+
+        const { data } = prisma.payStub.update.mock.calls[0][0];
+        expect(data.vacationPayAmount).toBe(184.32);
+      });
+
+      it('refuses an amendment that holds back more than was earned', async () => {
+        await expect(
+          service.update(
+            'stub-1',
+            { vacationPayHeld: 500 } as any,
+            accountant.id
+          )
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(prisma.payStub.update).not.toHaveBeenCalled();
+      });
+
+      it('leaves the accrual alone when neither changed', async () => {
+        await service.update('stub-1', { eiAmount: 60 } as any, accountant.id);
+
+        const { data } = prisma.payStub.update.mock.calls[0][0];
+        expect(data.vacationPayAmount).toBe(122.88);
+      });
+
+      it('keeps a deliberate part-payout when the earnings change', async () => {
+        prisma.payStub.findUnique.mockResolvedValue(
+          storedStub({ vacationPayHeld: 22.88 })
+        );
+
+        await service.update(
+          'stub-1',
+          { regularAmount: 4000 } as any,
+          accountant.id
+        );
+
+        // The accrual follows the new earnings; the amount actually paid out
+        // was a decision, not a formula, so it stands until someone changes it.
+        const { data } = prisma.payStub.update.mock.calls[0][0];
+        expect(data.vacationPayAmount).toBe(160);
+        expect(data.vacationPayHeld).toBe(22.88);
+      });
+
+      it('carries the correction into the year-to-date chain', async () => {
+        prisma.payStub.findMany.mockResolvedValue([
+          storedStub({ vacationPayAmount: 160, vacationPayHeld: 160 }),
+          storedStub({
+            id: 'stub-2',
+            payDate: new Date(Date.UTC(2026, 1, 28)),
+            createdAt: new Date(Date.UTC(2026, 1, 28)),
+          }),
+        ]);
+
+        await service.update(
+          'stub-1',
+          { regularAmount: 4000 } as any,
+          accountant.id
+        );
+
+        const ytdWrites = prisma.payStub.update.mock.calls
+          .map(([args]: any) => args)
+          .filter((args: any) => args.data.ytdVacationPayAmount !== undefined);
+
+        expect(ytdWrites).toHaveLength(2);
+        expect(ytdWrites[0].data.ytdVacationPayAmount).toBe(160);
+        expect(ytdWrites[1].data.ytdVacationPayAmount).toBe(282.88);
+      });
+    });
+
+    it('leaves stubs raised before vacation was tracked showing nothing', async () => {
+      // The columns default to zero on existing rows, and zero prints no lines.
+      const legacy = await service.create(
+        { ...baseDto, vacationPayRate: 0 } as any,
+        accountant.id
+      );
+
+      expect(legacy.vacationPayAmount).toBe(0);
+      expect(legacy.ytdVacationPayAmount).toBe(0);
+      expect(legacy.grossPay).toBe(3072);
+      expect(legacy.netPay).toBe(2854.96);
     });
   });
 });

--- a/server/src/pay-stubs/pay-stubs.service.ts
+++ b/server/src/pay-stubs/pay-stubs.service.ts
@@ -6,11 +6,13 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '@gt-automotive/database';
 import {
+  calculateVacationPay,
   CreatePayStubDto,
   PayStubDeductionEstimateDto,
   PayStubDeductionEstimateRequestDto,
   PayStubDto,
   PayType,
+  resolveVacationPayRate,
   UpdatePayStubDto,
 } from '@gt-automotive/data';
 import {
@@ -95,13 +97,38 @@ export class PayStubsService {
     // arithmetic on the printed stub is always internally consistent.
     const regularHours = round2(dto.regularHours);
     const regularAmount = round2(dto.regularAmount);
-    const grossPay = regularAmount;
+
+    // Vacation accrues on the period's regular earnings, then is held back
+    // again, so the pair nets to zero on the cheque while recording what the
+    // employee has banked. The rate is the employee's own, or the statutory
+    // minimum; the accountant can override either figure.
+    const vacationPayRate = round2(
+      dto.vacationPayRate ??
+        resolveVacationPayRate(compensation?.vacationPayRate)
+    );
+    const vacationPayAmount = round2(
+      dto.vacationPayAmount ??
+        calculateVacationPay(regularAmount, vacationPayRate)
+    );
+    const vacationPayHeld = round2(dto.vacationPayHeld ?? vacationPayAmount);
+
+    // Holding back more vacation than the period earned is not a split, it is a
+    // typo — 1228.80 for 122.88 passes the net-pay check, short-pays the
+    // employee by a thousand dollars and inflates the vacation the business
+    // appears to owe them.
+    if (vacationPayHeld > vacationPayAmount) {
+      throw new BadRequestException(
+        'Vacation pay held cannot exceed the vacation pay earned this period'
+      );
+    }
+
+    const grossPay = round2(regularAmount + vacationPayAmount);
     const eiAmount = round2(dto.eiAmount ?? 0);
     const cppAmount = round2(dto.cppAmount ?? 0);
     const incomeTaxAmount = round2(dto.incomeTaxAmount ?? 0);
     const otherDeductions = round2(dto.otherDeductions ?? 0);
     const totalWithholding = round2(
-      eiAmount + cppAmount + incomeTaxAmount + otherDeductions
+      eiAmount + cppAmount + incomeTaxAmount + otherDeductions + vacationPayHeld
     );
     const netPay = round2(grossPay - totalWithholding);
 
@@ -143,6 +170,9 @@ export class PayStubsService {
         regularHours,
         regularAmount,
         grossPay,
+        vacationPayRate,
+        vacationPayAmount,
+        vacationPayHeld,
         eiAmount,
         cppAmount,
         incomeTaxAmount,
@@ -153,6 +183,12 @@ export class PayStubsService {
         ytdHours: round2(priorTotals.hours + regularHours),
         ytdRegularAmount: round2(priorTotals.regularAmount + regularAmount),
         ytdGrossPay: round2(priorTotals.grossPay + grossPay),
+        ytdVacationPayAmount: round2(
+          priorTotals.vacationPayAmount + vacationPayAmount
+        ),
+        ytdVacationPayHeld: round2(
+          priorTotals.vacationPayHeld + vacationPayHeld
+        ),
         ytdEiAmount: round2(priorTotals.eiAmount + eiAmount),
         ytdCppAmount: round2(priorTotals.cppAmount + cppAmount),
         ytdIncomeTaxAmount: round2(
@@ -334,13 +370,42 @@ export class PayStubsService {
 
     const regularHours = pick(dto.regularHours, existing.regularHours);
     const regularAmount = pick(dto.regularAmount, existing.regularAmount);
-    const grossPay = regularAmount;
+
+    const vacationPayRate = pick(dto.vacationPayRate, existing.vacationPayRate);
+    // Correcting the earnings re-accrues vacation on them. Leaving the old
+    // figure would quietly break the 4% the stub still claims to apply, so an
+    // accountant who means to keep it has to say so with an explicit amount.
+    const vacationPayAmount =
+      dto.vacationPayAmount !== undefined
+        ? round2(dto.vacationPayAmount)
+        : dto.regularAmount !== undefined || dto.vacationPayRate !== undefined
+        ? calculateVacationPay(regularAmount, vacationPayRate)
+        : round2(num(existing.vacationPayAmount));
+    const vacationPayHeld =
+      dto.vacationPayHeld !== undefined
+        ? round2(dto.vacationPayHeld)
+        : // The held line tracks the accrual unless it was deliberately split.
+        num(existing.vacationPayHeld) === num(existing.vacationPayAmount)
+        ? vacationPayAmount
+        : round2(num(existing.vacationPayHeld));
+
+    // Holding back more vacation than the period earned is not a split, it is a
+    // typo — 1228.80 for 122.88 passes the net-pay check, short-pays the
+    // employee by a thousand dollars and inflates the vacation the business
+    // appears to owe them.
+    if (vacationPayHeld > vacationPayAmount) {
+      throw new BadRequestException(
+        'Vacation pay held cannot exceed the vacation pay earned this period'
+      );
+    }
+
+    const grossPay = round2(regularAmount + vacationPayAmount);
     const eiAmount = pick(dto.eiAmount, existing.eiAmount);
     const cppAmount = pick(dto.cppAmount, existing.cppAmount);
     const incomeTaxAmount = pick(dto.incomeTaxAmount, existing.incomeTaxAmount);
     const otherDeductions = pick(dto.otherDeductions, existing.otherDeductions);
     const totalWithholding = round2(
-      eiAmount + cppAmount + incomeTaxAmount + otherDeductions
+      eiAmount + cppAmount + incomeTaxAmount + otherDeductions + vacationPayHeld
     );
     const netPay = round2(grossPay - totalWithholding);
 
@@ -361,6 +426,9 @@ export class PayStubsService {
         regularHours,
         regularAmount,
         grossPay,
+        vacationPayRate,
+        vacationPayAmount,
+        vacationPayHeld,
         eiAmount,
         cppAmount,
         incomeTaxAmount,
@@ -440,6 +508,8 @@ export class PayStubsService {
       hours: 0,
       regularAmount: 0,
       grossPay: 0,
+      vacationPayAmount: 0,
+      vacationPayHeld: 0,
       eiAmount: 0,
       cppAmount: 0,
       incomeTaxAmount: 0,
@@ -452,6 +522,8 @@ export class PayStubsService {
       running.hours += num(stub.regularHours);
       running.regularAmount += num(stub.regularAmount);
       running.grossPay += num(stub.grossPay);
+      running.vacationPayAmount += num(stub.vacationPayAmount);
+      running.vacationPayHeld += num(stub.vacationPayHeld);
       running.eiAmount += num(stub.eiAmount);
       running.cppAmount += num(stub.cppAmount);
       running.incomeTaxAmount += num(stub.incomeTaxAmount);
@@ -465,6 +537,8 @@ export class PayStubsService {
           ytdHours: round2(running.hours),
           ytdRegularAmount: round2(running.regularAmount),
           ytdGrossPay: round2(running.grossPay),
+          ytdVacationPayAmount: round2(running.vacationPayAmount),
+          ytdVacationPayHeld: round2(running.vacationPayHeld),
           ytdEiAmount: round2(running.eiAmount),
           ytdCppAmount: round2(running.cppAmount),
           ytdIncomeTaxAmount: round2(running.incomeTaxAmount),
@@ -701,6 +775,8 @@ export class PayStubsService {
         hours: acc.hours + num(stub.regularHours),
         regularAmount: acc.regularAmount + num(stub.regularAmount),
         grossPay: acc.grossPay + num(stub.grossPay),
+        vacationPayAmount: acc.vacationPayAmount + num(stub.vacationPayAmount),
+        vacationPayHeld: acc.vacationPayHeld + num(stub.vacationPayHeld),
         eiAmount: acc.eiAmount + num(stub.eiAmount),
         cppAmount: acc.cppAmount + num(stub.cppAmount),
         incomeTaxAmount: acc.incomeTaxAmount + num(stub.incomeTaxAmount),
@@ -712,6 +788,8 @@ export class PayStubsService {
         hours: 0,
         regularAmount: 0,
         grossPay: 0,
+        vacationPayAmount: 0,
+        vacationPayHeld: 0,
         eiAmount: 0,
         cppAmount: 0,
         incomeTaxAmount: 0,
@@ -750,6 +828,9 @@ export class PayStubsService {
       regularHours: num(stub.regularHours),
       regularAmount: num(stub.regularAmount),
       grossPay: num(stub.grossPay),
+      vacationPayRate: num(stub.vacationPayRate),
+      vacationPayAmount: num(stub.vacationPayAmount),
+      vacationPayHeld: num(stub.vacationPayHeld),
       eiAmount: num(stub.eiAmount),
       cppAmount: num(stub.cppAmount),
       incomeTaxAmount: num(stub.incomeTaxAmount),
@@ -760,6 +841,8 @@ export class PayStubsService {
       ytdHours: num(stub.ytdHours),
       ytdRegularAmount: num(stub.ytdRegularAmount),
       ytdGrossPay: num(stub.ytdGrossPay),
+      ytdVacationPayAmount: num(stub.ytdVacationPayAmount),
+      ytdVacationPayHeld: num(stub.ytdVacationPayHeld),
       ytdEiAmount: num(stub.ytdEiAmount),
       ytdCppAmount: num(stub.ytdCppAmount),
       ytdIncomeTaxAmount: num(stub.ytdIncomeTaxAmount),

--- a/server/src/pdf/pay-stub-template.spec.ts
+++ b/server/src/pdf/pay-stub-template.spec.ts
@@ -216,4 +216,76 @@ describe('PdfService pay stub template', () => {
 
     expect(html).toContain('January 1, 2026');
   });
+
+  /**
+   * Vacation pay prints twice — earned in the earnings column, held back in the
+   * deductions column — so the employee can see what they banked without the
+   * cheque changing.
+   */
+  describe('vacation pay', () => {
+    const withVacation: any = {
+      ...januaryStub,
+      grossPay: 3194.88,
+      vacationPayRate: 4,
+      vacationPayAmount: 122.88,
+      vacationPayHeld: 122.88,
+      totalWithholding: 339.92,
+      ytdGrossPay: 3194.88,
+      ytdVacationPayAmount: 122.88,
+      ytdVacationPayHeld: 122.88,
+      ytdWithholding: 339.92,
+    };
+
+    it('shows what was earned, at the rate it was earned at', () => {
+      const html = service.generatePayStubHtml(withVacation);
+
+      expect(html).toContain('Vacation Pay (4%)');
+      expect(html).toContain('122.88');
+    });
+
+    it('shows the matching amount held back, named so it does not read as lost', () => {
+      const html = service.generatePayStubHtml(withVacation);
+
+      // s.27(g) requires the purpose of every deduction. This one is the
+      // employee's own money, banked until they take their vacation.
+      expect(html).toContain('Vacation Pay Held');
+    });
+
+    it('carries the year-to-date vacation figure', () => {
+      const html = service.generatePayStubHtml({
+        ...withVacation,
+        ytdVacationPayAmount: 491.52,
+        ytdVacationPayHeld: 491.52,
+      });
+
+      expect(html).toContain('491.52');
+    });
+
+    it('prints a fractional rate without trailing zeros', () => {
+      const html = service.generatePayStubHtml({
+        ...withVacation,
+        vacationPayRate: 4.5,
+      });
+
+      expect(html).toContain('Vacation Pay (4.5%)');
+    });
+
+    it('omits both lines on a stub that accrued nothing', () => {
+      // Stubs raised before vacation was tracked carry zeros, and must print
+      // exactly as they always did rather than gaining two empty rows.
+      const html = service.generatePayStubHtml(januaryStub);
+
+      expect(html).not.toContain('Vacation Pay');
+      expect(html).not.toContain('Vacation Pay Held');
+    });
+
+    it('leaves net pay out of the accrual, since it nets to zero', () => {
+      const html = service.generatePayStubHtml(withVacation);
+
+      // Gross rose and deductions rose by the same amount; take-home did not
+      // move.
+      expect(html).toContain('3,194.88');
+      expect(html).toContain('2,854.96');
+    });
+  });
 });

--- a/server/src/pdf/pdf.service.ts
+++ b/server/src/pdf/pdf.service.ts
@@ -1379,6 +1379,16 @@ ${
         always: false,
       },
       {
+        // Not a deduction the employee loses — it is their vacation pay, held
+        // back until they take it. Named so the stub does not read as money
+        // gone.
+        label: 'Vacation Pay Held',
+        current: stub.vacationPayHeld,
+        ytd: stub.ytdVacationPayHeld,
+        colour: '#4a7c59',
+        always: false,
+      },
+      {
         label: stub.otherDeductionsLabel || 'Other Deductions',
         current: stub.otherDeductions,
         ytd: stub.ytdOtherDeductions,
@@ -1386,6 +1396,30 @@ ${
         always: false,
       },
     ].filter((row) => row.always || row.current > 0 || row.ytd > 0);
+
+    /**
+     * Vacation earned this period, shown with the rate that produced it so the
+     * employee can check the percentage as well as the amount.
+     *
+     * Omitted entirely when there is nothing to show, so stubs raised before
+     * vacation was tracked print exactly as they always did.
+     */
+    const vacationEarningRow =
+      stub.vacationPayAmount > 0 || stub.ytdVacationPayAmount > 0
+        ? `
+          <tr>
+            <td>Vacation Pay${
+              stub.vacationPayRate > 0
+                ? // Number() rather than toFixed(), so 4 prints as "4%" and 4.5
+                  // as "4.5%" instead of a padded "4.00%".
+                  ` (${escapeHtml(String(Number(stub.vacationPayRate)))}%)`
+                : ''
+            }</td>
+            <td class="num"></td>
+            <td class="num">${money(stub.vacationPayAmount)}</td>
+            <td class="num muted">${money(stub.ytdVacationPayAmount)}</td>
+          </tr>`
+        : '';
 
     const deductionRows = deductions
       .map(
@@ -1807,6 +1841,7 @@ ${
             <td class="num">${money(stub.regularAmount)}</td>
             <td class="num muted">${money(stub.ytdRegularAmount)}</td>
           </tr>
+          ${vacationEarningRow}
           <tr class="total-row">
             <td>Gross Pay</td>
             <td class="num">${hours(stub.regularHours)}</td>

--- a/server/src/time-clock/time-clock.service.ts
+++ b/server/src/time-clock/time-clock.service.ts
@@ -91,6 +91,9 @@ export class TimeClockService {
           hourlyRate: dto.hourlyRate,
           annualSalary: dto.annualSalary,
           expectedWeeklyHours: dto.expectedWeeklyHours,
+          // Null rather than a default, so the stub can tell "not set" (use the
+          // statutory minimum) from a deliberate rate.
+          vacationPayRate: dto.vacationPayRate ?? null,
           effectiveFrom,
           createdBy: userId,
         },
@@ -682,6 +685,12 @@ export class TimeClockService {
       // Carried so the pay stub form can pre-fill the job title without a
       // second round trip for the compensation record.
       position: compensation?.position || undefined,
+      // Same reason as position: without it the stub form has no way to know
+      // this employee accrues at 6% and would quietly apply the minimum.
+      vacationPayRate:
+        compensation?.vacationPayRate == null
+          ? undefined
+          : Number(compensation.vacationPayRate),
       hourlyRate,
       salaryPay,
       grossPay,
@@ -1193,6 +1202,10 @@ export class TimeClockService {
         compensation.expectedWeeklyHours === null
           ? undefined
           : Number(compensation.expectedWeeklyHours),
+      vacationPayRate:
+        compensation.vacationPayRate == null
+          ? undefined
+          : Number(compensation.vacationPayRate),
       effectiveFrom: compensation.effectiveFrom.toISOString(),
       effectiveTo: compensation.effectiveTo?.toISOString(),
       isActive: compensation.isActive,


### PR DESCRIPTION
Closes [GA-62](https://gt-automotives.atlassian.net/browse/GA-62).

## Problem

BC employment standards require vacation pay of at least 4% of gross earnings, and the pay stub had nowhere to record it. The only way to note it was to abuse the free-text "other deduction" line, which loses the year-to-date figure and mixes vacation in with unrelated withholdings.

## What this does

Vacation is **accrued and banked**: earned as a line in the earnings column, held straight back in the deductions column. The pair nets to zero, so the cheque is unchanged, while the stub records what the employee banked this period and this year.

The rate is the employee's own if their compensation record carries one (6% after five years), otherwise the statutory minimum. It is frozen onto the stub alongside `payRate` and the company details, so reprinting an old stub reproduces the percentage it was issued under.

## Two things the accrual must not get wrong

**It accrues on the period's regular earnings, never on the gross it produces.** Taking the base after the accrual would compound vacation on vacation every period.

**The CRA estimate runs on gross including the accrual.** Vacation pay is insurable and pensionable, so deducting on the earnings alone would under-withhold EI, CPP and income tax on every stub that accrues it. **Confirmed with the business:** tax is withheld when vacation is *earned*, not when it is paid out.

## Amendments

Correcting the earnings or the rate re-accrues, since leaving the old figure would quietly break the percentage the stub still claims to apply. A deliberate part-payout stands until someone changes it. The vacation columns join the existing year-to-date rewrite, so correcting an earlier stub carries through the whole chain.

## Review findings fixed in this branch

`/review` caught four, all fixed:

1. **The per-employee rate never reached the form.** The dialog hardcoded the statutory minimum and always sent it, so a 6% employee still accrued 4% and the server's fallback was dead for the UI path. `PayrollHoursDto` now carries the rate from the compensation record, the same way it already carries the job title.
2. **Amending left the held line stale.** Both vacation fields were forced "overridden" on an amendment but only "Earned" had a restore control, so re-deriving the accrual silently paid out the difference. Restoring one now restores both, and "Held" has its own control.
3. **Editing the rate did not clear the amount override**, so a stub could store 6% against a 4% figure and print "Vacation Pay (6%) $122.88" beside $3,072 of earnings. Changing the rate now re-derives the amount.
4. **Nothing stopped holding back more than was earned.** A typo of 1228.80 for 122.88 cleared the only guard (`netPay < 0`), short-paid the employee by a thousand dollars and inflated the vacation owed to them. Now rejected server-side and blocked in the form.

## Migration

`20260807211039_add_pay_stub_vacation_pay` — additive, all columns defaulted, created with `prisma migrate dev`. Existing stubs get zeros and print exactly as they did: both lines are omitted when zero.

## Verification

- `tsc --noEmit` clean on `server` and `apps/webApp`
- 445 server tests pass, ~30 new across the service, the PDF template and the shared calculation
- 155 webApp tests, 187 data-lib tests pass
- Migration status clean against the local database

## Follow-up

[GA-64](https://gt-automotives.atlassian.net/browse/GA-64) covers paying banked vacation out — drawing the bank down, a true remaining balance that carries across the year boundary, and ROE reporting. Without it `ytdVacationPayAmount` only ever grows, which is fine while nothing is being paid out but drifts from the truth once it is. Raised deliberately as separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)