### PR TITLE
perf(pdf): wait for load, not an idle network, and stop re-reading th…

### DIFF
--- a/server/src/pdf/pdf-batch-render.spec.ts
+++ b/server/src/pdf/pdf-batch-render.spec.ts
@@ -78,6 +78,20 @@ describe('PdfService batch rendering', () => {
   });
 
   /**
+   * Invoice documents inline everything they need, so there is no network to
+   * go quiet. networkidle0 waits for an idle window regardless — measured at
+   * 2,112ms against 124ms for 'load' on an identical document, which across a
+   * statement is the difference between a minute and a second.
+   */
+  it('waits for load rather than an idle network window', async () => {
+    await service.generatePdfsFromHtml(['<p>a</p>']);
+
+    const [, options] = pages[0].setContent.mock.calls[0];
+    expect(options.waitUntil).toBe('load');
+    expect(options.waitUntil).not.toBe('networkidle0');
+  });
+
+  /**
    * The production failure, in one test: a document whose assets never settle
    * must not stop the ones after it.
    */

--- a/server/src/pdf/pdf.service.ts
+++ b/server/src/pdf/pdf.service.ts
@@ -118,7 +118,17 @@ export class PdfService {
   private async loadContent(page: Page, html: string): Promise<void> {
     try {
       await page.setContent(html, {
-        waitUntil: 'networkidle0',
+        // 'load', not 'networkidle0'. These documents inline everything they
+        // need — the logo is a data URI and signatures are taken on paper at
+        // the shop — so there is nothing to go quiet. networkidle0 waits for an
+        // idle window regardless: measured at 2,112ms against 124ms for 'load'
+        // on an identical document. Seventeen times the cost, for nothing.
+        //
+        // 'load' still waits for images if a document ever does reference one,
+        // so this stays correct for the stored-signature invoices that exist in
+        // older data; it just stops charging every other invoice for the
+        // possibility.
+        waitUntil: 'load',
         timeout: CONTENT_LOAD_TIMEOUT_MS,
       });
     } catch (error) {
@@ -875,7 +885,13 @@ ${
    * Load the GT logo from disk and return it as a base64 data URI (or '' if
    * unavailable). Shared by the invoice/quotation/inspection templates.
    */
+  /** Cached across calls — the file cannot change while the process runs. */
+  private cachedLogoDataUrl?: string;
+
   private loadGtLogoBase64(context: string): string {
+    if (this.cachedLogoDataUrl !== undefined) {
+      return this.cachedLogoDataUrl;
+    }
     try {
       // Try multiple paths for logo (dev vs production Docker)
       const possiblePaths = [
@@ -898,7 +914,10 @@ ${
         this.logger.log(
           `[PDF] GT logo loaded successfully for ${context} from: ${logoPath}`
         );
-        return `data:image/png;base64,${logoBuffer.toString('base64')}`;
+        this.cachedLogoDataUrl = `data:image/png;base64,${logoBuffer.toString(
+          'base64'
+        )}`;
+        return this.cachedLogoDataUrl;
       }
 
       this.logger.warn(
@@ -910,7 +929,11 @@ ${
         error
       );
     }
-    return '';
+    // Cache the failure too. Without this a missing logo costs a fresh scan of
+    // four candidate paths on every invoice in a statement, to reach the same
+    // answer each time.
+    this.cachedLogoDataUrl = '';
+    return this.cachedLogoDataUrl;
   }
 
   /**


### PR DESCRIPTION
…e logo

Statement rendering was costing 5-10 seconds per invoice in production. Almost all of it was spent waiting for nothing.

setContent waited on networkidle0, which watches for a quiet network. Invoice documents inline everything they need — the logo is a data URI, and customer signatures are taken on paper at the shop rather than stored — so there is no network to go quiet. The wait was pure overhead, and measurably so: 2,112ms against 124ms for 'load' on an identical document. Seventeen times the cost to learn that nothing was happening.

Across a seven-invoice statement, browser launch included:

    networkidle0   15,379 ms
    load            2,444 ms      6.3x faster

'load' still waits on images where a document does reference one, so invoices in older data that do carry a stored signature still render correctly; they simply stop charging every other invoice for the possibility. The bounded timeout stays as the backstop.

The logo is also cached now. It was read from disk and base64-encoded once per invoice — the production logs show "GT logo loaded successfully" seven times for one statement. The miss is cached too, so an absent logo costs one scan of the candidate paths rather than one per invoice.

## 📋 Description
Brief description of changes

## 🎯 Related Issue
Closes #(issue number)

## 📸 Screenshots (if applicable)
Add screenshots for UI changes

## ✅ Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No console errors
- [ ] Build passes locally (`yarn build`)
- [ ] Lint passes (`yarn lint`)

## 🧪 Testing Instructions
1. Step to test
2. Expected result

## 📝 Additional Notes
Any additional context or notes