### PR TITLE
fix(email): stop storing the same address twice in different cases

### DIFF
--- a/apps/webApp/src/app/components/common/EmailPromptDialog.tsx
+++ b/apps/webApp/src/app/components/common/EmailPromptDialog.tsx
@@ -16,6 +16,7 @@ import {
   Divider,
   useTheme,
 } from '@mui/material';
+import { containsEmail, dedupeEmails } from '@gt-automotive/data';
 import {
   Close as CloseIcon,
   Email as EmailIcon,
@@ -66,8 +67,10 @@ export const EmailPromptDialog: React.FC<EmailPromptDialogProps> = ({
   const [email, setEmail] = useState('');
 
   // Multi-email mode state
+  // Case-insensitive: a profile holding both jason@ and Jason@ is one inbox,
+  // and showing it twice invites sending the same document to it twice.
   const knownEmails = useMemo(
-    () => Array.from(new Set((availableEmails ?? []).filter((e) => !!e))),
+    () => dedupeEmails(availableEmails ?? []),
     [availableEmails]
   );
   const [selected, setSelected] = useState<string[]>([]);
@@ -105,7 +108,7 @@ export const EmailPromptDialog: React.FC<EmailPromptDialogProps> = ({
       setError('Please enter a valid email address');
       return;
     }
-    if ([...knownEmails, ...extraEmails].includes(trimmed)) {
+    if (containsEmail([...knownEmails, ...extraEmails], trimmed)) {
       setError('That email is already in the list');
       return;
     }

--- a/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
+++ b/apps/webApp/src/app/components/invoices/BulkInvoiceEmailDialog.tsx
@@ -27,7 +27,11 @@ import {
   Delete as DeleteIcon,
   Email as EmailIcon,
 } from '@mui/icons-material';
-import { getInvoiceBalanceDue } from '@gt-automotive/data';
+import {
+  containsEmail,
+  dedupeEmails,
+  getInvoiceBalanceDue,
+} from '@gt-automotive/data';
 import { invoiceService } from '../../requests/invoice.requests';
 
 /**
@@ -111,8 +115,10 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
   availableEmails,
   onSent,
 }) => {
+  // Deduped case-insensitively: a profile holding both jason@ and Jason@ is one
+  // inbox, and listing it twice invites sending the same statement to it twice.
   const knownEmails = useMemo(
-    () => Array.from(new Set((availableEmails ?? []).filter(Boolean))),
+    () => dedupeEmails(availableEmails ?? []),
     [availableEmails]
   );
 
@@ -193,7 +199,7 @@ export const BulkInvoiceEmailDialog: React.FC<BulkInvoiceEmailDialogProps> = ({
       setError('Please enter a valid email address');
       return;
     }
-    if ([...knownEmails, ...extraEmails].includes(trimmed)) {
+    if (containsEmail([...knownEmails, ...extraEmails], trimmed)) {
       setError('That email is already in the list');
       return;
     }

--- a/libs/data/src/lib/utils/email-address.spec.ts
+++ b/libs/data/src/lib/utils/email-address.spec.ts
@@ -1,0 +1,86 @@
+import {
+  containsEmail,
+  dedupeEmails,
+  isSameEmail,
+  normalizeEmail,
+} from './email-address';
+
+describe('isSameEmail', () => {
+  // The case that put jason@ and Jason@ on the same customer as two addresses.
+  it('treats a difference in case as the same address', () => {
+    expect(
+      isSameEmail('jason@khatraoenterprises.ca', 'Jason@khatraoenterprises.ca')
+    ).toBe(true);
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(isSameEmail(' fleet@northern.ca ', 'fleet@northern.ca')).toBe(true);
+  });
+
+  it('still tells different addresses apart', () => {
+    expect(isSameEmail('jason@example.ca', 'jason@example.com')).toBe(false);
+    expect(isSameEmail('jason@example.ca', 'jasons@example.ca')).toBe(false);
+  });
+});
+
+describe('containsEmail', () => {
+  const onFile = ['fleet@northern.ca', 'accounts@northern.ca'];
+
+  it('finds an address already on file regardless of case', () => {
+    expect(containsEmail(onFile, 'FLEET@northern.ca')).toBe(true);
+  });
+
+  it('does not find one that is genuinely new', () => {
+    expect(containsEmail(onFile, 'parts@northern.ca')).toBe(false);
+  });
+
+  it('copes with nulls in the list', () => {
+    expect(
+      containsEmail([null, undefined, 'fleet@northern.ca'], 'fleet@northern.ca')
+    ).toBe(true);
+  });
+});
+
+describe('dedupeEmails', () => {
+  it('collapses addresses differing only in case', () => {
+    expect(
+      dedupeEmails(['jason@example.ca', 'Jason@example.ca', 'JASON@example.ca'])
+    ).toEqual(['jason@example.ca']);
+  });
+
+  // The stored spelling is what the customer gave us. Not duplicating it is a
+  // far smaller claim than deciding what its canonical form should be.
+  it('keeps the first spelling rather than lowercasing', () => {
+    expect(dedupeEmails(['Jason@example.ca', 'jason@example.ca'])).toEqual([
+      'Jason@example.ca',
+    ]);
+  });
+
+  it('preserves order, so a primary address passed first stays first', () => {
+    expect(dedupeEmails(['primary@a.ca', 'second@b.ca', 'third@c.ca'])).toEqual(
+      ['primary@a.ca', 'second@b.ca', 'third@c.ca']
+    );
+  });
+
+  it('drops blanks, whitespace-only entries and nulls', () => {
+    expect(
+      dedupeEmails(['fleet@northern.ca', '', '   ', null, undefined])
+    ).toEqual(['fleet@northern.ca']);
+  });
+
+  it('trims what it keeps', () => {
+    expect(dedupeEmails(['  fleet@northern.ca  '])).toEqual([
+      'fleet@northern.ca',
+    ]);
+  });
+
+  it('returns nothing for an empty list', () => {
+    expect(dedupeEmails([])).toEqual([]);
+  });
+});
+
+describe('normalizeEmail', () => {
+  it('is for comparison only — lowercased and trimmed', () => {
+    expect(normalizeEmail('  Jason@Example.CA ')).toBe('jason@example.ca');
+  });
+});

--- a/libs/data/src/lib/utils/email-address.ts
+++ b/libs/data/src/lib/utils/email-address.ts
@@ -1,0 +1,58 @@
+/**
+ * Comparing email addresses.
+ *
+ * Shared by the browser and the server so "is this address already on file?"
+ * has one answer. It had three, all case-sensitive, and the result was customer
+ * profiles carrying `jason@example.ca` and `Jason@example.ca` as separate
+ * addresses — the same inbox listed twice on every email dialog, and a list
+ * that grows by one every time somebody capitalises differently.
+ *
+ * RFC 5321 does allow the local part to be case-sensitive, so these functions
+ * compare case-insensitively without ever rewriting what the user typed:
+ * `dedupeEmails` keeps the first spelling it saw. Not duplicating an address is
+ * a much smaller claim than deciding its canonical form.
+ */
+
+/** The form used for comparison only — never for storage or display. */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/** Whether two addresses reach the same inbox, for practical purposes. */
+export function isSameEmail(a: string, b: string): boolean {
+  return normalizeEmail(a) === normalizeEmail(b);
+}
+
+/** Whether a list already holds this address, ignoring case and surrounding space. */
+export function containsEmail(
+  list: readonly (string | null | undefined)[],
+  email: string
+): boolean {
+  return list.some((candidate) => !!candidate && isSameEmail(candidate, email));
+}
+
+/**
+ * Remove blanks and repeats, keeping the first spelling of each address and the
+ * order they arrived in — the primary address stays first where callers pass it
+ * first.
+ */
+export function dedupeEmails(
+  emails: readonly (string | null | undefined)[]
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const email of emails) {
+    if (!email) continue;
+    const trimmed = email.trim();
+    if (trimmed === '') continue;
+
+    const key = normalizeEmail(trimmed);
+    if (seen.has(key)) continue;
+
+    seen.add(key);
+    result.push(trimmed);
+  }
+
+  return result;
+}

--- a/libs/data/src/lib/utils/index.ts
+++ b/libs/data/src/lib/utils/index.ts
@@ -5,3 +5,4 @@ export * from './mapped-types';
 export * from './invoice-print-sections';
 export * from './invoice-balance';
 export * from './vacation-pay';
+export * from './email-address';

--- a/server/src/invoices/invoices-statement.service.spec.ts
+++ b/server/src/invoices/invoices-statement.service.spec.ts
@@ -229,6 +229,52 @@ describe('InvoicesService — statement email', () => {
     });
   });
 
+  /**
+   * A profile was found in production holding jason@ and Jason@ as separate
+   * addresses — one inbox listed twice on every email dialog, growing by one
+   * each time somebody capitalised differently.
+   */
+  describe('saving addresses to the customer', () => {
+    it('does not re-add an address already on file in another case', async () => {
+      await send(['inv-1'], {
+        emails: ['FLEET@Northern.CA'],
+        saveToCustomer: true,
+      });
+
+      expect(updateCustomer).not.toHaveBeenCalled();
+    });
+
+    it('keeps the spelling already stored rather than rewriting it', async () => {
+      await send(['inv-1'], {
+        emails: ['FLEET@Northern.CA', 'accounts@northern.ca'],
+        saveToCustomer: true,
+      });
+
+      expect(updateCustomer).toHaveBeenCalledWith('cust-1', {
+        email: 'fleet@northern.ca',
+        additionalEmails: ['accounts@northern.ca'],
+      });
+    });
+
+    // Profiles that already carry duplicates tidy themselves up next save.
+    it('collapses duplicates already on the record', async () => {
+      findCustomerById.mockResolvedValue({
+        ...customer,
+        additionalEmails: ['Fleet@northern.ca', 'accounts@northern.ca'],
+      });
+
+      await send(['inv-1'], {
+        emails: ['parts@northern.ca'],
+        saveToCustomer: true,
+      });
+
+      expect(updateCustomer).toHaveBeenCalledWith('cust-1', {
+        email: 'fleet@northern.ca',
+        additionalEmails: ['accounts@northern.ca', 'parts@northern.ca'],
+      });
+    });
+  });
+
   it('leaves the customer alone when not asked to save', async () => {
     await send(['inv-1'], { emails: ['someone@else.ca'] });
 

--- a/server/src/invoices/invoices.service.ts
+++ b/server/src/invoices/invoices.service.ts
@@ -8,8 +8,10 @@ import {
 import { InvoiceRepository } from './repositories/invoice.repository';
 import {
   CaptureInvoiceSignatureDto,
+  containsEmail,
   CreateInvoiceDto,
   CreateServiceDto,
+  dedupeEmails,
   UpdateInvoiceDto,
   UpdateServiceDto,
   StringUtils,
@@ -1180,7 +1182,10 @@ export class InvoicesService {
     const additional = [...(customer.additionalEmails ?? [])];
 
     for (const email of recipients) {
-      if (knownEmails.includes(email)) continue;
+      // Case-insensitively, because jason@ and Jason@ are one inbox. Comparing
+      // exactly is what let a profile accumulate the same address several times
+      // over, once for every way someone capitalised it.
+      if (containsEmail(knownEmails, email)) continue;
       if (!primary) {
         primary = email;
       } else {
@@ -1189,14 +1194,20 @@ export class InvoicesService {
       knownEmails.push(email);
     }
 
-    const dedupedAdditional = Array.from(new Set(additional)).filter(
-      (e) => e !== primary
-    );
+    // Passing the primary first means it wins if the additional list holds a
+    // differently-cased copy of it. This also collapses duplicates already on
+    // the record, so a profile cleans itself up the next time it is saved.
+    const [, ...dedupedAdditional] = dedupeEmails([primary, ...additional]);
 
-    if (
+    const existingAdditional = customer.additionalEmails ?? [];
+    const changed =
       primary !== (customer.email ?? undefined) ||
-      dedupedAdditional.length !== (customer.additionalEmails ?? []).length
-    ) {
+      dedupedAdditional.length !== existingAdditional.length ||
+      dedupedAdditional.some(
+        (email, index) => email !== existingAdditional[index]
+      );
+
+    if (changed) {
       await this.customerRepository.update(customer.id, {
         email: primary,
         additionalEmails: dedupedAdditional,


### PR DESCRIPTION
A customer profile was found holding jason@khatraoenterprises.ca and Jason@khatraoenterprises.ca as two separate addresses. Same inbox, listed twice on every email dialog, and growing by one more entry each time somebody typed it with different capitalisation.

Three places decided whether an address was already known, and all three compared exactly: the dialog that lists them, the check that refuses a duplicate when adding one, and the save that writes them back to the customer. So a differently-cased address matched nothing and was appended as new.

There is now one definition of "same address" in libs/data, used by all of them. It compares case-insensitively but never rewrites what was typed — RFC 5321 does permit a case-sensitive local part, and not duplicating an address is a much smaller claim than deciding its canonical form. The first spelling seen is the one kept.

The save also collapses duplicates already on the record, so profiles that have accumulated them tidy up the next time one is saved rather than needing a migration.

## 📋 Description
Brief description of changes

## 🎯 Related Issue
Closes #(issue number)

## 📸 Screenshots (if applicable)
Add screenshots for UI changes

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No console errors
- [ ] Build passes locally (`yarn build`)
- [ ] Lint passes (`yarn lint`)

## 🧪 Testing Instructions
1. Step to test
2. Expected result

## 📝 Additional Notes
Any additional context or notes