### PR TITLE
feat(time-clock): shop-hours window with automatic closing-time clock-out (GA-63)

### DIFF
--- a/apps/webApp/src/app/components/time-clock/TimeEntriesTable.tsx
+++ b/apps/webApp/src/app/components/time-clock/TimeEntriesTable.tsx
@@ -18,9 +18,17 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from '@mui/material';
-import { CheckCircle, Delete, Edit, MoreVert, Undo } from '@mui/icons-material';
+import {
+  CheckCircle,
+  Delete,
+  Edit,
+  MoreVert,
+  TimerOff as AutoCloseIcon,
+  Undo,
+} from '@mui/icons-material';
 import { format } from 'date-fns';
 import { TimeEntryDto, TimeEntryStatus } from '@gt-automotive/data';
 import { colors } from '../../theme/colors';
@@ -74,6 +82,28 @@ export interface TimeEntryActions {
   onApprove: (entry: TimeEntryDto) => void;
   onUnapprove: (entry: TimeEntryDto) => void;
   onDelete: (entry: TimeEntryDto) => void;
+}
+
+/**
+ * Marks a shift the closing-time job ended because nobody clocked out.
+ *
+ * A badge rather than a note buried in the reason text: the clock-out time on
+ * these is a guess about when the employee actually left, and it has to be
+ * obvious at a glance which rows need checking before payroll runs.
+ */
+function AutoClockedOutChip({ entry }: { entry: TimeEntryDto }) {
+  if (!entry.autoClockedOut) return null;
+  return (
+    <Tooltip title={entry.adjustmentReason || 'Automatically clocked out'}>
+      <Chip
+        size="small"
+        variant="outlined"
+        color="warning"
+        icon={<AutoCloseIcon />}
+        label="Auto clock-out"
+      />
+    </Tooltip>
+  );
 }
 
 interface TimeEntriesTableProps {
@@ -160,12 +190,22 @@ export function TimeEntriesTable({
                     {format(new Date(entry.clockInAt), 'MMM d, yyyy')}
                   </Typography>
                 </Box>
-                <Chip
-                  size="small"
-                  variant="outlined"
-                  color={getStatusColor(entry.status)}
-                  label={formatStatus(entry.status)}
-                />
+                <Box
+                  sx={{
+                    display: 'flex',
+                    gap: 0.5,
+                    flexWrap: 'wrap',
+                    justifyContent: 'flex-end',
+                  }}
+                >
+                  <AutoClockedOutChip entry={entry} />
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    color={getStatusColor(entry.status)}
+                    label={formatStatus(entry.status)}
+                  />
+                </Box>
               </Box>
 
               <Grid container spacing={1.5} sx={{ mb: actions ? 1.5 : 0 }}>
@@ -297,12 +337,15 @@ export function TimeEntriesTable({
                   {formatBreak(entry.unpaidBreakMinutes)}
                 </TableCell>
                 <TableCell>
-                  <Chip
-                    size="small"
-                    variant="outlined"
-                    color={getStatusColor(entry.status)}
-                    label={formatStatus(entry.status)}
-                  />
+                  <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                    <Chip
+                      size="small"
+                      variant="outlined"
+                      color={getStatusColor(entry.status)}
+                      label={formatStatus(entry.status)}
+                    />
+                    <AutoClockedOutChip entry={entry} />
+                  </Box>
                 </TableCell>
                 <TableCell align="right">
                   <Chip

--- a/apps/webApp/src/app/pages/admin/settings/GeneralSettings.tsx
+++ b/apps/webApp/src/app/pages/admin/settings/GeneralSettings.tsx
@@ -7,7 +7,9 @@ import {
   CardContent,
   CircularProgress,
   Divider,
+  FormControlLabel,
   Stack,
+  Switch,
   TextField,
   Typography,
 } from '@mui/material';
@@ -15,6 +17,7 @@ import {
   Edit as EditIcon,
   Gavel as GavelIcon,
   Save as SaveIcon,
+  Schedule as ScheduleIcon,
 } from '@mui/icons-material';
 import { companyService, Company } from '../../../requests/company.requests';
 import { colors } from '../../../theme/colors';
@@ -22,7 +25,7 @@ import { colors } from '../../../theme/colors';
 /**
  * The General tab of system settings.
  *
- * Holds the invoice terms & conditions. Those are a liability statement owned
+ * Holds the time clock's shop-hours window and the invoice terms & conditions. Those are a liability statement owned
  * by the business, so they live on the Company record and are edited here
  * rather than being baked into the invoice templates — the wording can change
  * without a deploy.
@@ -114,6 +117,17 @@ export function GeneralSettings() {
 
   return (
     <Box sx={{ p: { xs: 2, sm: 3 } }}>
+      <TimeClockHoursCard
+        company={companies.find((company) => company.isDefault)}
+        onSaved={(updated) =>
+          setCompanies((prev) =>
+            prev.map((company) =>
+              company.id === updated.id ? updated : company
+            )
+          )
+        }
+      />
+
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
         <GavelIcon color="primary" fontSize="small" />
         <Typography variant="h6">Invoice Terms &amp; Conditions</Typography>
@@ -250,3 +264,141 @@ export function GeneralSettings() {
 }
 
 export default GeneralSettings;
+
+/**
+ * The window the employee time clock is open for.
+ *
+ * Held as a setting rather than in code because the shop's hours change
+ * seasonally, and because switching the window off has to be possible without a
+ * deploy if it ever gets in the way of real work.
+ */
+function TimeClockHoursCard({
+  company,
+  onSaved,
+}: {
+  company?: Company;
+  onSaved: (company: Company) => void;
+}) {
+  const [enabled, setEnabled] = useState(true);
+  const [opensAt, setOpensAt] = useState('08:00');
+  const [closesAt, setClosesAt] = useState('20:00');
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!company) return;
+    setEnabled(company.timeClockWindowEnabled ?? true);
+    setOpensAt(company.timeClockOpensAt ?? '08:00');
+    setClosesAt(company.timeClockClosesAt ?? '20:00');
+  }, [company]);
+
+  if (!company) return null;
+
+  const invalid = closesAt <= opensAt;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const updated = await companyService.updateTimeClockHours(company.id, {
+        timeClockWindowEnabled: enabled,
+        timeClockOpensAt: opensAt,
+        timeClockClosesAt: closesAt,
+      });
+      onSaved(updated);
+      setSaved(true);
+    } catch (err: any) {
+      setError(
+        err?.response?.data?.message || 'Failed to save the time clock hours'
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card variant="outlined" sx={{ mb: 4 }}>
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <ScheduleIcon color="primary" fontSize="small" />
+          <Typography variant="h6">Time Clock Hours</Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Staff can only clock themselves in inside this window, and any shift
+          still running at closing time is clocked out automatically so a
+          forgotten clock-out cannot accrue overnight. Those entries are flagged
+          and left unapproved for review. Admins are never restricted — record
+          overtime by editing the time entry.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        {saved && (
+          <Alert
+            severity="success"
+            sx={{ mb: 2 }}
+            onClose={() => setSaved(false)}
+          >
+            Time clock hours updated.
+          </Alert>
+        )}
+
+        <FormControlLabel
+          control={
+            <Switch
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              disabled={saving}
+            />
+          }
+          label="Enforce shop hours on the time clock"
+        />
+
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          sx={{ mt: 2 }}
+        >
+          <TextField
+            type="time"
+            label="Opens at"
+            value={opensAt}
+            onChange={(e) => setOpensAt(e.target.value)}
+            disabled={saving || !enabled}
+            slotProps={{ inputLabel: { shrink: true } }}
+            sx={{ minWidth: 160 }}
+          />
+          <TextField
+            type="time"
+            label="Closes at"
+            value={closesAt}
+            onChange={(e) => setClosesAt(e.target.value)}
+            disabled={saving || !enabled}
+            error={invalid}
+            helperText={invalid ? 'Closing must be after opening' : ' '}
+            slotProps={{ inputLabel: { shrink: true } }}
+            sx={{ minWidth: 160 }}
+          />
+          <Button
+            variant="contained"
+            startIcon={<SaveIcon />}
+            onClick={handleSave}
+            disabled={saving || invalid}
+            sx={{ height: 56 }}
+          >
+            {saving ? 'Saving…' : 'Save Hours'}
+          </Button>
+        </Stack>
+
+        <Typography variant="caption" color="text.secondary">
+          Times are the shop's local time (America/Vancouver).
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/webApp/src/app/pages/staff/TimeClock.tsx
+++ b/apps/webApp/src/app/pages/staff/TimeClock.tsx
@@ -22,7 +22,10 @@ import {
   PayPeriodNavigator,
   TimeEntriesTable,
 } from '../../components/time-clock';
-import { timeClockService } from '../../requests/time-clock.requests';
+import {
+  timeClockService,
+  ShopHoursStatus,
+} from '../../requests/time-clock.requests';
 import { colors } from '../../theme/colors';
 import {
   PayPeriod,
@@ -43,6 +46,9 @@ export function TimeClock() {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The shop-hours window, so the clock-in button can disable itself and say
+  // why rather than letting someone press it and take an error back.
+  const [shopHours, setShopHours] = useState<ShopHoursStatus | null>(null);
 
   const periodStart = period.start.toISOString();
   const periodEnd = period.end.toISOString();
@@ -51,7 +57,7 @@ export function TimeClock() {
     try {
       setLoading(true);
       setError(null);
-      const [current, history, hours] = await Promise.all([
+      const [current, history, hours, hoursWindow] = await Promise.all([
         timeClockService.getMyCurrent(),
         timeClockService.getMyEntries({
           startDate: periodStart,
@@ -61,7 +67,11 @@ export function TimeClock() {
           startDate: periodStart,
           endDate: periodEnd,
         }),
+        // A failure here must not take the whole screen down — worst case the
+        // button stays enabled and the server refuses, which is where we were.
+        timeClockService.getShopHours().catch(() => null),
       ]);
+      setShopHours(hoursWindow);
       setCurrentEntry(current);
       setEntries(history);
       // The server has already narrowed this to the caller, so the first row
@@ -101,6 +111,9 @@ export function TimeClock() {
 
   const isClockedIn = Boolean(currentEntry);
   const isOnBreak = currentEntry?.status === TimeEntryStatus.ON_BREAK;
+  // Only clocking *in* is restricted. Someone already on the clock must always
+  // be able to clock out, whatever the hour.
+  const clockInClosed = shopHours ? !shopHours.isOpen : false;
 
   return (
     <Box sx={{ px: { xs: 1, sm: 0 } }}>
@@ -143,6 +156,12 @@ export function TimeClock() {
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}
+        </Alert>
+      )}
+
+      {clockInClosed && !isClockedIn && (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          {shopHours?.closedReason}
         </Alert>
       )}
 
@@ -211,7 +230,7 @@ export function TimeClock() {
                     variant="contained"
                     size="large"
                     startIcon={<Login />}
-                    disabled={submitting}
+                    disabled={submitting || clockInClosed}
                     onClick={() => runAction(() => timeClockService.clockIn())}
                     sx={{ width: { xs: '100%', sm: 'auto' } }}
                   >

--- a/apps/webApp/src/app/requests/company.requests.ts
+++ b/apps/webApp/src/app/requests/company.requests.ts
@@ -21,6 +21,10 @@ export interface Company {
   isDefault: boolean;
   /** Business-authored terms printed at the foot of this company's invoices. */
   termsAndConditions?: string | null;
+  /** Shop hours the employee time clock is open for, as HH:mm local time. */
+  timeClockOpensAt?: string;
+  timeClockClosesAt?: string;
+  timeClockWindowEnabled?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -112,6 +116,24 @@ class CompanyService {
     const response = await axios.patch(
       `${API_URL}/api/companies/${id}/terms`,
       { termsAndConditions },
+      { headers: await this.getHeaders() }
+    );
+    this.clearCache();
+    return response.data;
+  }
+
+  /** Admin-only. Sets the window the employee time clock is open for. */
+  async updateTimeClockHours(
+    id: string,
+    hours: {
+      timeClockWindowEnabled?: boolean;
+      timeClockOpensAt?: string;
+      timeClockClosesAt?: string;
+    }
+  ): Promise<Company> {
+    const response = await axios.patch(
+      `${API_URL}/api/companies/${id}/time-clock-hours`,
+      hours,
       { headers: await this.getHeaders() }
     );
     this.clearCache();

--- a/apps/webApp/src/app/requests/time-clock.requests.ts
+++ b/apps/webApp/src/app/requests/time-clock.requests.ts
@@ -25,6 +25,18 @@ export function setClerkTokenGetter(getter: () => Promise<string | null>) {
   clerkTokenGetter = getter;
 }
 
+/** The shop-hours window, as the clock UI needs to see it. */
+export interface ShopHoursStatus {
+  enabled: boolean;
+  /** HH:mm in the business timezone. */
+  opensAt: string;
+  closesAt: string;
+  timezone: string;
+  isOpen: boolean;
+  /** Present only when the clock is shut — why, and what to do instead. */
+  closedReason?: string;
+}
+
 class TimeClockService {
   private baseUrl = `${API_BASE_URL}/api/time-clock`;
 
@@ -190,6 +202,14 @@ class TimeClockService {
         body: JSON.stringify({ reason }),
       }
     );
+  }
+
+  /**
+   * The shop-hours window and whether the clock is open right now, so the
+   * clock-in button can disable itself and say why.
+   */
+  getShopHours(): Promise<ShopHoursStatus> {
+    return this.makeRequest<ShopHoursStatus>(`${this.baseUrl}/shop-hours`);
   }
 
   getCompensation(employeeId: string): Promise<EmployeeCompensationDto | null> {

--- a/libs/data/src/lib/company.dto.ts
+++ b/libs/data/src/lib/company.dto.ts
@@ -1,4 +1,10 @@
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator';
 
 /**
  * Update the invoice terms & conditions for a company. The wording is a
@@ -12,4 +18,31 @@ export class UpdateCompanyTermsDto {
     message: 'Terms and conditions cannot exceed 4000 characters',
   })
   termsAndConditions?: string | null;
+}
+
+/**
+ * Update the window the employee time clock is open for.
+ *
+ * Times are business-timezone wall-clock (HH:mm) rather than instants: the shop
+ * opens at 8 AM local whatever the server's clock says, and daylight saving
+ * must not shift it.
+ */
+export class UpdateCompanyTimeClockHoursDto {
+  @IsOptional()
+  @IsBoolean()
+  timeClockWindowEnabled?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
+    message: 'Opening time must be a 24-hour time in HH:mm format',
+  })
+  timeClockOpensAt?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
+    message: 'Closing time must be a 24-hour time in HH:mm format',
+  })
+  timeClockClosesAt?: string;
 }

--- a/libs/data/src/lib/time-clock.dto.ts
+++ b/libs/data/src/lib/time-clock.dto.ts
@@ -204,6 +204,8 @@ export interface TimeEntryDto {
   status: TimeEntryStatus;
   source: TimeEntrySource;
   notes?: string;
+  /** The closing-time job ended this shift because nobody clocked out. */
+  autoClockedOut: boolean;
   adjustedBy?: string;
   adjustmentReason?: string;
   approvedBy?: string;

--- a/libs/database/src/lib/prisma/migrations/20260807220000_add_time_clock_shop_hours/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260807220000_add_time_clock_shop_hours/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "public"."Company" ADD COLUMN     "timeClockClosesAt" TEXT NOT NULL DEFAULT '20:00',
+ADD COLUMN     "timeClockOpensAt" TEXT NOT NULL DEFAULT '08:00',
+ADD COLUMN     "timeClockWindowEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "public"."TimeEntry" ADD COLUMN     "autoClockedOut" BOOLEAN NOT NULL DEFAULT false;

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -36,10 +36,10 @@ model User {
   tireSales            TireSale[]             @relation("TireSales") // Tire sales made by this user (for commission tracking)
   inspectionsCreated   Inspection[]           @relation("InspectionCreatedBy")
   inspectionsFinalized Inspection[]           @relation("InspectionFinalizedBy")
-  roEmployees          ROEmployee[]           // Repair orders assigned to this employee
+  roEmployees          ROEmployee[] // Repair orders assigned to this employee
   roServices           ROService[]            @relation("ROServiceCompletedBy") // Service items completed by this user
-  roMedia              ROMedia[]              // Photos uploaded by this user
-  payStubs             PayStub[]              // Pay stubs issued to this employee
+  roMedia              ROMedia[] // Photos uploaded by this user
+  payStubs             PayStub[] // Pay stubs issued to this employee
 }
 
 model Role {
@@ -75,29 +75,29 @@ model RolePermission {
 }
 
 model Customer {
-  id              String           @id @default(cuid())
-  firstName       String
-  lastName        String
-  email           String?
-  additionalEmails String[]        @default([]) // Extra emails (e.g. spouse, business) for invoice sending
-  pstExempt       Boolean          @default(false) // When true, invoices for this customer are charged 0% PST
-  pstNumber       String?          // PST exemption / registration number, printed on invoices when pstExempt
-  fleetDiscount   Boolean          @default(false) // When true, a 10% discount on SERVICE items is auto-added to invoices
-  phone           String?
-  address         String?
-  businessName    String?
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
-  appointments    Appointment[]
-  invoices        Invoice[]
-  inspections     Inspection[]
-  vehicles        Vehicle[]
-  repairOrders    RepairOrder[]
-  smsMessages     SmsMessage[]
-  smsPreference   SmsPreference?
-  emailLogs       EmailLog[] // Email logs related to this customer
-  bookingRequests BookingRequest[] // Booking requests converted to this customer
-  tireSales       TireSale[] // Tire sales to this customer
+  id               String           @id @default(cuid())
+  firstName        String
+  lastName         String
+  email            String?
+  additionalEmails String[]         @default([]) // Extra emails (e.g. spouse, business) for invoice sending
+  pstExempt        Boolean          @default(false) // When true, invoices for this customer are charged 0% PST
+  pstNumber        String? // PST exemption / registration number, printed on invoices when pstExempt
+  fleetDiscount    Boolean          @default(false) // When true, a 10% discount on SERVICE items is auto-added to invoices
+  phone            String?
+  address          String?
+  businessName     String?
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
+  appointments     Appointment[]
+  invoices         Invoice[]
+  inspections      Inspection[]
+  vehicles         Vehicle[]
+  repairOrders     RepairOrder[]
+  smsMessages      SmsMessage[]
+  smsPreference    SmsPreference?
+  emailLogs        EmailLog[] // Email logs related to this customer
+  bookingRequests  BookingRequest[] // Booking requests converted to this customer
+  tireSales        TireSale[] // Tire sales to this customer
 }
 
 model Vehicle {
@@ -219,48 +219,59 @@ model ServiceCatalogItem {
 }
 
 model Company {
-  id                 String    @id @default(cuid())
-  name               String
-  registrationNumber String    @unique
-  businessType       String?
-  address            String?
-  phone              String?
-  email              String?
-  isDefault          Boolean   @default(false)
+  id                     String    @id @default(cuid())
+  name                   String
+  registrationNumber     String    @unique
+  businessType           String?
+  address                String?
+  phone                  String?
+  email                  String?
+  isDefault              Boolean   @default(false)
   // Free-text terms & conditions printed at the bottom of this company's
   // invoices, above the signature block. Business-authored (it is a liability
   // statement), editable from admin settings so the wording can change without
   // a deploy. Null/blank means no T&C block is rendered.
-  termsAndConditions String?
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-  invoices           Invoice[]
+  termsAndConditions     String?
+  // Shop hours the employee time clock is open for, as HH:mm in the business
+  // timezone (see BUSINESS_TIMEZONE). Employees cannot clock in outside the
+  // window, and anything still running at closing time is clocked out
+  // automatically so a forgotten clock-out cannot accrue overnight. Admins are
+  // never restricted — genuine overtime is recorded by editing the entry.
+  //
+  // Held here rather than in code because the shop's hours change seasonally,
+  // and that should not need a deploy.
+  timeClockOpensAt       String    @default("08:00")
+  timeClockClosesAt      String    @default("20:00")
+  timeClockWindowEnabled Boolean   @default(true)
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+  invoices               Invoice[]
 }
 
 model Invoice {
-  id             String          @id @default(cuid())
-  invoiceNumber  String          @unique @default(cuid())
-  customerId     String
-  vehicleId      String?
-  companyId      String
-  appointmentId  String?         @unique // Link back to appointment if auto-generated
-  subtotal       Decimal         @db.Decimal(10, 2)
-  taxRate        Decimal         @db.Decimal(5, 4)
-  taxAmount      Decimal         @db.Decimal(10, 2)
-  total          Decimal         @db.Decimal(10, 2)
-  status         InvoiceStatus
-  paymentMethod  PaymentMethod?
-  amountPaid     Decimal         @default(0) @db.Decimal(10, 2) // Cached sum of InvoicePayment rows
-  notes          String?
-  invoiceDate    DateTime        @default(now())
-  createdBy      String
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  paidAt         DateTime?
-  gstAmount      Decimal?        @db.Decimal(10, 2)
-  gstRate        Decimal?        @db.Decimal(5, 4)
-  pstAmount      Decimal?        @db.Decimal(10, 2)
-  pstRate        Decimal?        @db.Decimal(5, 4)
+  id                     String                @id @default(cuid())
+  invoiceNumber          String                @unique @default(cuid())
+  customerId             String
+  vehicleId              String?
+  companyId              String
+  appointmentId          String?               @unique // Link back to appointment if auto-generated
+  subtotal               Decimal               @db.Decimal(10, 2)
+  taxRate                Decimal               @db.Decimal(5, 4)
+  taxAmount              Decimal               @db.Decimal(10, 2)
+  total                  Decimal               @db.Decimal(10, 2)
+  status                 InvoiceStatus
+  paymentMethod          PaymentMethod?
+  amountPaid             Decimal               @default(0) @db.Decimal(10, 2) // Cached sum of InvoicePayment rows
+  notes                  String?
+  invoiceDate            DateTime              @default(now())
+  createdBy              String
+  createdAt              DateTime              @default(now())
+  updatedAt              DateTime              @updatedAt
+  paidAt                 DateTime?
+  gstAmount              Decimal?              @db.Decimal(10, 2)
+  gstRate                Decimal?              @db.Decimal(5, 4)
+  pstAmount              Decimal?              @db.Decimal(10, 2)
+  pstRate                Decimal?              @db.Decimal(5, 4)
   // Customer signature captured at handover. Always optional — an unsigned
   // invoice prints a blank signature line for a wet signature. The image lives
   // in Azure Blob; that account forbids public blob access, so it is served via
@@ -271,27 +282,27 @@ model Invoice {
   // blob URL (re-signed as a SAS URL on read); in development, where Azure is
   // not configured, it is an inline data URL so the pad still works locally.
   signatureUrl           String?
-  signatureSignedByName  String?   // Printed name, shown under the signature
+  signatureSignedByName  String? // Printed name, shown under the signature
   signatureSignedAt      DateTime?
-  signatureCapturedBy    String?   // User id of the staff member who witnessed it
+  signatureCapturedBy    String? // User id of the staff member who witnessed it
   // Combined-invoice consolidation: a parent invoice rolls up several pending children
-  combinedInvoiceId String?
-  customer       Customer        @relation(fields: [customerId], references: [id])
-  vehicle        Vehicle?        @relation(fields: [vehicleId], references: [id])
-  company        Company         @relation(fields: [companyId], references: [id])
-  appointment    Appointment?    @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
-  items          InvoiceItem[]
-  declinedItems  InvoiceDeclinedItem[] // Work the customer declined; never billed
-  payments       InvoicePayment[] // Payment ledger (supports partial/split payments)
-  inspections    Inspection[]
-  squarePayments SquarePayment[] // Square payments for this invoice
-  emailLogs      EmailLog[] // Email logs related to this invoice
-  tireSale       TireSale?     // Tire sale that generated this invoice (one-to-one)
-  repairOrder    RepairOrder?  @relation(fields: [repairOrderId], references: [id], onDelete: SetNull)
-  repairOrderId  String?       @unique // Link to repair order that generated this invoice
-  carfaxSync     CarfaxSync?   // CARFAX Service Data Transfer record for this invoice
-  combinedInvoice      Invoice?  @relation("CombinedInvoice", fields: [combinedInvoiceId], references: [id], onDelete: SetNull)
-  consolidatedInvoices Invoice[] @relation("CombinedInvoice")
+  combinedInvoiceId      String?
+  customer               Customer              @relation(fields: [customerId], references: [id])
+  vehicle                Vehicle?              @relation(fields: [vehicleId], references: [id])
+  company                Company               @relation(fields: [companyId], references: [id])
+  appointment            Appointment?          @relation(fields: [appointmentId], references: [id], onDelete: SetNull)
+  items                  InvoiceItem[]
+  declinedItems          InvoiceDeclinedItem[] // Work the customer declined; never billed
+  payments               InvoicePayment[] // Payment ledger (supports partial/split payments)
+  inspections            Inspection[]
+  squarePayments         SquarePayment[] // Square payments for this invoice
+  emailLogs              EmailLog[] // Email logs related to this invoice
+  tireSale               TireSale? // Tire sale that generated this invoice (one-to-one)
+  repairOrder            RepairOrder?          @relation(fields: [repairOrderId], references: [id], onDelete: SetNull)
+  repairOrderId          String?               @unique // Link to repair order that generated this invoice
+  carfaxSync             CarfaxSync? // CARFAX Service Data Transfer record for this invoice
+  combinedInvoice        Invoice?              @relation("CombinedInvoice", fields: [combinedInvoiceId], references: [id], onDelete: SetNull)
+  consolidatedInvoices   Invoice[]             @relation("CombinedInvoice")
 
   @@index([customerId])
   @@index([status])
@@ -773,8 +784,8 @@ model Payment {
 }
 
 model EmployeeCompensation {
-  id         String @id @default(cuid())
-  employeeId String
+  id                  String    @id @default(cuid())
+  employeeId          String
   // Job title as it should read on a pay stub ("Tire Technician"), which the
   // permission role (STAFF, ACCOUNTANT) does not capture. Optional: an employee
   // can be paid without one, and the stub simply omits the line.
@@ -805,6 +816,10 @@ model TimeEntry {
   status             TimeEntryStatus @default(OPEN)
   source             TimeEntrySource @default(EMPLOYEE)
   notes              String?
+  // Set when the closing-time job ended this shift because nobody clocked out.
+  // A flag rather than string-matching the reason text: the UI badges these for
+  // review, and an auto-closed time is a guess about when someone left.
+  autoClockedOut     Boolean         @default(false)
   adjustedBy         String?
   adjustmentReason   String?
   approvedBy         String?
@@ -913,9 +928,9 @@ model PayStub {
   companyPhone              String?
   companyEmail              String?
   employeeName              String
-  position       String?
-  payRate        Decimal? @db.Decimal(10, 2)
-  payType        PayType  @default(HOURLY)
+  position                  String?
+  payRate                   Decimal? @db.Decimal(10, 2)
+  payType                   PayType  @default(HOURLY)
 
   // Current-period earnings.
   regularHours  Decimal @default(0) @db.Decimal(10, 2)
@@ -1665,33 +1680,33 @@ enum CommissionStatus {
 // ============================================
 
 model RepairOrder {
-  id              String      @id @default(cuid())
-  roNumber        String      @unique // e.g. RO-202606-0001
-  appointmentId   String      @unique // 1:1 with Appointment
+  id              String    @id @default(cuid())
+  roNumber        String    @unique // e.g. RO-202606-0001
+  appointmentId   String    @unique // 1:1 with Appointment
   customerId      String
   vehicleId       String?
-  quotationId     String?     @unique // Quotation generated from this RO's quotation-flagged items (1:1)
-  noVehicle       Boolean     @default(false) // Intentionally no vehicle (loose tires, battery, or other counter service)
-  status          ROStatus    @default(OPEN)
-  customerConcern String?     // What the customer reported
-  technicianNotes String?     // Overall technician notes
-  mileageIn       Int?        // Odometer on arrival
-  mileageOut      Int?        // Odometer on departure
-  estimatedCost   Decimal?    @db.Decimal(10, 2)
-  openedAt        DateTime    @default(now())
+  quotationId     String?   @unique // Quotation generated from this RO's quotation-flagged items (1:1)
+  noVehicle       Boolean   @default(false) // Intentionally no vehicle (loose tires, battery, or other counter service)
+  status          ROStatus  @default(OPEN)
+  customerConcern String? // What the customer reported
+  technicianNotes String? // Overall technician notes
+  mileageIn       Int? // Odometer on arrival
+  mileageOut      Int? // Odometer on departure
+  estimatedCost   Decimal?  @db.Decimal(10, 2)
+  openedAt        DateTime  @default(now())
   closedAt        DateTime?
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
-  appointment  Appointment   @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
-  customer     Customer      @relation(fields: [customerId], references: [id])
-  vehicle      Vehicle?      @relation(fields: [vehicleId], references: [id])
-  quotation    Quotation?    @relation(fields: [quotationId], references: [id])
-  employees    ROEmployee[]
-  services     ROService[]
-  inspections  Inspection[]
-  media        ROMedia[]
-  invoice      Invoice?
+  appointment Appointment  @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
+  customer    Customer     @relation(fields: [customerId], references: [id])
+  vehicle     Vehicle?     @relation(fields: [vehicleId], references: [id])
+  quotation   Quotation?   @relation(fields: [quotationId], references: [id])
+  employees   ROEmployee[]
+  services    ROService[]
+  inspections Inspection[]
+  media       ROMedia[]
+  invoice     Invoice?
 
   @@index([customerId])
   @@index([vehicleId])
@@ -1701,11 +1716,11 @@ model RepairOrder {
 }
 
 model ROEmployee {
-  id            String      @id @default(cuid())
+  id            String   @id @default(cuid())
   repairOrderId String
   userId        String
-  role          String?     // "Lead", "Assistant"
-  assignedAt    DateTime    @default(now())
+  role          String? // "Lead", "Assistant"
+  assignedAt    DateTime @default(now())
 
   repairOrder RepairOrder @relation(fields: [repairOrderId], references: [id], onDelete: Cascade)
   user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -1717,26 +1732,26 @@ model ROEmployee {
 }
 
 model ROService {
-  id              String          @id @default(cuid())
-  repairOrderId   String
-  description     String
-  type            ROServiceType   @default(LABOR)
-  quantity        Decimal         @default(1) @db.Decimal(10, 2)
-  unitPrice       Decimal         @default(0) @db.Decimal(10, 2)
-  total           Decimal         @default(0) @db.Decimal(10, 2)
-  technicianNotes String?
-  status          ROServiceStatus @default(PENDING)
+  id               String            @id @default(cuid())
+  repairOrderId    String
+  description      String
+  type             ROServiceType     @default(LABOR)
+  quantity         Decimal           @default(1) @db.Decimal(10, 2)
+  unitPrice        Decimal           @default(0) @db.Decimal(10, 2)
+  total            Decimal           @default(0) @db.Decimal(10, 2)
+  technicianNotes  String?
+  status           ROServiceStatus   @default(PENDING)
   // Customer's approve/decline decision for this line item (independent of work completion)
   customerApproval ROServiceApproval @default(PENDING)
   // When true, this item should be quoted (via a quotation) rather than billed on the RO invoice
-  isQuotation     Boolean         @default(false)
+  isQuotation      Boolean           @default(false)
   // Set when this line is the fee auto-added from a completed inspection, so it
   // can be kept in sync (and not duplicated) with that inspection.
-  inspectionId    String?
-  completedById   String?
-  completedAt     DateTime?
-  createdAt       DateTime        @default(now())
-  updatedAt       DateTime        @updatedAt
+  inspectionId     String?
+  completedById    String?
+  completedAt      DateTime?
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
 
   repairOrder RepairOrder @relation(fields: [repairOrderId], references: [id], onDelete: Cascade)
   completedBy User?       @relation("ROServiceCompletedBy", fields: [completedById], references: [id])
@@ -1819,9 +1834,9 @@ enum ROMediaType {
 // See .claude/docs/carfax-integration.md
 // ============================================================================
 model CarfaxSync {
-  id        String           @id @default(cuid())
-  invoiceId String           @unique
-  invoice   Invoice          @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+  id        String  @id @default(cuid())
+  invoiceId String  @unique
+  invoice   Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
 
   // Snapshot of what was/should be reported (anonymous - no customer PII)
   vin         String?
@@ -1835,8 +1850,8 @@ model CarfaxSync {
   lastError  String?
 
   sentAt    DateTime?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@index([status])
   @@index([createdAt])

--- a/server/src/app/app.module.ts
+++ b/server/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -43,6 +44,10 @@ import { RoleGuard } from '../auth/guards/role.guard';
       isGlobal: true,
       envFilePath: ['.env.local', '.env'],
     }),
+    // Registered once at the root. The explorer scans every provider in the
+    // app for @Cron, so feature modules declare scheduled work without each
+    // having to call forRoot() and risk registering the same job twice.
+    ScheduleModule.forRoot(),
     CommonModule,
     AuthModule,
     UsersModule,

--- a/server/src/companies/companies.controller.ts
+++ b/server/src/companies/companies.controller.ts
@@ -1,7 +1,10 @@
 import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
 import { CompaniesService } from './companies.service';
 import { Roles } from '../auth/decorators/roles.decorator';
-import { UpdateCompanyTermsDto } from '@gt-automotive/data';
+import {
+  UpdateCompanyTermsDto,
+  UpdateCompanyTimeClockHoursDto,
+} from '@gt-automotive/data';
 
 @Controller('companies')
 export class CompaniesController {
@@ -28,5 +31,16 @@ export class CompaniesController {
       id,
       dto.termsAndConditions ?? null
     );
+  }
+
+  // Admin-only: these hours decide when staff can clock in and when a
+  // forgotten shift is closed automatically.
+  @Patch(':id/time-clock-hours')
+  @Roles('ADMIN')
+  updateTimeClockHours(
+    @Param('id') id: string,
+    @Body() dto: UpdateCompanyTimeClockHoursDto
+  ) {
+    return this.companiesService.updateTimeClockHours(id, dto);
   }
 }

--- a/server/src/companies/companies.service.ts
+++ b/server/src/companies/companies.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PrismaService } from '@gt-automotive/database';
 
 @Injectable()
@@ -42,6 +46,43 @@ export class CompaniesService {
       where: { id },
       // Blank input clears the block entirely rather than printing an empty box.
       data: { termsAndConditions: trimmed ? trimmed : null },
+    });
+  }
+
+  /**
+   * Update the shop-hours window the employee time clock honours.
+   *
+   * Rejects a closing time at or before the opening time: that would describe a
+   * window spanning midnight, which nothing here supports and which would leave
+   * the clock shut all day.
+   */
+  async updateTimeClockHours(
+    id: string,
+    hours: {
+      timeClockWindowEnabled?: boolean;
+      timeClockOpensAt?: string;
+      timeClockClosesAt?: string;
+    }
+  ) {
+    const company = await this.prisma.company.findUnique({ where: { id } });
+    if (!company) {
+      throw new NotFoundException(`Company with ID ${id} not found`);
+    }
+
+    const opensAt = hours.timeClockOpensAt ?? company.timeClockOpensAt;
+    const closesAt = hours.timeClockClosesAt ?? company.timeClockClosesAt;
+
+    if (closesAt <= opensAt) {
+      throw new BadRequestException('The time clock must close after it opens');
+    }
+
+    return this.prisma.company.update({
+      where: { id },
+      data: {
+        timeClockWindowEnabled: hours.timeClockWindowEnabled,
+        timeClockOpensAt: hours.timeClockOpensAt,
+        timeClockClosesAt: hours.timeClockClosesAt,
+      },
     });
   }
 }

--- a/server/src/config/timezone.config.ts
+++ b/server/src/config/timezone.config.ts
@@ -189,6 +189,50 @@ export function businessDayUtcRange(dateStr: string): {
 }
 
 /**
+ * The wall-clock time an instant falls on in the business timezone, as HH:mm.
+ *
+ * Use this instead of `new Date().getHours()` for anything the shop's day
+ * governs. Production runs UTC, so the server's own clock reads 8 PM Pacific as
+ * 4 AM the next morning.
+ */
+export function businessTimeOfDay(instant: Date = new Date()): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: BUSINESS_TIMEZONE,
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(instant);
+  const get = (type: string) =>
+    Number(parts.find((part) => part.type === type)?.value);
+  // Midnight comes back as hour 24 in some environments.
+  const hour = get('hour') % 24;
+  return `${String(hour).padStart(2, '0')}:${String(get('minute')).padStart(
+    2,
+    '0'
+  )}`;
+}
+
+/**
+ * The UTC instant of a wall-clock time on a business calendar day — e.g. 8 PM
+ * on 2026-08-07 in Vancouver.
+ *
+ * DST-correct: the day's offset is sampled at noon UTC, which is after the 2 AM
+ * local changeover, so both the spring-forward and fall-back days resolve to the
+ * offset actually in force during shop hours.
+ *
+ * @param dateStr business date in YYYY-MM-DD format
+ * @param timeOfDay wall-clock time as HH:mm
+ */
+export function businessDayInstantAt(dateStr: string, timeOfDay: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const [hour, minute] = timeOfDay.split(':').map(Number);
+  const offsetMinutes = businessTimezoneOffsetMinutes(year, month, day);
+  return new Date(
+    Date.UTC(year, month - 1, day, hour, minute, 0, 0) - offsetMinutes * 60000
+  );
+}
+
+/**
  * Format PostgreSQL AT TIME ZONE clause for date comparison
  * Use this in raw SQL queries to ensure dates are compared in business timezone
  *

--- a/server/src/sms/sms.module.ts
+++ b/server/src/sms/sms.module.ts
@@ -1,12 +1,10 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 import { PrismaService } from '@gt-automotive/database';
 import { SmsService } from './sms.service';
 import { SmsController } from './sms.controller';
 import { SmsSchedulerService } from './sms-scheduler.service';
 
 @Module({
-  imports: [ScheduleModule.forRoot()],
   controllers: [SmsController],
   providers: [SmsService, SmsSchedulerService, PrismaService],
   exports: [SmsService],

--- a/server/src/time-clock/shop-hours.spec.ts
+++ b/server/src/time-clock/shop-hours.spec.ts
@@ -1,0 +1,254 @@
+import {
+  closingInstantFor,
+  DEFAULT_SHOP_HOURS,
+  formatTimeOfDay,
+  isWithinShopHours,
+  resolveShopHours,
+  shopHoursRefusal,
+  toMinutes,
+} from './shop-hours';
+
+/**
+ * The whole point of this module is that the shop's day is Pacific and the
+ * production server's is UTC, so every case here is expressed as a real instant
+ * and checked against what the clock on the shop wall would say.
+ */
+
+/** A UTC instant, written the way the server actually sees one. */
+const utc = (iso: string) => new Date(iso);
+
+const HOURS = DEFAULT_SHOP_HOURS;
+
+describe('toMinutes', () => {
+  it('reads a wall-clock time', () => {
+    expect(toMinutes('08:00')).toBe(480);
+    expect(toMinutes('20:00')).toBe(1200);
+    expect(toMinutes('00:00')).toBe(0);
+    expect(toMinutes('23:59')).toBe(1439);
+  });
+
+  it('rejects anything that is not HH:mm', () => {
+    expect(toMinutes('8:00')).toBeNull();
+    expect(toMinutes('24:00')).toBeNull();
+    expect(toMinutes('08:60')).toBeNull();
+    expect(toMinutes('')).toBeNull();
+    expect(toMinutes('lunchtime')).toBeNull();
+  });
+});
+
+describe('formatTimeOfDay', () => {
+  it('reads back the way the shop would say it', () => {
+    expect(formatTimeOfDay('08:00')).toBe('8:00 AM');
+    expect(formatTimeOfDay('20:00')).toBe('8:00 PM');
+    expect(formatTimeOfDay('12:00')).toBe('12:00 PM');
+    expect(formatTimeOfDay('00:30')).toBe('12:30 AM');
+  });
+});
+
+describe('resolveShopHours', () => {
+  it('uses what the shop configured', () => {
+    expect(
+      resolveShopHours({
+        timeClockWindowEnabled: true,
+        timeClockOpensAt: '07:00',
+        timeClockClosesAt: '21:00',
+      })
+    ).toEqual({ enabled: true, opensAt: '07:00', closesAt: '21:00' });
+  });
+
+  it('falls back when there is no company configured', () => {
+    expect(resolveShopHours(null)).toEqual(DEFAULT_SHOP_HOURS);
+  });
+
+  // A garbled time must not lock the whole shop out of the clock.
+  it('falls back on a malformed time rather than refusing everyone', () => {
+    expect(
+      resolveShopHours({
+        timeClockWindowEnabled: true,
+        timeClockOpensAt: 'eight',
+        timeClockClosesAt: '',
+      })
+    ).toEqual(DEFAULT_SHOP_HOURS);
+  });
+
+  it('carries the off switch through', () => {
+    expect(resolveShopHours({ timeClockWindowEnabled: false }).enabled).toBe(
+      false
+    );
+  });
+});
+
+describe('isWithinShopHours', () => {
+  // PST is UTC-8, so 8 AM Pacific is 16:00 UTC and 8 PM Pacific is 04:00 UTC
+  // the following day.
+  describe('in winter (PST, UTC-8)', () => {
+    it('is shut just before opening', () => {
+      // 07:59 Pacific
+      expect(isWithinShopHours(HOURS, utc('2026-01-15T15:59:00Z'))).toBe(false);
+    });
+
+    it('opens on the hour', () => {
+      // 08:00 Pacific
+      expect(isWithinShopHours(HOURS, utc('2026-01-15T16:00:00Z'))).toBe(true);
+    });
+
+    it('is open through the day', () => {
+      // 13:00 Pacific
+      expect(isWithinShopHours(HOURS, utc('2026-01-15T21:00:00Z'))).toBe(true);
+    });
+
+    it('is open for the last minute before closing', () => {
+      // 19:59 Pacific
+      expect(isWithinShopHours(HOURS, utc('2026-01-16T03:59:00Z'))).toBe(true);
+    });
+
+    it('shuts on the closing hour', () => {
+      // 20:00 Pacific — and note this instant is already the next day in UTC,
+      // which is exactly the trap this module exists to avoid.
+      expect(isWithinShopHours(HOURS, utc('2026-01-16T04:00:00Z'))).toBe(false);
+    });
+
+    it('is shut overnight', () => {
+      // 03:00 Pacific
+      expect(isWithinShopHours(HOURS, utc('2026-01-16T11:00:00Z'))).toBe(false);
+    });
+  });
+
+  // PDT is UTC-7, so the same wall-clock times sit an hour earlier in UTC.
+  describe('in summer (PDT, UTC-7)', () => {
+    it('is shut just before opening', () => {
+      expect(isWithinShopHours(HOURS, utc('2026-07-15T14:59:00Z'))).toBe(false);
+    });
+
+    it('opens on the hour', () => {
+      expect(isWithinShopHours(HOURS, utc('2026-07-15T15:00:00Z'))).toBe(true);
+    });
+
+    it('shuts on the closing hour', () => {
+      expect(isWithinShopHours(HOURS, utc('2026-07-16T03:00:00Z'))).toBe(false);
+    });
+  });
+
+  describe('across the daylight saving changeovers', () => {
+    // Clocks go forward at 2 AM local on 8 March 2026.
+    it('holds 8 AM local on the spring-forward day', () => {
+      expect(isWithinShopHours(HOURS, utc('2026-03-08T14:59:00Z'))).toBe(false);
+      expect(isWithinShopHours(HOURS, utc('2026-03-08T15:00:00Z'))).toBe(true);
+    });
+
+    it('holds 8 PM local on the spring-forward day', () => {
+      expect(isWithinShopHours(HOURS, utc('2026-03-09T02:59:00Z'))).toBe(true);
+      expect(isWithinShopHours(HOURS, utc('2026-03-09T03:00:00Z'))).toBe(false);
+    });
+
+    // Clocks go back at 2 AM local on 1 November 2026.
+    it('holds 8 AM local on the fall-back day', () => {
+      expect(isWithinShopHours(HOURS, utc('2026-11-01T15:59:00Z'))).toBe(false);
+      expect(isWithinShopHours(HOURS, utc('2026-11-01T16:00:00Z'))).toBe(true);
+    });
+
+    it('holds 8 PM local on the fall-back day', () => {
+      expect(isWithinShopHours(HOURS, utc('2026-11-02T03:59:00Z'))).toBe(true);
+      expect(isWithinShopHours(HOURS, utc('2026-11-02T04:00:00Z'))).toBe(false);
+    });
+  });
+
+  it('is always open when the window is switched off', () => {
+    const off = { ...HOURS, enabled: false };
+    expect(isWithinShopHours(off, utc('2026-01-16T11:00:00Z'))).toBe(true);
+  });
+
+  // Closing before opening would invert the comparison and shut the clock all
+  // day. Misconfiguration should not cost the shop a day's time tracking.
+  it('stays open when the window is configured backwards', () => {
+    const backwards = { ...HOURS, opensAt: '20:00', closesAt: '08:00' };
+    expect(isWithinShopHours(backwards, utc('2026-01-15T21:00:00Z'))).toBe(
+      true
+    );
+  });
+
+  it('respects a window the shop widened', () => {
+    const extended = { ...HOURS, opensAt: '07:00', closesAt: '21:00' };
+    // 07:30 Pacific — inside the wider window, outside the default one.
+    expect(isWithinShopHours(extended, utc('2026-01-15T15:30:00Z'))).toBe(true);
+    expect(isWithinShopHours(HOURS, utc('2026-01-15T15:30:00Z'))).toBe(false);
+  });
+});
+
+describe('shopHoursRefusal', () => {
+  it('says when the clock opens if someone is early', () => {
+    expect(shopHoursRefusal(HOURS, utc('2026-01-15T15:30:00Z'))).toContain(
+      'opens at 8:00 AM'
+    );
+  });
+
+  it('says when it closed if someone is late', () => {
+    expect(shopHoursRefusal(HOURS, utc('2026-01-16T05:00:00Z'))).toContain(
+      'closed at 8:00 PM'
+    );
+  });
+
+  // Standing in the bay with "not allowed" and no next step is the failure mode
+  // this is written against.
+  it('always names a way forward', () => {
+    expect(shopHoursRefusal(HOURS, utc('2026-01-15T15:30:00Z'))).toContain(
+      'admin'
+    );
+    expect(shopHoursRefusal(HOURS, utc('2026-01-16T05:00:00Z'))).toContain(
+      'admin'
+    );
+  });
+});
+
+describe('closingInstantFor', () => {
+  it('closes a winter shift at 8 PM Pacific', () => {
+    // Clocked in 09:00 Pacific on 15 January.
+    const closing = closingInstantFor(utc('2026-01-15T17:00:00Z'), HOURS);
+    expect(closing.toISOString()).toBe('2026-01-16T04:00:00.000Z');
+  });
+
+  it('closes a summer shift at 8 PM Pacific', () => {
+    const closing = closingInstantFor(utc('2026-07-15T16:00:00Z'), HOURS);
+    expect(closing.toISOString()).toBe('2026-07-16T03:00:00.000Z');
+  });
+
+  it('closes at the shift own day, not today', () => {
+    // A shift from three days ago is closed at the closing time it ran past.
+    const closing = closingInstantFor(utc('2026-01-12T17:00:00Z'), HOURS);
+    expect(closing.toISOString()).toBe('2026-01-13T04:00:00.000Z');
+  });
+
+  it('uses a widened closing time', () => {
+    const closing = closingInstantFor(utc('2026-01-15T17:00:00Z'), {
+      ...HOURS,
+      closesAt: '21:00',
+    });
+    expect(closing.toISOString()).toBe('2026-01-16T05:00:00.000Z');
+  });
+
+  /**
+   * Only an admin can start a shift after closing time — the window blocks
+   * employees — and that exemption exists precisely to record late work. The
+   * backstop must not eat it.
+   */
+  describe('a shift that began after closing time', () => {
+    const lateClockIn = utc('2026-01-16T06:00:00Z'); // 22:00 Pacific, 15 Jan
+
+    it('is not collapsed to zero minutes', () => {
+      expect(closingInstantFor(lateClockIn, HOURS)).not.toEqual(lateClockIn);
+    });
+
+    it('is bounded at the next closing time instead', () => {
+      // 20:00 Pacific on 16 January — the first closing time after it started.
+      expect(closingInstantFor(lateClockIn, HOURS).toISOString()).toBe(
+        '2026-01-17T04:00:00.000Z'
+      );
+    });
+
+    it('still lands after the clock-in', () => {
+      expect(closingInstantFor(lateClockIn, HOURS).getTime()).toBeGreaterThan(
+        lateClockIn.getTime()
+      );
+    });
+  });
+});

--- a/server/src/time-clock/shop-hours.ts
+++ b/server/src/time-clock/shop-hours.ts
@@ -1,0 +1,150 @@
+/**
+ * The window the employee time clock is open for.
+ *
+ * Two problems this solves. A clock-in at 3 AM — a phone in a pocket, or worse
+ * — used to be accepted without question. And an employee who left without
+ * clocking out kept accruing hours overnight, sometimes for days, until someone
+ * noticed and had to reconstruct the shift from memory.
+ *
+ * The rules here govern the employee-facing clock only. Admins record genuine
+ * overtime by adding or editing an entry, which is audited; restricting that
+ * would leave late work with nowhere to go.
+ */
+
+import {
+  businessDayInstantAt,
+  businessTimeOfDay,
+  extractBusinessDate,
+  shiftBusinessDate,
+} from '../config/timezone.config';
+
+/** Shop hours as configured, in business-timezone wall-clock time. */
+export interface ShopHours {
+  enabled: boolean;
+  /** HH:mm the clock opens, inclusive. */
+  opensAt: string;
+  /** HH:mm the clock closes, exclusive — 20:00 means 19:59 is the last minute. */
+  closesAt: string;
+}
+
+export const DEFAULT_SHOP_HOURS: ShopHours = {
+  enabled: true,
+  opensAt: '08:00',
+  closesAt: '20:00',
+};
+
+const TIME_OF_DAY = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+/** Minutes since midnight, or null if the value is not a valid HH:mm. */
+export function toMinutes(timeOfDay: string): number | null {
+  const match = TIME_OF_DAY.exec(timeOfDay ?? '');
+  if (!match) return null;
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+/**
+ * Read shop hours off a company record, falling back to the defaults for
+ * anything missing or malformed.
+ *
+ * A garbled time must not lock the whole shop out of the clock, so an
+ * unparseable value falls back rather than throwing.
+ */
+export function resolveShopHours(
+  company?: {
+    timeClockWindowEnabled?: boolean | null;
+    timeClockOpensAt?: string | null;
+    timeClockClosesAt?: string | null;
+  } | null
+): ShopHours {
+  const opensAt = company?.timeClockOpensAt ?? '';
+  const closesAt = company?.timeClockClosesAt ?? '';
+  return {
+    enabled: company?.timeClockWindowEnabled ?? DEFAULT_SHOP_HOURS.enabled,
+    opensAt: toMinutes(opensAt) === null ? DEFAULT_SHOP_HOURS.opensAt : opensAt,
+    closesAt:
+      toMinutes(closesAt) === null ? DEFAULT_SHOP_HOURS.closesAt : closesAt,
+  };
+}
+
+/** A time as it should read to a person: "8:00 AM", "8:00 PM". */
+export function formatTimeOfDay(timeOfDay: string): string {
+  const minutes = toMinutes(timeOfDay);
+  if (minutes === null) return timeOfDay;
+  const hour24 = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  const suffix = hour24 < 12 ? 'AM' : 'PM';
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return `${hour12}:${String(minute).padStart(2, '0')} ${suffix}`;
+}
+
+/** Whether the clock is open at a given instant. */
+export function isWithinShopHours(
+  hours: ShopHours,
+  instant: Date = new Date()
+): boolean {
+  if (!hours.enabled) return true;
+
+  const now = toMinutes(businessTimeOfDay(instant));
+  const opens = toMinutes(hours.opensAt);
+  const closes = toMinutes(hours.closesAt);
+  if (now === null || opens === null || closes === null) return true;
+
+  // Closing before opening would mean a window spanning midnight, which no
+  // configuration in this business wants and which would silently invert the
+  // check. Treated as misconfigured: leave the clock open rather than lock
+  // everyone out.
+  if (closes <= opens) return true;
+
+  return now >= opens && now < closes;
+}
+
+/**
+ * Why a clock-in was refused, phrased for the person holding the phone.
+ *
+ * "Not allowed" on its own leaves an employee standing in the bay with no idea
+ * what to do next, so both branches say what happens instead.
+ */
+export function shopHoursRefusal(
+  hours: ShopHours,
+  instant: Date = new Date()
+): string {
+  const now = toMinutes(businessTimeOfDay(instant));
+  const opens = toMinutes(hours.opensAt);
+
+  if (now !== null && opens !== null && now < opens) {
+    return `The time clock opens at ${formatTimeOfDay(
+      hours.opensAt
+    )}. Ask an admin to add your hours if you started earlier.`;
+  }
+
+  return `The time clock closed at ${formatTimeOfDay(
+    hours.closesAt
+  )}. Ask an admin to add your hours.`;
+}
+
+/**
+ * The instant an open shift should be closed at: closing time on the business
+ * day it was started.
+ *
+ * Using the shift's own day rather than today's matters for an entry left open
+ * across midnight — it is closed at the closing time it ran past, not at
+ * tonight's.
+ *
+ * A shift that began *after* closing time is the case to be careful with. Only
+ * an admin can create one, because the window blocks employees, and the whole
+ * point of that exemption is to record work that genuinely ran late. Closing it
+ * at its own day's closing time would land before it started; stamping it at
+ * the clock-in instead would zero it out within five minutes of the admin
+ * making it, destroying the escape hatch rather than backstopping it. So it is
+ * bounded at the *next* closing time — late work still gets clocked out if
+ * nobody remembers to, just not before it happened.
+ */
+export function closingInstantFor(clockInAt: Date, hours: ShopHours): Date {
+  const businessDate = extractBusinessDate(clockInAt);
+  const closing = businessDayInstantAt(businessDate, hours.closesAt);
+  if (closing > clockInAt) return closing;
+  return businessDayInstantAt(
+    shiftBusinessDate(businessDate, 1),
+    hours.closesAt
+  );
+}

--- a/server/src/time-clock/time-clock-scheduler.service.ts
+++ b/server/src/time-clock/time-clock-scheduler.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { TimeClockService } from './time-clock.service';
+
+/**
+ * Closes shifts left running past the shop's closing time.
+ *
+ * Polls rather than firing once at 8 PM, because closing time is a setting the
+ * shop can change without a deploy and a `@Cron` expression is fixed at build
+ * time. The stamped clock-out is the configured closing instant either way, so
+ * the interval only affects how soon the entry is tidied up, never the hours
+ * recorded on it.
+ *
+ * The interval is deliberately timezone-free for the same reason. `@Cron` fires
+ * on the server's clock — UTC in production — and a naive `'0 20 * * *'` would
+ * clock the whole shop out at noon Pacific. All the timezone reasoning lives in
+ * the service, against the business timezone.
+ */
+@Injectable()
+export class TimeClockSchedulerService {
+  private readonly logger = new Logger(TimeClockSchedulerService.name);
+
+  constructor(private readonly timeClockService: TimeClockService) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async closeForgottenShifts() {
+    try {
+      await this.timeClockService.autoClockOutStaleEntries();
+    } catch (error) {
+      // A failed sweep must not take the scheduler down with it — the next run
+      // picks up whatever this one missed.
+      this.logger.error(
+        `Failed to auto-clock-out open shifts: ${
+          error instanceof Error ? error.message : error
+        }`
+      );
+    }
+  }
+}

--- a/server/src/time-clock/time-clock-shop-hours.service.spec.ts
+++ b/server/src/time-clock/time-clock-shop-hours.service.spec.ts
@@ -1,0 +1,341 @@
+import { BadRequestException } from '@nestjs/common';
+import { TimeClockService } from './time-clock.service';
+
+/**
+ * Unit tests for the shop-hours window as the service applies it.
+ *
+ * shop-hours.spec.ts pins the arithmetic; these pin the decisions built on it —
+ * who the window applies to, which entries the closing sweep is allowed to
+ * touch, and what state it leaves them in.
+ */
+describe('TimeClockService shop hours', () => {
+  let service: TimeClockService;
+  let prisma: any;
+  let auditRepository: any;
+
+  const employee = {
+    id: 'emp-1',
+    firstName: 'Rohit',
+    lastName: 'Toora',
+    email: 'rohit@example.com',
+    role: { name: 'STAFF' },
+  };
+
+  /** 13:00 Pacific on 15 January — mid-shift, inside the window. */
+  const DURING_HOURS = new Date('2026-01-15T21:00:00.000Z');
+  /** 03:00 Pacific on 16 January — long shut. */
+  const OVERNIGHT = new Date('2026-01-16T11:00:00.000Z');
+  /** 07:30 Pacific on 15 January — before opening. */
+  const BEFORE_OPENING = new Date('2026-01-15T15:30:00.000Z');
+  /** 20:00 Pacific on 15 January, the closing instant that day. */
+  const CLOSING_INSTANT = new Date('2026-01-16T04:00:00.000Z');
+  /** 20:30 Pacific on 15 January — just after closing. */
+  const AFTER_CLOSING = new Date('2026-01-16T04:30:00.000Z');
+
+  const openEntry = (overrides: any = {}) => ({
+    id: 'te-1',
+    employeeId: 'emp-1',
+    // Clocked in 09:00 Pacific.
+    clockInAt: new Date('2026-01-15T17:00:00.000Z'),
+    clockOutAt: null,
+    status: 'OPEN',
+    source: 'EMPLOYEE',
+    breaks: [],
+    employee,
+    ...overrides,
+  });
+
+  /** Put the clock at a given instant, so "now" is the shop's time, not the runner's. */
+  const at = (instant: Date) => {
+    jest.useFakeTimers({
+      now: instant,
+      doNotFake: ['nextTick', 'queueMicrotask'],
+    });
+  };
+
+  beforeEach(() => {
+    prisma = {
+      user: { findUnique: jest.fn().mockResolvedValue(employee) },
+      company: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'co-1',
+          isDefault: true,
+          timeClockWindowEnabled: true,
+          timeClockOpensAt: '08:00',
+          timeClockClosesAt: '20:00',
+        }),
+      },
+      timeEntry: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        findMany: jest.fn().mockResolvedValue([]),
+        create: jest.fn((args: any) => ({
+          id: 'te-new',
+          breaks: [],
+          employee,
+          ...args.data,
+        })),
+        update: jest.fn(({ where, data }: any) => ({
+          ...openEntry(),
+          id: where.id,
+          ...data,
+        })),
+      },
+      breakEntry: { updateMany: jest.fn() },
+      $transaction: jest.fn((fn: any) => fn(prisma)),
+    };
+    auditRepository = { create: jest.fn() };
+    service = new TimeClockService(prisma, auditRepository);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe('clocking in', () => {
+    it('is allowed during shop hours', async () => {
+      at(DURING_HOURS);
+
+      await expect(service.clockIn('emp-1', {} as any)).resolves.toBeDefined();
+    });
+
+    it('is refused before opening, and says when the clock opens', async () => {
+      at(BEFORE_OPENING);
+
+      await expect(service.clockIn('emp-1', {} as any)).rejects.toThrow(
+        /opens at 8:00 AM/
+      );
+      expect(prisma.timeEntry.create).not.toHaveBeenCalled();
+    });
+
+    it('is refused after closing', async () => {
+      at(OVERNIGHT);
+
+      await expect(service.clockIn('emp-1', {} as any)).rejects.toBeInstanceOf(
+        BadRequestException
+      );
+    });
+
+    // Genuine late work still has to be recordable, or the window just loses
+    // hours people actually worked.
+    it('is allowed at any hour when an admin does it on their behalf', async () => {
+      at(OVERNIGHT);
+
+      await expect(
+        service.clockIn('emp-1', {} as any, false)
+      ).resolves.toBeDefined();
+    });
+
+    it('is allowed at any hour when the window is switched off', async () => {
+      prisma.company.findFirst.mockResolvedValue({
+        isDefault: true,
+        timeClockWindowEnabled: false,
+        timeClockOpensAt: '08:00',
+        timeClockClosesAt: '20:00',
+      });
+      at(OVERNIGHT);
+
+      await expect(service.clockIn('emp-1', {} as any)).resolves.toBeDefined();
+    });
+
+    it('respects a window the shop widened', async () => {
+      prisma.company.findFirst.mockResolvedValue({
+        isDefault: true,
+        timeClockWindowEnabled: true,
+        timeClockOpensAt: '07:00',
+        timeClockClosesAt: '21:00',
+      });
+      at(BEFORE_OPENING);
+
+      await expect(service.clockIn('emp-1', {} as any)).resolves.toBeDefined();
+    });
+  });
+
+  describe('closing shifts left open', () => {
+    it('closes an open shift at the day closing time, not at now', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([openEntry()]);
+      at(OVERNIGHT);
+
+      const closed = await service.autoClockOutStaleEntries();
+
+      expect(closed).toBe(1);
+      const [[{ data }]] = prisma.timeEntry.update.mock.calls;
+      expect(data.clockOutAt).toEqual(CLOSING_INSTANT);
+      expect(data.status).toBe('CLOCKED_OUT');
+    });
+
+    it('marks the entry as system-closed and says why', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([openEntry()]);
+      at(OVERNIGHT);
+
+      await service.autoClockOutStaleEntries();
+
+      const [[{ data }]] = prisma.timeEntry.update.mock.calls;
+      expect(data.source).toBe('SYSTEM');
+      expect(data.autoClockedOut).toBe(true);
+      expect(data.adjustmentReason).toContain('8:00 PM');
+    });
+
+    // An auto clock-out is a guess about when someone left. It must be looked
+    // at before it is paid, so it stays in the review queue.
+    it('leaves the entry unapproved', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([openEntry()]);
+      at(OVERNIGHT);
+
+      await service.autoClockOutStaleEntries();
+
+      const [[{ data }]] = prisma.timeEntry.update.mock.calls;
+      expect(data.approvedAt).toBeUndefined();
+      expect(data.approvedBy).toBeUndefined();
+    });
+
+    it('ends an open break at the same instant', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([
+        openEntry({ status: 'ON_BREAK' }),
+      ]);
+      at(OVERNIGHT);
+
+      await service.autoClockOutStaleEntries();
+
+      expect(prisma.breakEntry.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { timeEntryId: 'te-1', endAt: null },
+          data: expect.objectContaining({ endAt: CLOSING_INSTANT }),
+        })
+      );
+    });
+
+    it('leaves a shift alone while it is still within its day', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([openEntry()]);
+      at(DURING_HOURS);
+
+      const closed = await service.autoClockOutStaleEntries();
+
+      expect(closed).toBe(0);
+      expect(prisma.timeEntry.update).not.toHaveBeenCalled();
+    });
+
+    it('only ever looks at open and on-break shifts', async () => {
+      at(OVERNIGHT);
+
+      await service.autoClockOutStaleEntries();
+
+      // Approved, voided and payroll-processed entries are terminal; the query
+      // must not reach them at all.
+      const [[{ where }]] = prisma.timeEntry.findMany.mock.calls;
+      expect(where.status.in).toEqual(['OPEN', 'ON_BREAK']);
+    });
+
+    it('does nothing when the window is switched off', async () => {
+      prisma.company.findFirst.mockResolvedValue({
+        isDefault: true,
+        timeClockWindowEnabled: false,
+      });
+      prisma.timeEntry.findMany.mockResolvedValue([openEntry()]);
+      at(OVERNIGHT);
+
+      expect(await service.autoClockOutStaleEntries()).toBe(0);
+      expect(prisma.timeEntry.update).not.toHaveBeenCalled();
+    });
+
+    it('closes a shift left open for days at the closing time it ran past', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([
+        // Clocked in 09:00 Pacific on 12 January.
+        openEntry({ clockInAt: new Date('2026-01-12T17:00:00.000Z') }),
+      ]);
+      at(OVERNIGHT);
+
+      await service.autoClockOutStaleEntries();
+
+      const [[{ data }]] = prisma.timeEntry.update.mock.calls;
+      expect(data.clockOutAt).toEqual(new Date('2026-01-13T04:00:00.000Z'));
+    });
+
+    // The admin exemption exists to record work that genuinely ran late. A
+    // sweep that zeroed those entries would destroy the escape hatch within
+    // five minutes of it being used.
+    it('does not zero out a shift an admin started after closing time', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([
+        // 22:00 Pacific on 15 January — only an admin could have made this.
+        openEntry({ clockInAt: new Date('2026-01-16T06:00:00.000Z') }),
+      ]);
+      at(OVERNIGHT);
+
+      const closed = await service.autoClockOutStaleEntries();
+
+      // Its own day's closing time is already behind it, so it is left running
+      // until the next one rather than stamped at the instant it began.
+      expect(closed).toBe(0);
+      expect(prisma.timeEntry.update).not.toHaveBeenCalled();
+    });
+
+    it('closes a late admin shift at the next closing time', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([
+        openEntry({ clockInAt: new Date('2026-01-16T06:00:00.000Z') }),
+      ]);
+      // 21:00 Pacific on 16 January — past the next closing time.
+      at(new Date('2026-01-17T05:00:00.000Z'));
+
+      await service.autoClockOutStaleEntries();
+
+      const [[{ data }]] = prisma.timeEntry.update.mock.calls;
+      expect(data.clockOutAt).toEqual(new Date('2026-01-17T04:00:00.000Z'));
+    });
+
+    // Nothing else mutates a time entry without an audit trail, and this one
+    // changes paid hours with no user behind it.
+    it('audits the automatic clock-out', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([openEntry()]);
+      at(OVERNIGHT);
+
+      await service.autoClockOutStaleEntries();
+
+      expect(auditRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'AUTO_CLOCK_OUT',
+          resource: 'TimeEntry',
+          resourceId: 'te-1',
+        })
+      );
+    });
+
+    it('is idempotent — a second sweep finds nothing left open', async () => {
+      prisma.timeEntry.findMany.mockResolvedValue([]);
+      at(OVERNIGHT);
+
+      expect(await service.autoClockOutStaleEntries()).toBe(0);
+    });
+  });
+
+  describe('reporting the window to the UI', () => {
+    it('says the clock is open during shop hours', async () => {
+      at(DURING_HOURS);
+
+      const status = await service.getShopHoursStatus();
+
+      expect(status.isOpen).toBe(true);
+      expect(status.closedReason).toBeUndefined();
+      expect(status.opensAt).toBe('08:00');
+      expect(status.closesAt).toBe('20:00');
+    });
+
+    it('says the clock has closed for the day if the shift ran late', async () => {
+      at(AFTER_CLOSING);
+
+      const status = await service.getShopHoursStatus();
+
+      expect(status.isOpen).toBe(false);
+      expect(status.closedReason).toContain('closed at 8:00 PM');
+    });
+
+    // At 3 AM the useful answer is when it opens, not when it shut.
+    it('says when the clock next opens if it is the small hours', async () => {
+      at(OVERNIGHT);
+
+      const status = await service.getShopHoursStatus();
+
+      expect(status.isOpen).toBe(false);
+      expect(status.closedReason).toContain('opens at 8:00 AM');
+    });
+  });
+});

--- a/server/src/time-clock/time-clock.controller.ts
+++ b/server/src/time-clock/time-clock.controller.ts
@@ -36,13 +36,28 @@ export class TimeClockController {
     return this.timeClockService.clockIn(user.id, dto);
   }
 
+  /**
+   * Clock someone in on their behalf. Deliberately exempt from the shop-hours
+   * window: this is how a shift that genuinely ran outside it gets recorded.
+   */
   @Post('employees/:employeeId/clock-in')
   @Roles('ADMIN', 'FOREMAN')
   adminClockIn(
     @Param('employeeId') employeeId: string,
     @Body() dto: ClockInDto
   ) {
-    return this.timeClockService.clockIn(employeeId, dto);
+    return this.timeClockService.clockIn(employeeId, dto, false);
+  }
+
+  /**
+   * The shop-hours window and whether the clock is open right now, so the
+   * clock-in button can disable itself and say why rather than letting someone
+   * press it and take an error.
+   */
+  @Get('shop-hours')
+  @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF', 'ACCOUNTANT')
+  getShopHours() {
+    return this.timeClockService.getShopHoursStatus();
   }
 
   @Post('employees/:employeeId/clock-out')

--- a/server/src/time-clock/time-clock.module.ts
+++ b/server/src/time-clock/time-clock.module.ts
@@ -3,10 +3,16 @@ import { PrismaService } from '@gt-automotive/database';
 import { AuditRepository } from '../audit/repositories/audit.repository';
 import { TimeClockController } from './time-clock.controller';
 import { TimeClockService } from './time-clock.service';
+import { TimeClockSchedulerService } from './time-clock-scheduler.service';
 
 @Module({
   controllers: [TimeClockController],
-  providers: [TimeClockService, PrismaService, AuditRepository],
+  providers: [
+    TimeClockService,
+    TimeClockSchedulerService,
+    PrismaService,
+    AuditRepository,
+  ],
   exports: [TimeClockService],
 })
 export class TimeClockModule {}

--- a/server/src/time-clock/time-clock.service.ts
+++ b/server/src/time-clock/time-clock.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ForbiddenException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '@gt-automotive/database';
@@ -21,6 +22,15 @@ import {
   UpsertEmployeeCompensationDto,
 } from '@gt-automotive/data';
 import { AuditRepository } from '../audit/repositories/audit.repository';
+import { BUSINESS_TIMEZONE } from '../config/timezone.config';
+import {
+  closingInstantFor,
+  formatTimeOfDay,
+  isWithinShopHours,
+  resolveShopHours,
+  ShopHours,
+  shopHoursRefusal,
+} from './shop-hours';
 
 const ACTIVE_TIME_ENTRY_STATUSES = [
   TimeEntryStatus.OPEN,
@@ -60,6 +70,8 @@ const TEAM_WIDE_TIME_CLOCK_ROLES = [
 
 @Injectable()
 export class TimeClockService {
+  private readonly logger = new Logger(TimeClockService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly auditRepository: AuditRepository
@@ -118,8 +130,24 @@ export class TimeClockService {
     return compensation ? this.toCompensationDto(compensation) : null;
   }
 
-  async clockIn(employeeId: string, dto: ClockInDto) {
+  /**
+   * Clock an employee in.
+   *
+   * @param enforceShopHours whether the shop-hours window applies. True for an
+   * employee clocking themselves in; false when an admin does it on their
+   * behalf, which is the escape hatch for a shift that genuinely ran outside
+   * the window.
+   */
+  async clockIn(employeeId: string, dto: ClockInDto, enforceShopHours = true) {
     await this.assertPayrollEmployee(employeeId);
+
+    if (enforceShopHours) {
+      const hours = await this.getShopHours();
+      if (!isWithinShopHours(hours)) {
+        throw new BadRequestException(shopHoursRefusal(hours));
+      }
+    }
+
     const current = await this.findCurrentEntry(employeeId);
 
     if (current) {
@@ -214,6 +242,117 @@ export class TimeClockService {
     });
 
     return this.toTimeEntryDto(updated);
+  }
+
+  /**
+   * The shop's configured clock window, read from the default company.
+   *
+   * Falls back to the defaults when no company is configured — a missing
+   * settings row is not a reason to refuse everyone a clock-in.
+   */
+  async getShopHours(): Promise<ShopHours> {
+    const company = await this.prisma.company.findFirst({
+      where: { isDefault: true },
+    });
+    return resolveShopHours(company);
+  }
+
+  /** Shop hours plus whether the clock is open right now, for the UI. */
+  async getShopHoursStatus() {
+    const hours = await this.getShopHours();
+    return {
+      ...hours,
+      timezone: BUSINESS_TIMEZONE,
+      isOpen: isWithinShopHours(hours),
+      /** Why the clock is shut, so the button can explain itself. */
+      closedReason: isWithinShopHours(hours)
+        ? undefined
+        : shopHoursRefusal(hours),
+    };
+  }
+
+  /**
+   * Close every shift still running past its day's closing time.
+   *
+   * Run on a schedule rather than trusted to the employee: a forgotten
+   * clock-out otherwise accrues overnight, and by the time anyone notices the
+   * shift has to be reconstructed from memory — or worse, gets paid.
+   *
+   * What it does *not* do is approve them. An 8 PM clock-out is a guess about
+   * when someone actually left, so the entry stays unapproved and flagged, and
+   * lands in the admin's review queue rather than flowing into payroll. Entries
+   * already approved, voided or paid are terminal and never touched.
+   *
+   * Idempotent: an entry closed at its day's closing time is no longer open, so
+   * a second run finds nothing to do.
+   */
+  async autoClockOutStaleEntries(): Promise<number> {
+    const hours = await this.getShopHours();
+    if (!hours.enabled) return 0;
+
+    const now = new Date();
+    const openEntries = await this.prisma.timeEntry.findMany({
+      where: { status: { in: ACTIVE_TIME_ENTRY_STATUSES as any[] } },
+    });
+
+    let closed = 0;
+
+    for (const entry of openEntries) {
+      const closingAt = closingInstantFor(entry.clockInAt, hours);
+      if (closingAt > now) continue;
+
+      await this.prisma.$transaction(async (tx) => {
+        // An open break has to end at the same instant, or the break minutes
+        // would run past the shift that contains them.
+        await tx.breakEntry.updateMany({
+          where: { timeEntryId: entry.id, endAt: null },
+          data: {
+            endAt: closingAt,
+            notes: 'Auto-ended at closing time',
+          },
+        });
+
+        await tx.timeEntry.update({
+          where: { id: entry.id },
+          data: {
+            clockOutAt: closingAt,
+            status: TimeEntryStatus.CLOCKED_OUT as any,
+            source: TimeEntrySource.SYSTEM as any,
+            autoClockedOut: true,
+            adjustmentReason: `Automatically clocked out at ${formatTimeOfDay(
+              hours.closesAt
+            )} — the employee did not clock out.`,
+          },
+        });
+      });
+
+      await this.auditRepository.create({
+        userId: 'system',
+        action: 'AUTO_CLOCK_OUT',
+        resource: 'TimeEntry',
+        resourceId: entry.id,
+        oldValue: {
+          employeeId: entry.employeeId,
+          clockInAt: entry.clockInAt.toISOString(),
+          status: entry.status,
+        },
+        newValue: {
+          clockOutAt: closingAt.toISOString(),
+          status: TimeEntryStatus.CLOCKED_OUT,
+          reason: `Shift left open past ${hours.closesAt}`,
+        },
+      });
+
+      closed += 1;
+    }
+
+    if (closed > 0) {
+      this.logger.log(
+        `Auto-clocked out ${closed} shift(s) left open past ${hours.closesAt}`
+      );
+    }
+
+    return closed;
   }
 
   async getCurrentForEmployee(employeeId: string) {
@@ -1125,6 +1264,7 @@ export class TimeClockService {
       status: entry.status,
       source: entry.source,
       notes: entry.notes || undefined,
+      autoClockedOut: entry.autoClockedOut ?? false,
       adjustedBy: entry.adjustedBy || undefined,
       adjustmentReason: entry.adjustmentReason || undefined,
       approvedBy: entry.approvedBy || undefined,


### PR DESCRIPTION
Closes [GA-63](https://gt-automotives.atlassian.net/browse/GA-63).

## Problem

The clock accepted a clock-in at any hour and left an entry open indefinitely. An employee who walked out without clocking out kept accruing hours overnight — sometimes for days — until someone noticed and had to reconstruct the shift from memory, or it slipped through and got paid.

## What this does

Staff can only clock themselves in between the shop's opening and closing times. A sweep closes anything still running past closing **at the closing instant itself**, not at whatever time the sweep happens to run.

Auto-closed entries are marked `SYSTEM`-sourced, flagged with `autoClockedOut`, badged in the admin view and the employee's history, and **left unapproved**. The clock-out time is a guess about when someone left, so it belongs in the review queue rather than flowing into payroll. Approved, voided and paid entries are never touched.

**Admins are exempt throughout.** Clocking someone in on their behalf skips the window, and editing an entry already demands a reason and records who made the change, so genuine overtime keeps the audit trail it had.

The window is configurable under System Settings → General, with an off switch, since the shop's hours change seasonally. A malformed or backwards window fails open rather than locking everyone out of the clock.

## Timezone

All the reasoning runs against `America/Vancouver`, not the server clock — which is UTC in production. A naive `@Cron('0 20 * * *')` would have clocked the whole shop out at noon Pacific. **This is not hypothetical:** the existing SMS scheduler has exactly that bug (see below).

The sweep polls rather than firing once at 20:00, both because the closing time is a setting and because that keeps the schedule free of timezone assumptions. Tests pin 07:59/08:00/19:59/20:00 in winter and summer, and both DST changeover days in each direction.

`ScheduleModule.forRoot()` moves to the root module. The explorer scans every provider in the app, so having each feature module call it risked registering the same job twice.

## Review findings fixed in this branch

`/review` caught four; three fixed, one accepted.

1. **The admin escape hatch destroyed itself.** `closingInstantFor` clamped to "never earlier than the clock-in", so a shift an admin started at 21:00 was closed by the very next sweep with `clockOutAt === clockInAt` — zero minutes, and the employee could then no longer clock out at all. The documented exemption was erased within five minutes of being used. Late shifts are now bounded at the **next** closing time, so they still get a backstop but never before they happened.
2. **No audit record for the automatic clock-out.** It was the only TimeEntry mutation in the service without one, and the only one that changes paid hours with no user behind it. Now audited as `AUTO_CLOCK_OUT`.
3. **Dead `include: { breaks: true }`** in the sweep query; the open break is closed by a separate `updateMany`.
4. **Accepted, not fixed:** narrowing the closing time mid-day (21:00 → 18:00 at 19:00) clocks out everyone still working, backdated to 18:00. Those entries are flagged, unapproved and land in the review queue — which is what the feature promises for any automatic clock-out. Fixing it properly needs a record of when the setting changed; raise a ticket if that is wanted.

## Verification

- `tsc --noEmit` clean on `server` and `apps/webApp`
- 476 server tests pass, 54 of them new across `shop-hours.spec.ts` and `time-clock-shop-hours.service.spec.ts`
- Migration `20260807220000_add_time_clock_shop_hours` is additive with defaults, so existing time entries are unaffected

## Separate bug found, deliberately not fixed here

`server/src/sms/sms-scheduler.service.ts:20` is `@Cron('0 8 * * *')` with no timezone, commented "Every day at 8:00 AM". Production runs UTC, so staff have been receiving their daily schedule email at **midnight Pacific**. One-line fix, but it changes when staff notifications fire, so it wants its own ticket rather than riding along in a time-clock change.

## Open question

Someone genuinely working past closing gets auto-clocked-out mid-shift and cannot clock back in; the admin fixes the entry next morning. That matches what the ticket asked for. If late shifts turn out to be common, a per-day exemption would be worth building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)