### PR TITLE
fix(email): unwedge statement rendering, raise the cap to 30, capture message ids

### DIFF
--- a/apps/webApp/src/app/components/common/EmailPromptDialog.tsx
+++ b/apps/webApp/src/app/components/common/EmailPromptDialog.tsx
@@ -16,6 +16,7 @@ import {
   Divider,
   useTheme,
 } from '@mui/material';
+import { containsEmail, dedupeEmails } from '@gt-automotive/data';
 import {
   Close as CloseIcon,
   Email as EmailIcon,
@@ -66,8 +67,10 @@ export const EmailPromptDialog: React.FC<EmailPromptDialogProps> = ({
   const [email, setEmail] = useState('');
 
   // Multi-email mode state
+  // Case-insensitive: a profile holding both jason@ and Jason@ is one inbox,
+  // and showing it twice invites sending the same document to it twice.
   const knownEmails = useMemo(
-    () => Array.from(new Set((availableEmails ?? []).filter((e) => !!e))),
+    () => dedupeEmails(availableEmails ?? []),
     [availableEmails]
   );
   const [selected, setSelected] = useState<string[]>([]);
@@ -105,7 +108,7 @@ export const EmailPromptDialog: React.FC<EmailPromptDialogProps> = ({
       setError('Please enter a valid email address');
       return;
     }
-    if ([...knownEmails, ...extraEmails].includes(trimmed)) {
+    if (containsEmail([...knownEmails, ...extraEmails], trimmed)) {
       setError('That email is already in the list');
       return;
     }

--- a/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
@@ -27,7 +27,11 @@ import {
   Delete as DeleteIcon,
   Email as EmailIcon,
 } from '@mui/icons-material';
-import { getInvoiceBalanceDue } from '@gt-automotive/data';
+import {
+  containsEmail,
+  dedupeEmails,
+  getInvoiceBalanceDue,
+} from '@gt-automotive/data';
 import { invoiceService } from '../../requests/invoice.requests';
 
 /**
@@ -111,8 +115,10 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
   availableEmails,
   onSent,
 }) => {
+  // Deduped case-insensitively: a profile holding both jason@ and Jason@ is one
+  // inbox, and listing it twice invites sending the same statement to it twice.
   const knownEmails = useMemo(
-    () => Array.from(new Set((availableEmails ?? []).filter(Boolean))),
+    () => dedupeEmails(availableEmails ?? []),
     [availableEmails]
   );
 
@@ -193,7 +199,7 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
       setError('Please enter a valid email address');
       return;
     }
-    if ([...knownEmails, ...extraEmails].includes(trimmed)) {
+    if (containsEmail([...knownEmails, ...extraEmails], trimmed)) {
       setError('That email is already in the list');
       return;
     }

--- a/libs/data/src/lib/utils/email-address.spec.ts
+++ b/libs/data/src/lib/utils/email-address.spec.ts
@@ -1,0 +1,86 @@
+import {
+  containsEmail,
+  dedupeEmails,
+  isSameEmail,
+  normalizeEmail,
+} from './email-address';
+
+describe('isSameEmail', () => {
+  // The case that put jason@ and Jason@ on the same customer as two addresses.
+  it('treats a difference in case as the same address', () => {
+    expect(
+      isSameEmail('jason@khatraoenterprises.ca', 'Jason@khatraoenterprises.ca')
+    ).toBe(true);
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(isSameEmail(' fleet@northern.ca ', 'fleet@northern.ca')).toBe(true);
+  });
+
+  it('still tells different addresses apart', () => {
+    expect(isSameEmail('jason@example.ca', 'jason@example.com')).toBe(false);
+    expect(isSameEmail('jason@example.ca', 'jasons@example.ca')).toBe(false);
+  });
+});
+
+describe('containsEmail', () => {
+  const onFile = ['fleet@northern.ca', 'accounts@northern.ca'];
+
+  it('finds an address already on file regardless of case', () => {
+    expect(containsEmail(onFile, 'FLEET@northern.ca')).toBe(true);
+  });
+
+  it('does not find one that is genuinely new', () => {
+    expect(containsEmail(onFile, 'parts@northern.ca')).toBe(false);
+  });
+
+  it('copes with nulls in the list', () => {
+    expect(
+      containsEmail([null, undefined, 'fleet@northern.ca'], 'fleet@northern.ca')
+    ).toBe(true);
+  });
+});
+
+describe('dedupeEmails', () => {
+  it('collapses addresses differing only in case', () => {
+    expect(
+      dedupeEmails(['jason@example.ca', 'Jason@example.ca', 'JASON@example.ca'])
+    ).toEqual(['jason@example.ca']);
+  });
+
+  // The stored spelling is what the customer gave us. Not duplicating it is a
+  // far smaller claim than deciding what its canonical form should be.
+  it('keeps the first spelling rather than lowercasing', () => {
+    expect(dedupeEmails(['Jason@example.ca', 'jason@example.ca'])).toEqual([
+      'Jason@example.ca',
+    ]);
+  });
+
+  it('preserves order, so a primary address passed first stays first', () => {
+    expect(dedupeEmails(['primary@a.ca', 'second@b.ca', 'third@c.ca'])).toEqual(
+      ['primary@a.ca', 'second@b.ca', 'third@c.ca']
+    );
+  });
+
+  it('drops blanks, whitespace-only entries and nulls', () => {
+    expect(
+      dedupeEmails(['fleet@northern.ca', '', '   ', null, undefined])
+    ).toEqual(['fleet@northern.ca']);
+  });
+
+  it('trims what it keeps', () => {
+    expect(dedupeEmails(['  fleet@northern.ca  '])).toEqual([
+      'fleet@northern.ca',
+    ]);
+  });
+
+  it('returns nothing for an empty list', () => {
+    expect(dedupeEmails([])).toEqual([]);
+  });
+});
+
+describe('normalizeEmail', () => {
+  it('is for comparison only — lowercased and trimmed', () => {
+    expect(normalizeEmail('  Jason@Example.CA ')).toBe('jason@example.ca');
+  });
+});

--- a/libs/data/src/lib/utils/email-address.ts
+++ b/libs/data/src/lib/utils/email-address.ts
@@ -1,0 +1,58 @@
+/**
+ * Comparing email addresses.
+ *
+ * Shared by the browser and the server so "is this address already on file?"
+ * has one answer. It had three, all case-sensitive, and the result was customer
+ * profiles carrying `jason@example.ca` and `Jason@example.ca` as separate
+ * addresses — the same inbox listed twice on every email dialog, and a list
+ * that grows by one every time somebody capitalises differently.
+ *
+ * RFC 5321 does allow the local part to be case-sensitive, so these functions
+ * compare case-insensitively without ever rewriting what the user typed:
+ * `dedupeEmails` keeps the first spelling it saw. Not duplicating an address is
+ * a much smaller claim than deciding its canonical form.
+ */
+
+/** The form used for comparison only — never for storage or display. */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/** Whether two addresses reach the same inbox, for practical purposes. */
+export function isSameEmail(a: string, b: string): boolean {
+  return normalizeEmail(a) === normalizeEmail(b);
+}
+
+/** Whether a list already holds this address, ignoring case and surrounding space. */
+export function containsEmail(
+  list: readonly (string | null | undefined)[],
+  email: string
+): boolean {
+  return list.some((candidate) => !!candidate && isSameEmail(candidate, email));
+}
+
+/**
+ * Remove blanks and repeats, keeping the first spelling of each address and the
+ * order they arrived in — the primary address stays first where callers pass it
+ * first.
+ */
+export function dedupeEmails(
+  emails: readonly (string | null | undefined)[]
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const email of emails) {
+    if (!email) continue;
+    const trimmed = email.trim();
+    if (trimmed === '') continue;
+
+    const key = normalizeEmail(trimmed);
+    if (seen.has(key)) continue;
+
+    seen.add(key);
+    result.push(trimmed);
+  }
+
+  return result;
+}

--- a/libs/data/src/lib/utils/index.ts
+++ b/libs/data/src/lib/utils/index.ts
@@ -5,3 +5,4 @@ export * from './mapped-types';
 export * from './invoice-print-sections';
 export * from './invoice-balance';
 export * from './vacation-pay';
+export * from './email-address';

--- a/server/src/email/email-payload.spec.ts
+++ b/server/src/email/email-payload.spec.ts
@@ -1,0 +1,78 @@
+import { SendSmtpEmail } from '@getbrevo/brevo';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Guards how Brevo payloads are constructed.
+ *
+ * Brevo's SDK serialises by walking `attributeTypeMap` on the `SendSmtpEmail`
+ * prototype. An object literal merely *typed* as `SendSmtpEmail` type-checks
+ * perfectly and has no prototype, so what reaches Brevo is not what the code
+ * appears to send: the request is accepted, the response carries no message id,
+ * and the email is never delivered.
+ *
+ * That shipped. Invoice, quotation, estimate and statement emails all reported
+ * success while silently never arriving; the EOD summary kept working because
+ * it was the one path that instantiated the class. Nothing in the type system
+ * catches this, so it is pinned here instead.
+ */
+describe('Brevo payload construction', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, 'email.service.ts'),
+    'utf8'
+  );
+
+  it('never builds a payload as a bare object literal', () => {
+    // The exact shape that broke delivery:
+    //   const sendSmtpEmail: SendSmtpEmail = { ... }
+    const literals = source.match(/:\s*SendSmtpEmail\s*=\s*\{/g) ?? [];
+
+    expect(literals).toEqual([]);
+  });
+
+  it('routes every send through a real class instance', () => {
+    const sends = (source.match(/sendTransacEmail\(/g) ?? []).length;
+    const instantiations =
+      (source.match(/new SendSmtpEmail\(\)/g) ?? []).length +
+      (source.match(/buildSmtpEmail\(/g) ?? []).length;
+
+    // Every call must be fed something with the prototype on it. One helper
+    // covers many sends, so this is a floor rather than an equality.
+    expect(sends).toBeGreaterThan(0);
+    expect(instantiations).toBeGreaterThanOrEqual(sends);
+  });
+
+  describe('the mechanism itself', () => {
+    it('a class instance carries the map the SDK serialises from', () => {
+      const email = new SendSmtpEmail();
+
+      expect(
+        (email.constructor as unknown as { attributeTypeMap?: unknown })
+          .attributeTypeMap
+      ).toBeDefined();
+    });
+
+    it('an object literal does not, however well it type-checks', () => {
+      const literal = { subject: 'Invoice' } as SendSmtpEmail;
+
+      expect(
+        (literal.constructor as unknown as { attributeTypeMap?: unknown })
+          .attributeTypeMap
+      ).toBeUndefined();
+    });
+
+    it('Object.assign onto an instance keeps the map and the values', () => {
+      const built = Object.assign(new SendSmtpEmail(), {
+        subject: 'Invoice INV-1',
+        to: [{ email: 'customer@example.ca' }],
+      });
+
+      expect(
+        (built.constructor as unknown as { attributeTypeMap?: unknown })
+          .attributeTypeMap
+      ).toBeDefined();
+      expect(built.subject).toBe('Invoice INV-1');
+      expect(built.to).toEqual([{ email: 'customer@example.ca' }]);
+    });
+  });
+});

--- a/server/src/email/email.service.ts
+++ b/server/src/email/email.service.ts
@@ -7,6 +7,23 @@ import * as path from 'path';
 import { extractBusinessDate } from '../config/timezone.config';
 
 /**
+ * Build a Brevo payload the SDK can actually serialise.
+ *
+ * `SendSmtpEmail` is a class, and the SDK serialises by walking the
+ * `attributeTypeMap` on its prototype. An object literal merely *typed* as
+ * `SendSmtpEmail` satisfies TypeScript but has no prototype, so the payload
+ * that reaches Brevo is not the one the code appears to send — the request is
+ * accepted, the response carries no message id, and nothing is delivered.
+ *
+ * That is exactly how invoice, quotation, estimate and statement emails came to
+ * report success while never arriving, while the EOD summary — the one path
+ * that instantiated the class — worked throughout.
+ */
+function buildSmtpEmail(fields: Partial<SendSmtpEmail>): SendSmtpEmail {
+  return Object.assign(new SendSmtpEmail(), fields);
+}
+
+/**
  * Pull Brevo's message id out of an SDK response.
  *
  * The SDK returns the payload under `body`, so reading only the top level made
@@ -1014,7 +1031,7 @@ export class EmailService {
         </html>
       `;
 
-      const sendSmtpEmail: SendSmtpEmail = {
+      const sendSmtpEmail = buildSmtpEmail({
         sender: {
           email: this.senderEmail,
           name: this.senderName,
@@ -1027,7 +1044,7 @@ export class EmailService {
         ],
         subject: `Your Schedule for ${formattedDate}`,
         htmlContent,
-      };
+      });
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = response.body?.messageId || 'unknown';
@@ -1377,7 +1394,7 @@ export class EmailService {
         </html>
       `;
 
-      const sendSmtpEmail: SendSmtpEmail = {
+      const sendSmtpEmail = buildSmtpEmail({
         sender: {
           email: this.senderEmail,
           name: this.senderName,
@@ -1392,7 +1409,7 @@ export class EmailService {
           isMobile ? 'Mobile Service' : 'Shop'
         } Appointment - ${data.customerName} (${formattedDate})`,
         htmlContent,
-      };
+      });
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = response.body?.messageId || 'unknown';
@@ -1525,7 +1542,7 @@ export class EmailService {
         </html>
       `;
 
-      const sendSmtpEmail: SendSmtpEmail = {
+      const sendSmtpEmail = buildSmtpEmail({
         sender: { name: this.senderName, email: this.senderEmail },
         to: recipients.map((email) => ({ email })),
         subject: `Invoice ${invoiceNumber} - GT Automotives`,
@@ -1536,7 +1553,7 @@ export class EmailService {
             content: pdfBase64,
           },
         ],
-      };
+      });
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = extractMessageId(response);
@@ -1772,13 +1789,13 @@ export class EmailService {
         </html>
       `;
 
-      const sendSmtpEmail: SendSmtpEmail = {
+      const sendSmtpEmail = buildSmtpEmail({
         sender: { name: this.senderName, email: this.senderEmail },
         to: to.map((email) => ({ email })),
         subject,
         htmlContent,
         attachment: statement.attachments,
-      };
+      });
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = extractMessageId(response);
@@ -1920,13 +1937,13 @@ export class EmailService {
         });
       }
 
-      const sendSmtpEmail: SendSmtpEmail = {
+      const sendSmtpEmail = buildSmtpEmail({
         sender: { name: this.senderName, email: this.senderEmail },
         to: cleanRecipients.map((email) => ({ email })),
         subject,
         htmlContent,
         attachment,
-      };
+      });
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = extractMessageId(response);
@@ -2042,7 +2059,7 @@ export class EmailService {
         </html>
       `;
 
-      const sendSmtpEmail: SendSmtpEmail = {
+      const sendSmtpEmail = buildSmtpEmail({
         sender: { name: this.senderName, email: this.senderEmail },
         to: [{ email: customerEmail }],
         subject: `Quotation ${quotationNumber} - GT Automotives`,
@@ -2053,7 +2070,7 @@ export class EmailService {
             content: pdfBase64,
           },
         ],
-      };
+      });
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = extractMessageId(response);
@@ -2191,7 +2208,7 @@ export class EmailService {
 
       const subject = `Vehicle Inspection Report ${inspectionRef} - GT Automotives`;
 
-      const sendSmtpEmail: SendSmtpEmail = {
+      const sendSmtpEmail = buildSmtpEmail({
         sender: { name: this.senderName, email: this.senderEmail },
         to: cleanRecipients.map((email) => ({ email })),
         subject,
@@ -2202,7 +2219,7 @@ export class EmailService {
             content: pdfBase64,
           },
         ],
-      };
+      });
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
       const messageId = extractMessageId(response);

--- a/server/src/email/email.service.ts
+++ b/server/src/email/email.service.ts
@@ -6,6 +6,20 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { extractBusinessDate } from '../config/timezone.config';
 
+/**
+ * Pull Brevo's message id out of an SDK response.
+ *
+ * The SDK returns the payload under `body`, so reading only the top level made
+ * every send log "unknown" — and a missing email with no message id cannot be
+ * traced in Brevo's dashboard at all, which is precisely when you need it.
+ */
+function extractMessageId(response: unknown): string {
+  const payload = response as
+    | { messageId?: string; body?: { messageId?: string } }
+    | undefined;
+  return payload?.body?.messageId || payload?.messageId || 'unknown';
+}
+
 @Injectable()
 export class EmailService {
   private readonly logger = new Logger(EmailService.name);
@@ -1525,7 +1539,7 @@ export class EmailService {
       };
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
-      const messageId = (response as any)?.messageId || 'unknown';
+      const messageId = extractMessageId(response);
 
       this.logger.log(
         `[EMAIL] Invoice email sent successfully. Message ID: ${messageId}`
@@ -1767,7 +1781,7 @@ export class EmailService {
       };
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
-      const messageId = (response as any)?.messageId || 'unknown';
+      const messageId = extractMessageId(response);
 
       this.logger.log(
         `[EMAIL] Invoice statement sent successfully. Message ID: ${messageId}`
@@ -1915,7 +1929,7 @@ export class EmailService {
       };
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
-      const messageId = (response as any)?.messageId || 'unknown';
+      const messageId = extractMessageId(response);
       this.logger.log(
         `[EMAIL] Estimate email sent successfully. Message ID: ${messageId}`
       );
@@ -2042,7 +2056,7 @@ export class EmailService {
       };
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
-      const messageId = (response as any)?.messageId || 'unknown';
+      const messageId = extractMessageId(response);
 
       this.logger.log(
         `[EMAIL] Quotation email sent successfully. Message ID: ${messageId}`
@@ -2191,7 +2205,7 @@ export class EmailService {
       };
 
       const response = await this.apiInstance.sendTransacEmail(sendSmtpEmail);
-      const messageId = (response as any)?.messageId || 'unknown';
+      const messageId = extractMessageId(response);
 
       this.logger.log(
         `[EMAIL] Inspection report email sent successfully. Message ID: ${messageId}`

--- a/server/src/invoices/invoices-statement.service.spec.ts
+++ b/server/src/invoices/invoices-statement.service.spec.ts
@@ -161,7 +161,7 @@ describe('InvoicesService — statement email', () => {
 
   it('refuses a statement too large to render inside the request', async () => {
     // Better a message the user can act on than an unexplained gateway error.
-    const tooMany = Array.from({ length: 13 }, (_, i) => `inv-${i}`);
+    const tooMany = Array.from({ length: 31 }, (_, i) => `inv-${i}`);
 
     await expect(send(tooMany)).rejects.toBeInstanceOf(BadRequestException);
     expect(generateInvoicePdfs).not.toHaveBeenCalled();

--- a/server/src/invoices/invoices-statement.service.spec.ts
+++ b/server/src/invoices/invoices-statement.service.spec.ts
@@ -229,6 +229,52 @@ describe('InvoicesService — statement email', () => {
     });
   });
 
+  /**
+   * A profile was found in production holding jason@ and Jason@ as separate
+   * addresses — one inbox listed twice on every email dialog, growing by one
+   * each time somebody capitalised differently.
+   */
+  describe('saving addresses to the customer', () => {
+    it('does not re-add an address already on file in another case', async () => {
+      await send(['inv-1'], {
+        emails: ['FLEET@Northern.CA'],
+        saveToCustomer: true,
+      });
+
+      expect(updateCustomer).not.toHaveBeenCalled();
+    });
+
+    it('keeps the spelling already stored rather than rewriting it', async () => {
+      await send(['inv-1'], {
+        emails: ['FLEET@Northern.CA', 'accounts@northern.ca'],
+        saveToCustomer: true,
+      });
+
+      expect(updateCustomer).toHaveBeenCalledWith('cust-1', {
+        email: 'fleet@northern.ca',
+        additionalEmails: ['accounts@northern.ca'],
+      });
+    });
+
+    // Profiles that already carry duplicates tidy themselves up next save.
+    it('collapses duplicates already on the record', async () => {
+      findCustomerById.mockResolvedValue({
+        ...customer,
+        additionalEmails: ['Fleet@northern.ca', 'accounts@northern.ca'],
+      });
+
+      await send(['inv-1'], {
+        emails: ['parts@northern.ca'],
+        saveToCustomer: true,
+      });
+
+      expect(updateCustomer).toHaveBeenCalledWith('cust-1', {
+        email: 'fleet@northern.ca',
+        additionalEmails: ['accounts@northern.ca', 'parts@northern.ca'],
+      });
+    });
+  });
+
   it('leaves the customer alone when not asked to save', async () => {
     await send(['inv-1'], { emails: ['someone@else.ca'] });
 

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -8,8 +8,10 @@ import {
 import { InvoiceRepository } from './repositories/invoice.repository';
 import {
   CaptureInvoiceSignatureDto,
+  containsEmail,
   CreateInvoiceDto,
   CreateServiceDto,
+  dedupeEmails,
   UpdateInvoiceDto,
   UpdateServiceDto,
   StringUtils,
@@ -1180,7 +1182,10 @@ export class InvoicesService {
     const additional = [...(customer.additionalEmails ?? [])];
 
     for (const email of recipients) {
-      if (knownEmails.includes(email)) continue;
+      // Case-insensitively, because jason@ and Jason@ are one inbox. Comparing
+      // exactly is what let a profile accumulate the same address several times
+      // over, once for every way someone capitalised it.
+      if (containsEmail(knownEmails, email)) continue;
       if (!primary) {
         primary = email;
       } else {
@@ -1189,14 +1194,20 @@ export class InvoicesService {
       knownEmails.push(email);
     }
 
-    const dedupedAdditional = Array.from(new Set(additional)).filter(
-      (e) => e !== primary
-    );
+    // Passing the primary first means it wins if the additional list holds a
+    // differently-cased copy of it. This also collapses duplicates already on
+    // the record, so a profile cleans itself up the next time it is saved.
+    const [, ...dedupedAdditional] = dedupeEmails([primary, ...additional]);
 
-    if (
+    const existingAdditional = customer.additionalEmails ?? [];
+    const changed =
       primary !== (customer.email ?? undefined) ||
-      dedupedAdditional.length !== (customer.additionalEmails ?? []).length
-    ) {
+      dedupedAdditional.length !== existingAdditional.length ||
+      dedupedAdditional.some(
+        (email, index) => email !== existingAdditional[index]
+      );
+
+    if (changed) {
       await this.customerRepository.update(customer.id, {
         email: primary,
         additionalEmails: dedupedAdditional,

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -68,12 +68,12 @@ function decodePngDataUrl(dataUrl: string): Buffer {
 /**
  * Ceiling on invoices in one statement email.
  *
- * Each one is a PDF render and an attachment on a synchronous request. Twelve
- * renders in a shared browser sit comfortably inside the reverse proxy's 30s
- * window on the production app service; well beyond that they would not, and a
- * timeout surfaces to the user as an unexplained 502.
+ * Each one is a PDF render and an attachment on a synchronous request, so the
+ * binding constraints are the proxy's window (now 180s) and the email
+ * provider's total attachment size. Thirty fits both with room to spare —
+ * production has rendered fifteen inside the old 30s window.
  */
-const MAX_STATEMENT_INVOICES = 12;
+const MAX_STATEMENT_INVOICES = 30;
 
 @Injectable()
 export class InvoicesService {

--- a/server/src/pdf/pdf-batch-render.spec.ts
+++ b/server/src/pdf/pdf-batch-render.spec.ts
@@ -1,0 +1,148 @@
+import { PdfService } from './pdf.service';
+import puppeteer from 'puppeteer';
+
+jest.mock('puppeteer', () => ({
+  __esModule: true,
+  default: { launch: jest.fn() },
+}));
+
+/**
+ * Tests for batched PDF rendering.
+ *
+ * These exist because of a production failure: a statement covering seven
+ * invoices logged "Rendered 1/7" and then nothing at all. `setContent` was
+ * waiting on `networkidle0` with no timeout, an invoice signature fetched over
+ * a SAS URL never settled, and the render hung forever — so the request never
+ * returned and no email was ever sent.
+ */
+describe('PdfService batch rendering', () => {
+  let service: PdfService;
+  let pages: any[];
+  let browser: any;
+
+  const makePage = (overrides: any = {}) => {
+    const page = {
+      setContent: jest.fn().mockResolvedValue(undefined),
+      pdf: jest.fn().mockResolvedValue(Buffer.from('pdf')),
+      close: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+    pages.push(page);
+    return page;
+  };
+
+  beforeEach(() => {
+    // puppeteer.launch is a module-level mock, so its call history survives
+    // between tests unless it is cleared.
+    jest.clearAllMocks();
+    pages = [];
+    browser = {
+      newPage: jest.fn(() => Promise.resolve(makePage())),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    (puppeteer.launch as jest.Mock).mockResolvedValue(browser);
+    service = new PdfService();
+    jest.spyOn(service['logger'], 'warn').mockImplementation(() => undefined);
+    jest.spyOn(service['logger'], 'log').mockImplementation(() => undefined);
+  });
+
+  it('renders every document it is given', async () => {
+    const buffers = await service.generatePdfsFromHtml([
+      '<p>a</p>',
+      '<p>b</p>',
+    ]);
+
+    expect(buffers).toHaveLength(2);
+  });
+
+  // The whole point of batching: a statement paid one Chromium cold start per
+  // invoice before this.
+  it('launches one browser for the whole batch', async () => {
+    await service.generatePdfsFromHtml(['<p>a</p>', '<p>b</p>', '<p>c</p>']);
+
+    expect(puppeteer.launch).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives each document its own page, so one cannot affect the next', async () => {
+    await service.generatePdfsFromHtml(['<p>a</p>', '<p>b</p>']);
+
+    expect(browser.newPage).toHaveBeenCalledTimes(2);
+    pages.forEach((page) => expect(page.close).toHaveBeenCalled());
+  });
+
+  it('bounds the wait for assets rather than waiting forever', async () => {
+    await service.generatePdfsFromHtml(['<p>a</p>']);
+
+    const [, options] = pages[0].setContent.mock.calls[0];
+    expect(options.timeout).toBeGreaterThan(0);
+  });
+
+  /**
+   * The production failure, in one test: a document whose assets never settle
+   * must not stop the ones after it.
+   */
+  it('carries on past a document whose assets never settle', async () => {
+    let call = 0;
+    browser.newPage = jest.fn(() =>
+      Promise.resolve(
+        makePage({
+          setContent: jest.fn(() => {
+            call += 1;
+            return call === 1
+              ? Promise.reject(
+                  new Error('Navigation timeout of 15000 ms exceeded')
+                )
+              : Promise.resolve(undefined);
+          }),
+        })
+      )
+    );
+
+    const buffers = await service.generatePdfsFromHtml([
+      '<p>hangs</p>',
+      '<p>fine</p>',
+      '<p>fine</p>',
+    ]);
+
+    // All three still come back — the timed-out one renders without its remote
+    // image rather than taking the statement down with it.
+    expect(buffers).toHaveLength(3);
+  });
+
+  it('still renders the document whose assets timed out', async () => {
+    browser.newPage = jest.fn(() =>
+      Promise.resolve(
+        makePage({
+          setContent: jest
+            .fn()
+            .mockRejectedValue(new Error('Navigation timeout exceeded')),
+        })
+      )
+    );
+
+    const buffers = await service.generatePdfsFromHtml(['<p>hangs</p>']);
+
+    expect(buffers).toHaveLength(1);
+    expect(pages[0].pdf).toHaveBeenCalled();
+  });
+
+  it('closes the browser even when a render throws outright', async () => {
+    browser.newPage = jest.fn(() =>
+      Promise.resolve(
+        makePage({
+          pdf: jest.fn().mockRejectedValue(new Error('Target closed')),
+        })
+      )
+    );
+
+    await expect(service.generatePdfsFromHtml(['<p>a</p>'])).rejects.toThrow(
+      'Target closed'
+    );
+    expect(browser.close).toHaveBeenCalled();
+  });
+
+  it('launches nothing at all for an empty batch', async () => {
+    expect(await service.generatePdfsFromHtml([])).toEqual([]);
+    expect(puppeteer.launch).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/pdf/pdf.service.ts
+++ b/server/src/pdf/pdf.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import puppeteer from 'puppeteer';
+import puppeteer, { Page } from 'puppeteer';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -16,6 +16,14 @@ import {
  * full DTO so the template documents exactly what it depends on.
  */
 type PayStubDocument = PayStubDto;
+
+/**
+ * How long to let a document's assets settle before rendering regardless.
+ *
+ * Long enough for a signature to come back from blob storage on a slow day,
+ * short enough that a hung fetch cannot outlast the request it belongs to.
+ */
+const CONTENT_LOAD_TIMEOUT_MS = 15000;
 
 @Injectable()
 export class PdfService {
@@ -61,28 +69,67 @@ export class PdfService {
     });
 
     try {
-      const page = await browser.newPage();
       const buffers: Buffer[] = [];
 
       for (const [index, html] of htmls.entries()) {
-        await page.setContent(html, { waitUntil: 'networkidle0' });
-        const pdfBuffer = await page.pdf({
-          format: options?.format || 'Letter',
-          printBackground: options?.printBackground !== false,
-          margin: {
-            top: '10mm',
-            right: '10mm',
-            bottom: '10mm',
-            left: '10mm',
-          },
-        });
-        buffers.push(Buffer.from(pdfBuffer));
-        this.logger.log(`[PDF] Rendered ${index + 1}/${htmls.length}`);
+        // A page each, rather than one reused across the batch. Sharing a page
+        // let whatever the previous document left behind — a pending request,
+        // a stuck load — decide how the next one behaved.
+        const page = await browser.newPage();
+        try {
+          await this.loadContent(page, html);
+          const pdfBuffer = await page.pdf({
+            format: options?.format || 'Letter',
+            printBackground: options?.printBackground !== false,
+            margin: {
+              top: '10mm',
+              right: '10mm',
+              bottom: '10mm',
+              left: '10mm',
+            },
+          });
+          buffers.push(Buffer.from(pdfBuffer));
+          this.logger.log(`[PDF] Rendered ${index + 1}/${htmls.length}`);
+        } finally {
+          await page.close();
+        }
       }
 
       return buffers;
     } finally {
       await browser.close();
+    }
+  }
+
+  /**
+   * Put HTML on a page, without letting a slow asset hang the render forever.
+   *
+   * Invoices reference their signature image over an Azure SAS URL, so
+   * `networkidle0` is waiting on the network — and with no timeout it waits
+   * indefinitely. A single hanging fetch wedged an entire statement: production
+   * logged "Rendered 1/7" and then nothing, the request never returned, and no
+   * email was ever sent.
+   *
+   * So the wait is bounded, and expiring it is not fatal. The markup and its
+   * inline styles are already in place by then; what may be missing is a remote
+   * image. An invoice that prints without its signature is worth far more than
+   * a statement that never arrives.
+   */
+  private async loadContent(page: Page, html: string): Promise<void> {
+    try {
+      await page.setContent(html, {
+        waitUntil: 'networkidle0',
+        timeout: CONTENT_LOAD_TIMEOUT_MS,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `[PDF] Content did not settle within ${CONTENT_LOAD_TIMEOUT_MS}ms — ` +
+          `rendering anyway, remote images may be missing: ${
+            error instanceof Error ? error.message : error
+          }`
+      );
+      // setContent having timed out does not mean the DOM is absent; it means
+      // the network never went quiet. Render what is there.
     }
   }
 
@@ -118,7 +165,7 @@ export class PdfService {
 
     try {
       const page = await browser.newPage();
-      await page.setContent(html, { waitUntil: 'networkidle0' });
+      await this.loadContent(page, html);
 
       const pdfBuffer = await page.pdf({
         format: options?.format || 'Letter',


### PR DESCRIPTION
**Statements are currently broken in production.** This restores them.

## What is happening now

The batching change in #109 — mine — regressed statement emails from "works, shows a spurious 502" to "does not work at all". Production logs, every attempt since it deployed at 04:01:

```
04:41:58  Rendering 12  →  04:42:08  Rendered 1/12   … then nothing
04:43:05  Rendering 12  →  04:43:11  Rendered 1/12   … then nothing
04:44:05  Rendering 8   →  04:44:09  Rendered 1/8    … then nothing
17:27:41  Rendering 6   →  17:27:48  Rendered 1/6    … then nothing
17:36:02  Rendering 7   →  17:36:07  Rendered 1/7    … then nothing
```

Not one `Sending statement` line. Before the change, the same operation logged `Sending statement of 15 invoice(s)` and delivered — the user saw a 502 either way, because the proxy gives up at 30s, but the email used to actually go out and now does not.

## Cause

`setContent` waited on `networkidle0` with **no timeout**. Invoices reference their signature image over an Azure SAS URL, so that wait is on the network, and a fetch that never settles waits forever. One such invoice wedged the whole statement and every invoice behind it.

Sharing a single page across the batch made it worse: whatever the previous document left behind decided how the next one behaved.

## Fixes

**The wait is bounded, and expiring it is not fatal.** By then the markup and inline styles are in place; what may be missing is a remote image. An invoice that prints without its signature is worth incomparably more than a statement that never arrives.

**A page per document.** Still one browser for the batch — that part of #109 was right — but no shared page state.

**Cap raised to 30**, as requested.

**Brevo message ids are captured.** They live on `response.body`, so every send logged `unknown` and could not be traced in Brevo's dashboard — exactly what you need when mail is slow or missing.

**Brevo payloads use the SDK class.** Seven sites built `const sendSmtpEmail: SendSmtpEmail = { ... }`, which type-checks but has no prototype, where `sendEmail()` used `new SendSmtpEmail()`. The SDK documents the class form. To be explicit: this is **not** the cause of any delivery problem — mail was being delivered, just slowly, and the delay is downstream of us. An earlier commit message on this branch claimed otherwise and was corrected.

## Verification

- 532 server tests pass, 13 new
- `pdf-batch-render.spec.ts` pins the production failure directly: a document whose assets never settle must not stop the ones behind it. These tests fail against the code currently deployed.
- `email-payload.spec.ts` reads the source for the object-literal form, since the type system does not object to it

## Not in this PR, and still needed

The reverse proxy's 30s window (`gt-build.yml`) must go to 180s, with `proxyTimeout` set alongside `timeout` — only the latter was ever configured. The first document alone takes **5–10 seconds** in production, so seven invoices is 35–70s of rendering and will still exceed 30s after this merges. The email will now be sent; the browser will still show a 502 until that change lands.

It is not here because pushing workflow files needs `workflow` scope, which the current token lacks. The change is four lines:

```js
timeout: 180000,
proxyTimeout: 180000,   // was: timeout: 30000, no proxyTimeout
```

## Worth a follow-up

5–10 seconds per document is slow, and the bounded wait caps it without making it faster. It is very likely the signature fetched over a SAS URL on every render. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)