### PR TITLE
Repair order fixes: staff access, foreman visibility, delete-if-empty, carry work to next day

### DIFF
--- a/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
+++ b/apps/webApp/src/app/components/appointments/AppointmentDialog.tsx
@@ -51,6 +51,13 @@ interface AppointmentDialogProps {
    * calendar). A past date is clamped up to today; the past is never bookable.
    */
   initialDate?: Date;
+  /**
+   * Proposed new slot for an appointment being moved — work carried over to
+   * another day. Overrides the date, time and crew of the appointment being
+   * edited; everything else stays as it was booked. Pass a stable reference:
+   * it drives the prefill effect.
+   */
+  rescheduleTo?: { date: Date; time: string; employeeIds: string[] };
 }
 
 /** Local midnight of today — the earliest date an appointment can be booked. */
@@ -70,6 +77,7 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
   preselectedAppointmentType,
   preselectedServiceAddress,
   initialDate,
+  rescheduleTo,
 }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -127,9 +135,11 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
           customerId: appointment.customerId,
           vehicleId: appointment.vehicleId || '',
           employeeId: appointment.employeeId || '',
-          employeeIds: employeeIds,
-          scheduledDate: localDate,
-          scheduledTime: appointment.scheduledTime,
+          // A move proposes its own slot and crew; the rest of the booking is
+          // carried over untouched.
+          employeeIds: rescheduleTo?.employeeIds ?? employeeIds,
+          scheduledDate: rescheduleTo?.date ?? localDate,
+          scheduledTime: rescheduleTo?.time ?? appointment.scheduledTime,
           duration: appointment.duration,
           serviceType: appointment.serviceType,
           appointmentType: appointment.appointmentType || 'AT_GARAGE',
@@ -200,7 +210,17 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
     preselectedAppointmentType,
     preselectedServiceAddress,
     initialDate,
+    rescheduleTo,
   ]);
+
+  // A move carries the crew over as ids, so the chips can only be filled in
+  // once the assignable employee list has loaded.
+  useEffect(() => {
+    if (!open || !rescheduleTo || employees.length === 0) return;
+    setSelectedEmployees(
+      employees.filter((e) => rescheduleTo.employeeIds.includes(e.id))
+    );
+  }, [open, rescheduleTo, employees]);
 
   // Auto-adjust time if date changes to today and selected time is in the past
   useEffect(() => {
@@ -376,6 +396,10 @@ export const AppointmentDialog: React.FC<AppointmentDialogProps> = ({
 
       if (appointment) {
         await appointmentService.updateAppointment(appointment.id, {
+          // Moving unfinished work to another day is an internal scheduling
+          // change — the customer keeps their slot in the shop's queue and
+          // should not be texted about it.
+          ...(rescheduleTo ? { notifyCustomer: false } : {}),
           // Send '' to clear the vehicle, or the selected id to link/change it.
           vehicleId: formData.vehicleId || '',
           employeeIds:

--- a/apps/webApp/src/app/components/appointments/PaymentDialog.tsx
+++ b/apps/webApp/src/app/components/appointments/PaymentDialog.tsx
@@ -188,9 +188,9 @@ export const PaymentDialog: React.FC<PaymentDialogProps> = ({
         const staff = users.filter(
           (u) =>
             u.isActive &&
-            (u.role?.name === 'STAFF' ||
-              u.role?.name === 'ADMIN' ||
-              u.role?.name === 'SUPERVISOR')
+            ['STAFF', 'ADMIN', 'SUPERVISOR', 'FOREMAN'].includes(
+              u.role?.name || ''
+            )
         );
         const unique = staff.filter(
           (u, i, arr) => i === arr.findIndex((x) => x.id === u.id)

--- a/apps/webApp/src/app/components/payroll/CreateJobDialog.tsx
+++ b/apps/webApp/src/app/components/payroll/CreateJobDialog.tsx
@@ -103,12 +103,13 @@ export const CreateJobDialog: React.FC<CreateJobDialogProps> = ({
   const fetchEmployees = async () => {
     try {
       const users = await userService.getUsers();
-      // Include STAFF, ADMIN, and SUPERVISOR users in the dropdown
+      // Include active STAFF, ADMIN, SUPERVISOR and FOREMAN users in the
+      // dropdown — a foreman is paid for jobs like anyone else.
       const staffAndAdmins = users.filter(
         (u) =>
-          u.role?.name === 'STAFF' ||
-          u.role?.name === 'ADMIN' ||
-          u.role?.name === 'SUPERVISOR'
+          ['STAFF', 'ADMIN', 'SUPERVISOR', 'FOREMAN'].includes(
+            u.role?.name || ''
+          ) && u.isActive
       );
       setEmployees(staffAndAdmins);
     } catch (err) {

--- a/apps/webApp/src/app/components/repair-orders/AssignEmployeesDialog.tsx
+++ b/apps/webApp/src/app/components/repair-orders/AssignEmployeesDialog.tsx
@@ -16,6 +16,8 @@ import {
 import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { EmployeeChipSelector } from '../appointments/EmployeeChipSelector';
 
+const ASSIGNABLE_ROLES = ['STAFF', 'ADMIN', 'SUPERVISOR', 'FOREMAN'];
+
 interface AssignEmployeesDialogProps {
   open: boolean;
   onClose: () => void;
@@ -51,20 +53,25 @@ export function AssignEmployeesDialog({
       .getUsers()
       .then((allUsers) => {
         if (!active) return;
-        const staffAndAdmin = allUsers.filter(
+        // Same roles the appointment and RO-creation pickers offer — FOREMAN
+        // included, or a foreman assigned on the appointment could never be
+        // added here.
+        const currentUserIds = new Set(currentEmployees.map((e) => e.userId));
+        const assignable = allUsers.filter(
           (user) =>
-            (user.role?.name === 'STAFF' ||
-              user.role?.name === 'ADMIN' ||
-              user.role?.name === 'SUPERVISOR') &&
-            user.isActive
+            (ASSIGNABLE_ROLES.includes(user.role?.name ?? '') &&
+              user.isActive) ||
+            // Anyone already on the RO stays in the list whatever their role or
+            // active state. Saving replaces the whole crew, so dropping them
+            // from the options would silently unassign them.
+            currentUserIds.has(user.id)
         );
-        const uniqueUsers = staffAndAdmin.filter(
+        const uniqueUsers = assignable.filter(
           (user, index, self) =>
             index === self.findIndex((u) => u.id === user.id)
         );
         setEmployees(uniqueUsers);
         // Pre-select the RO's current employees by matching userId.
-        const currentUserIds = new Set(currentEmployees.map((e) => e.userId));
         setSelectedEmployees(
           uniqueUsers.filter((u) => currentUserIds.has(u.id))
         );

--- a/apps/webApp/src/app/components/repair-orders/ServiceDrawer.tsx
+++ b/apps/webApp/src/app/components/repair-orders/ServiceDrawer.tsx
@@ -60,7 +60,7 @@ const STATUS_COLORS: Record<
 };
 
 // Default labor rate ($/hour). LABOR cost = hours × rate.
-const DEFAULT_LABOR_RATE = 100;
+const DEFAULT_LABOR_RATE = 110;
 
 const CANNED_JOBS = [
   { description: 'Oil Change', type: 'LABOR' as ROServiceType, unitPrice: 45 },
@@ -348,7 +348,7 @@ export function ServiceDrawer({
 
   const handleTypeChange = (type: ROServiceType) => {
     setNewType(type);
-    // Switching to labor defaults the rate to $100/hr if none set yet.
+    // Switching to labor defaults the rate to $110/hr if none set yet.
     if (type === 'LABOR' && !newPrice) setNewPrice(DEFAULT_LABOR_RATE);
   };
 
@@ -372,7 +372,7 @@ export function ServiceDrawer({
     }
   };
 
-  // Labor items default to the $100/hr rate when the catalog has no price.
+  // Labor items default to the $110/hr rate when the catalog has no price.
   const priceFor = (type: ROServiceType, unitPrice: number) =>
     type === 'LABOR' ? unitPrice || DEFAULT_LABOR_RATE : unitPrice;
 

--- a/apps/webApp/src/app/pages/admin/EmployeeSchedule.tsx
+++ b/apps/webApp/src/app/pages/admin/EmployeeSchedule.tsx
@@ -26,6 +26,7 @@ interface User {
   firstName: string;
   lastName: string;
   email: string;
+  isActive: boolean;
   role: {
     name: string;
   };
@@ -56,7 +57,10 @@ export default function EmployeeSchedule() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [message, setMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
 
   useEffect(() => {
     fetchEmployees();
@@ -70,9 +74,13 @@ export default function EmployeeSchedule() {
         headers: { Authorization: `Bearer ${token}` },
       });
 
-      // Filter only STAFF, ADMIN, and SUPERVISOR users
+      // Filter only active STAFF, ADMIN, and SUPERVISOR users
       const staffAndAdmin = response.data.filter(
-        (user: User) => user.role.name === 'STAFF' || user.role.name === 'ADMIN' || user.role.name === 'SUPERVISOR'
+        (user: User) =>
+          (user.role.name === 'STAFF' ||
+            user.role.name === 'ADMIN' ||
+            user.role.name === 'SUPERVISOR') &&
+          user.isActive
       );
       setEmployees(staffAndAdmin);
     } catch (error) {
@@ -105,7 +113,7 @@ export default function EmployeeSchedule() {
       setMessage(null);
 
       const token = await window.Clerk?.session?.getToken();
-      const employee = employees.find(e => e.id === selectedEmployee);
+      const employee = employees.find((e) => e.id === selectedEmployee);
 
       if (!employee) {
         throw new Error('Employee not found');
@@ -119,14 +127,17 @@ export default function EmployeeSchedule() {
       const day = String(selectedDate.getDate()).padStart(2, '0');
       const dateStr = `${year}-${month}-${day}`;
 
-      const appointmentsResponse = await axios.get(`${API_URL}/api/appointments`, {
-        params: {
-          startDate: dateStr,
-          endDate: dateStr,
-          employeeId: selectedEmployee,
-        },
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const appointmentsResponse = await axios.get(
+        `${API_URL}/api/appointments`,
+        {
+          params: {
+            startDate: dateStr,
+            endDate: dateStr,
+            employeeId: selectedEmployee,
+          },
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
 
       const appointments: Appointment[] = appointmentsResponse.data;
 
@@ -136,14 +147,15 @@ export default function EmployeeSchedule() {
       });
 
       // Format appointments for email
-      const formattedAppointments = appointments.map(apt => ({
+      const formattedAppointments = appointments.map((apt) => ({
         time: formatTime(apt.scheduledTime),
         customerName: `${apt.customer.firstName} ${apt.customer.lastName}`,
         serviceType: apt.serviceType,
         vehicleInfo: apt.vehicle
           ? `${apt.vehicle.year} ${apt.vehicle.make} ${apt.vehicle.model}`
           : 'No vehicle specified',
-        location: apt.appointmentType === 'AT_GARAGE' ? 'At Shop' : 'Mobile Service',
+        location:
+          apt.appointmentType === 'AT_GARAGE' ? 'At Shop' : 'Mobile Service',
         duration: apt.duration,
         notes: apt.notes,
       }));
@@ -164,7 +176,11 @@ export default function EmployeeSchedule() {
 
       setMessage({
         type: 'success',
-        text: `Schedule email sent successfully to ${employee.firstName} ${employee.lastName} (${appointments.length} appointment${appointments.length !== 1 ? 's' : ''})`,
+        text: `Schedule email sent successfully to ${employee.firstName} ${
+          employee.lastName
+        } (${appointments.length} appointment${
+          appointments.length !== 1 ? 's' : ''
+        })`,
       });
     } catch (error: any) {
       console.error('Failed to send schedule:', error);
@@ -179,7 +195,11 @@ export default function EmployeeSchedule() {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Typography variant="h4" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Typography
+        variant="h4"
+        gutterBottom
+        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+      >
         <EmailIcon /> Employee Day Schedule
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
@@ -200,7 +220,8 @@ export default function EmployeeSchedule() {
                 >
                   {employees.map((employee) => (
                     <MenuItem key={employee.id} value={employee.id}>
-                      {employee.firstName} {employee.lastName} ({employee.role.name})
+                      {employee.firstName} {employee.lastName} (
+                      {employee.role.name})
                     </MenuItem>
                   ))}
                 </Select>
@@ -232,9 +253,17 @@ export default function EmployeeSchedule() {
 
             <Grid size={{ xs: 12 }}>
               <Button
-                variant={!selectedEmployee || sending ? 'outlined' : 'contained'}
+                variant={
+                  !selectedEmployee || sending ? 'outlined' : 'contained'
+                }
                 size="large"
-                startIcon={sending ? <CircularProgress size={20} color="inherit" /> : <SendIcon />}
+                startIcon={
+                  sending ? (
+                    <CircularProgress size={20} color="inherit" />
+                  ) : (
+                    <SendIcon />
+                  )
+                }
                 onClick={sendEmployeeSchedule}
                 disabled={!selectedEmployee || sending}
                 fullWidth
@@ -254,8 +283,13 @@ export default function EmployeeSchedule() {
           <ol>
             <li>Select an employee from the dropdown</li>
             <li>Choose the date for the schedule</li>
-            <li>Click "Send Schedule Email" to email their daily appointments</li>
-            <li>The email will include appointment times, customer names, services, and vehicle details</li>
+            <li>
+              Click "Send Schedule Email" to email their daily appointments
+            </li>
+            <li>
+              The email will include appointment times, customer names,
+              services, and vehicle details
+            </li>
           </ol>
         </Typography>
       </Box>

--- a/apps/webApp/src/app/pages/admin/appointments/AppointmentsManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/appointments/AppointmentsManagement.tsx
@@ -980,24 +980,18 @@ export const AppointmentsManagement: React.FC = () => {
                                 md: '120px',
                               },
                               border: 1,
-                              borderColor: hasAttentionNeeded
-                                ? 'warning.main'
-                                : isToday
-                                ? 'primary.main'
-                                : 'divider',
-                              borderWidth: hasAttentionNeeded
-                                ? { xs: 3, sm: 2 }
-                                : isToday
-                                ? 2
-                                : 1,
+                              // Only today gets a border of its own. Days
+                              // needing attention are called out by their
+                              // corner dot and the colour of what is inside
+                              // them, so the grid stays quiet enough to scan.
+                              borderColor: isToday ? 'primary.main' : 'divider',
+                              borderWidth: isToday ? 2 : 1,
+                              // Days needing attention are marked by their
+                              // border and corner dot only — filling the cell
+                              // drowned out everything inside it.
                               bgcolor: date
                                 ? isPast
                                   ? 'action.hover'
-                                  : hasAttentionNeeded
-                                  ? {
-                                      xs: 'warning.light',
-                                      sm: 'warning.lighter',
-                                    }
                                   : 'background.paper'
                                 : 'action.disabledBackground',
                               borderRadius: { xs: 1, sm: 1 },
@@ -1063,10 +1057,15 @@ export const AppointmentsManagement: React.FC = () => {
                                       : 'normal'
                                   }
                                   color={
-                                    hasAttentionNeeded
+                                    // Today reads white out of its filled
+                                    // circle. Its own colour would be lost
+                                    // there, and on a day that also needs
+                                    // attention the warning colour used to win
+                                    // and leave today with no cue at all.
+                                    isToday
+                                      ? 'primary.contrastText'
+                                      : hasAttentionNeeded
                                       ? 'warning.dark'
-                                      : isToday
-                                      ? 'primary.main'
                                       : isPast
                                       ? 'text.disabled'
                                       : 'text.primary'
@@ -1075,6 +1074,16 @@ export const AppointmentsManagement: React.FC = () => {
                                   sx={{
                                     fontSize: { xs: '0.75rem', sm: '0.875rem' },
                                     textAlign: 'center',
+                                    // A filled circle marks today the way a
+                                    // calendar is normally read at a glance.
+                                    ...(isToday && {
+                                      bgcolor: 'primary.main',
+                                      borderRadius: '50%',
+                                      width: { xs: 20, sm: 24 },
+                                      height: { xs: 20, sm: 24 },
+                                      lineHeight: { xs: '20px', sm: '24px' },
+                                      mx: 'auto',
+                                    }),
                                   }}
                                 >
                                   {date.getDate()}

--- a/apps/webApp/src/app/pages/admin/payroll/JobsManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/JobsManagement.tsx
@@ -201,7 +201,17 @@ export function JobsManagement() {
         })
       );
 
-      setEmployeeSummaries(summaries);
+      // Show active employees, and keep a deactivated one only while jobs of
+      // theirs are still pending or awaiting payment — the summaries have to
+      // be fetched first to know that.
+      setEmployeeSummaries(
+        summaries.filter(
+          (employee) =>
+            employee.isActive ||
+            employee.pendingJobs > 0 ||
+            employee.readyJobs > 0
+        )
+      );
       setError(null);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch employee data');

--- a/apps/webApp/src/app/pages/admin/payroll/PaymentsManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/PaymentsManagement.tsx
@@ -85,6 +85,8 @@ interface Employee {
   };
 }
 
+const PAYROLL_ROLES = ['STAFF', 'ADMIN', 'SUPERVISOR', 'FOREMAN'];
+
 interface EmployeePaymentSummary extends Employee {
   totalReadyJobs: number;
   totalReadyAmount: number;
@@ -108,17 +110,22 @@ export function PaymentsManagement() {
   const [payments, setPayments] = useState<PaymentResponseDto[]>([]);
   const [pendingJobs, setPendingJobs] = useState<JobResponseDto[]>([]);
   const [employees, setEmployees] = useState<Employee[]>([]);
-  const [employeePaymentSummaries, setEmployeePaymentSummaries] = useState<EmployeePaymentSummary[]>([]);
+  const [employeePaymentSummaries, setEmployeePaymentSummaries] = useState<
+    EmployeePaymentSummary[]
+  >([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [processDialogOpen, setProcessDialogOpen] = useState(false);
   const [selectedJob, setSelectedJob] = useState<JobResponseDto | null>(null);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
-  const [selectedPayment, setSelectedPayment] = useState<PaymentResponseDto | null>(null);
+  const [selectedPayment, setSelectedPayment] =
+    useState<PaymentResponseDto | null>(null);
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set());
   const [processingAllJobs, setProcessingAllJobs] = useState(false);
-  const [currentEmployeeJobs, setCurrentEmployeeJobs] = useState<JobResponseDto[]>([]);
+  const [currentEmployeeJobs, setCurrentEmployeeJobs] = useState<
+    JobResponseDto[]
+  >([]);
   const [currentJobIndex, setCurrentJobIndex] = useState(0);
 
   // Filters
@@ -148,76 +155,114 @@ export function PaymentsManagement() {
       const filterParams = {
         employeeId: filters.employeeId || undefined,
         status: filters.status ? (filters.status as PaymentStatus) : undefined,
-        paymentMethod: filters.paymentMethod ? (filters.paymentMethod as PaymentMethod) : undefined,
+        paymentMethod: filters.paymentMethod
+          ? (filters.paymentMethod as PaymentMethod)
+          : undefined,
         startDate: filters.startDate?.toISOString() || undefined,
         endDate: filters.endDate?.toISOString() || undefined,
       };
-      const payrollStartDate = (filters.startDate || startOfMonth(new Date())).toISOString();
-      const payrollEndDate = (filters.endDate || endOfMonth(new Date())).toISOString();
+      const payrollStartDate = (
+        filters.startDate || startOfMonth(new Date())
+      ).toISOString();
+      const payrollEndDate = (
+        filters.endDate || endOfMonth(new Date())
+      ).toISOString();
 
-      const [paymentsData, pendingJobsData, users, payrollSummary] = await Promise.all([
-        paymentService.getPayments(filterParams),
-        jobService.getJobsReadyForPayment(),
-        userService.getUsers(),
-        timeClockService.getPayrollSummary({
-          startDate: payrollStartDate,
-          endDate: payrollEndDate,
-        }),
-      ]);
+      const [paymentsData, pendingJobsData, users, payrollSummary] =
+        await Promise.all([
+          paymentService.getPayments(filterParams),
+          jobService.getJobsReadyForPayment(),
+          userService.getUsers(),
+          timeClockService.getPayrollSummary({
+            startDate: payrollStartDate,
+            endDate: payrollEndDate,
+          }),
+        ]);
 
       setPayments(paymentsData);
       setPendingJobs(pendingJobsData);
 
       // Calculate employee summaries after data is fetched
-      // Include STAFF, ADMIN, and SUPERVISOR users
-      const staffMembers = users.filter(u => u.role?.name === 'STAFF' || u.role?.name === 'ADMIN' || u.role?.name === 'SUPERVISOR');
+      // Include active STAFF, ADMIN, SUPERVISOR and FOREMAN users — plus
+      // anyone deactivated who is still owed money, so a final payout never
+      // disappears from the screen that settles it.
+      const owedEmployeeIds = new Set([
+        ...pendingJobsData.map((job) => job.employee?.id),
+        ...paymentsData
+          .filter((p) => p.status === 'PENDING')
+          .map((p) => p.employee?.id),
+      ]);
+      const staffMembers = users.filter(
+        (u) =>
+          PAYROLL_ROLES.includes(u.role?.name || '') &&
+          (u.isActive || owedEmployeeIds.has(u.id))
+      );
       setEmployees(staffMembers);
 
-      const summaries: EmployeePaymentSummary[] = staffMembers.map((employee) => {
-        // Get ready jobs for this employee
-        const readyJobs = pendingJobsData.filter(job => job.employee?.id === employee.id);
-        const readyAmount = readyJobs.reduce((sum, job) => sum + job.payAmount, 0);
+      const summaries: EmployeePaymentSummary[] = staffMembers.map(
+        (employee) => {
+          // Get ready jobs for this employee
+          const readyJobs = pendingJobsData.filter(
+            (job) => job.employee?.id === employee.id
+          );
+          const readyAmount = readyJobs.reduce(
+            (sum, job) => sum + job.payAmount,
+            0
+          );
 
-        // Get payments for this employee
-        const employeePayments = paymentsData.filter(p => p.employee?.id === employee.id);
-        const paidPayments = employeePayments.filter(p => p.status === 'PAID');
-        const pendingCount = employeePayments.filter(p => p.status === 'PENDING').length;
-        const paidAmount = paidPayments.reduce((sum, p) => sum + p.amount, 0);
+          // Get payments for this employee
+          const employeePayments = paymentsData.filter(
+            (p) => p.employee?.id === employee.id
+          );
+          const paidPayments = employeePayments.filter(
+            (p) => p.status === 'PAID'
+          );
+          const pendingCount = employeePayments.filter(
+            (p) => p.status === 'PENDING'
+          ).length;
+          const paidAmount = paidPayments.reduce((sum, p) => sum + p.amount, 0);
 
-        // Calculate Today, MTD, YTD earnings
-        const now = new Date();
-        const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-        const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-        const yearStart = new Date(now.getFullYear(), 0, 1);
+          // Calculate Today, MTD, YTD earnings
+          const now = new Date();
+          const todayStart = new Date(
+            now.getFullYear(),
+            now.getMonth(),
+            now.getDate()
+          );
+          const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+          const yearStart = new Date(now.getFullYear(), 0, 1);
 
-        const todayEarnings = paidPayments
-          .filter(p => p.paidAt && new Date(p.paidAt) >= todayStart)
-          .reduce((sum, p) => sum + p.amount, 0);
+          const todayEarnings = paidPayments
+            .filter((p) => p.paidAt && new Date(p.paidAt) >= todayStart)
+            .reduce((sum, p) => sum + p.amount, 0);
 
-        const mtdEarnings = paidPayments
-          .filter(p => p.paidAt && new Date(p.paidAt) >= monthStart)
-          .reduce((sum, p) => sum + p.amount, 0);
+          const mtdEarnings = paidPayments
+            .filter((p) => p.paidAt && new Date(p.paidAt) >= monthStart)
+            .reduce((sum, p) => sum + p.amount, 0);
 
-        const ytdEarnings = paidPayments
-          .filter(p => p.paidAt && new Date(p.paidAt) >= yearStart)
-          .reduce((sum, p) => sum + p.amount, 0);
-        const payrollEmployee = payrollSummary.employees.find(item => item.employee.id === employee.id);
+          const ytdEarnings = paidPayments
+            .filter((p) => p.paidAt && new Date(p.paidAt) >= yearStart)
+            .reduce((sum, p) => sum + p.amount, 0);
+          const payrollEmployee = payrollSummary.employees.find(
+            (item) => item.employee.id === employee.id
+          );
 
-        return {
-          ...employee,
-          totalReadyJobs: readyJobs.length,
-          totalReadyAmount: readyAmount,
-          totalPaidJobs: paidPayments.length,
-          totalPaidAmount: paidAmount,
-          pendingPayments: pendingCount,
-          todayEarnings,
-          mtdEarnings,
-          ytdEarnings,
-          payrollReadyHours: payrollEmployee?.unpaidApprovedHours || 0,
-          payrollReadyAmount: payrollEmployee?.hourlyPay || 0,
-          payrollProcessedHours: payrollEmployee?.processedHours || 0,
-        };
-      });
+          return {
+            ...employee,
+            totalReadyJobs: readyJobs.length,
+            totalReadyAmount: readyAmount,
+            totalPaidJobs: paidPayments.length,
+            totalPaidAmount: paidAmount,
+            pendingPayments: pendingCount,
+            todayEarnings,
+            mtdEarnings,
+            ytdEarnings,
+            payrollReadyHours: payrollEmployee?.unpaidApprovedHours || 0,
+            payrollReadyAmount: payrollEmployee?.hourlyPay || 0,
+            payrollProcessedHours: payrollEmployee?.processedHours || 0,
+          };
+        }
+      );
 
       setEmployeePaymentSummaries(summaries);
       setError(null);
@@ -240,7 +285,11 @@ export function PaymentsManagement() {
   const handleProcessTimePayroll = async (employee: EmployeePaymentSummary) => {
     const confirmed = await showConfirmation(
       'Process Payroll Hours',
-      `Process ${employee.payrollReadyHours.toFixed(2)} approved hours for ${getEmployeeName(employee)}? These hours will move out of unpaid payroll-ready hours.`,
+      `Process ${employee.payrollReadyHours.toFixed(
+        2
+      )} approved hours for ${getEmployeeName(
+        employee
+      )}? These hours will move out of unpaid payroll-ready hours.`,
       'Process Hours',
       'info'
     );
@@ -248,21 +297,30 @@ export function PaymentsManagement() {
     if (!confirmed) return;
 
     try {
-      const startDate = (filters.startDate || startOfMonth(new Date())).toISOString();
+      const startDate = (
+        filters.startDate || startOfMonth(new Date())
+      ).toISOString();
       const endDate = (filters.endDate || endOfMonth(new Date())).toISOString();
       const result = await timeClockService.processPayroll({
         employeeId: employee.id,
         startDate,
         endDate,
       });
-      setMessage(`Processed ${result.processedHours.toFixed(2)} payroll hours for ${getEmployeeName(employee)}`);
+      setMessage(
+        `Processed ${result.processedHours.toFixed(
+          2
+        )} payroll hours for ${getEmployeeName(employee)}`
+      );
       await fetchData();
     } catch (err: any) {
       setError(err.message || 'Failed to process payroll hours');
     }
   };
 
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>, payment: PaymentResponseDto) => {
+  const handleMenuOpen = (
+    event: React.MouseEvent<HTMLElement>,
+    payment: PaymentResponseDto
+  ) => {
     setMenuAnchor(event.currentTarget);
     setSelectedPayment(payment);
   };
@@ -277,7 +335,9 @@ export function PaymentsManagement() {
 
     const confirmed = await showConfirmation(
       'Delete Payment',
-      `Are you sure you want to delete this payment for "${getEmployeeName(selectedPayment.employee)}"? This action cannot be undone.`,
+      `Are you sure you want to delete this payment for "${getEmployeeName(
+        selectedPayment.employee
+      )}"? This action cannot be undone.`,
       'Delete',
       'error'
     );
@@ -292,8 +352,13 @@ export function PaymentsManagement() {
         }, 100);
       } catch (err: any) {
         console.error('Delete error:', err);
-        if (err.message?.includes('404') || err.message?.includes('Not Found')) {
-          setError('Payment not found. It may have already been deleted. Refreshing the list...');
+        if (
+          err.message?.includes('404') ||
+          err.message?.includes('Not Found')
+        ) {
+          setError(
+            'Payment not found. It may have already been deleted. Refreshing the list...'
+          );
           await fetchData();
         } else {
           setError(err.message || 'Failed to delete payment');
@@ -308,7 +373,9 @@ export function PaymentsManagement() {
 
     const confirmed = await showConfirmation(
       'Revert Payment Status',
-      `Are you sure you want to revert this payment status back to PENDING? This will also change the related job status back to READY for reprocessing. Payment: $${selectedPayment.amount.toFixed(2)} for ${getEmployeeName(selectedPayment.employee)}.`,
+      `Are you sure you want to revert this payment status back to PENDING? This will also change the related job status back to READY for reprocessing. Payment: $${selectedPayment.amount.toFixed(
+        2
+      )} for ${getEmployeeName(selectedPayment.employee)}.`,
       'Revert Status',
       'warning'
     );
@@ -331,11 +398,16 @@ export function PaymentsManagement() {
 
   const getStatusColor = (status: PaymentStatus) => {
     switch (status) {
-      case PaymentStatus.PENDING: return 'warning';
-      case PaymentStatus.PAID: return 'success';
-      case PaymentStatus.FAILED: return 'error';
-      case PaymentStatus.CANCELLED: return 'default';
-      default: return 'default';
+      case PaymentStatus.PENDING:
+        return 'warning';
+      case PaymentStatus.PAID:
+        return 'success';
+      case PaymentStatus.FAILED:
+        return 'error';
+      case PaymentStatus.CANCELLED:
+        return 'default';
+      default:
+        return 'default';
     }
   };
 
@@ -351,27 +423,41 @@ export function PaymentsManagement() {
 
   const getEmployeeName = (employee: any) => {
     if (!employee) return 'Unknown';
-    const name = [employee.firstName, employee.lastName].filter(Boolean).join(' ');
+    const name = [employee.firstName, employee.lastName]
+      .filter(Boolean)
+      .join(' ');
     return name || employee.email;
   };
 
   const getEmployeeInitials = (employee: Employee) => {
     const firstInitial = employee.firstName?.charAt(0)?.toUpperCase() || '';
     const lastInitial = employee.lastName?.charAt(0)?.toUpperCase() || '';
-    return `${firstInitial}${lastInitial}` || employee.email.charAt(0).toUpperCase();
+    return (
+      `${firstInitial}${lastInitial}` || employee.email.charAt(0).toUpperCase()
+    );
   };
 
   const getAvatarColor = (email: string) => {
     const avatarColors = [
-      '#1976d2', '#388e3c', '#f57c00', '#d32f2f', '#7b1fa2',
-      '#00796b', '#c2185b', '#5d4037', '#616161', '#e64a19'
+      '#1976d2',
+      '#388e3c',
+      '#f57c00',
+      '#d32f2f',
+      '#7b1fa2',
+      '#00796b',
+      '#c2185b',
+      '#5d4037',
+      '#616161',
+      '#e64a19',
     ];
     const charCode = email.charCodeAt(0) + email.charCodeAt(email.length - 1);
     return avatarColors[charCode % avatarColors.length];
   };
 
   const handleProcessJobsOneByOne = async (employeeId: string) => {
-    const employeeReadyJobs = pendingJobs.filter(job => job.employee?.id === employeeId);
+    const employeeReadyJobs = pendingJobs.filter(
+      (job) => job.employee?.id === employeeId
+    );
     if (employeeReadyJobs.length > 0) {
       setCurrentEmployeeJobs(employeeReadyJobs);
       setCurrentJobIndex(0);
@@ -382,7 +468,7 @@ export function PaymentsManagement() {
   };
 
   const toggleCardExpanded = (employeeId: string) => {
-    setExpandedCards(prev => {
+    setExpandedCards((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(employeeId)) {
         newSet.delete(employeeId);
@@ -395,7 +481,14 @@ export function PaymentsManagement() {
 
   if (loading && !payments.length && !pendingJobs.length) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 400 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: 400,
+        }}
+      >
         <Typography>Loading payment data...</Typography>
       </Box>
     );
@@ -405,9 +498,28 @@ export function PaymentsManagement() {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <Box sx={{ p: { xs: 0, sm: 3 } }}>
         {/* Header */}
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, px: { xs: 1.5, sm: 0 } }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 } }}>
-            <PaymentIcon sx={{ fontSize: { xs: 28, sm: 32 }, color: colors.semantic.success }} />
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 3,
+            px: { xs: 1.5, sm: 0 },
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: { xs: 1, sm: 2 },
+            }}
+          >
+            <PaymentIcon
+              sx={{
+                fontSize: { xs: 28, sm: 32 },
+                color: colors.semantic.success,
+              }}
+            />
             <Typography variant={isMobile ? 'h5' : 'h4'} fontWeight="bold">
               Payments{isMobile ? '' : ' Management'}
             </Typography>
@@ -415,12 +527,28 @@ export function PaymentsManagement() {
         </Box>
 
         {error && (
-          <Alert severity="error" sx={{ mb: 3, mx: { xs: 1.5, sm: 0 }, borderRadius: { xs: 0, sm: 1 } }} onClose={() => setError(null)}>
+          <Alert
+            severity="error"
+            sx={{
+              mb: 3,
+              mx: { xs: 1.5, sm: 0 },
+              borderRadius: { xs: 0, sm: 1 },
+            }}
+            onClose={() => setError(null)}
+          >
             {error}
           </Alert>
         )}
         {message && (
-          <Alert severity="success" sx={{ mb: 3, mx: { xs: 1.5, sm: 0 }, borderRadius: { xs: 0, sm: 1 } }} onClose={() => setMessage(null)}>
+          <Alert
+            severity="success"
+            sx={{
+              mb: 3,
+              mx: { xs: 1.5, sm: 0 },
+              borderRadius: { xs: 0, sm: 1 },
+            }}
+            onClose={() => setMessage(null)}
+          >
             {message}
           </Alert>
         )}
@@ -444,37 +572,33 @@ export function PaymentsManagement() {
                   },
                 }}
               >
-              <Tab
-                label={
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <GroupIcon fontSize={isTablet ? 'small' : 'medium'} />
-                    <Box>
-                      Employees ({employeePaymentSummaries.length})
+                <Tab
+                  label={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <GroupIcon fontSize={isTablet ? 'small' : 'medium'} />
+                      <Box>Employees ({employeePaymentSummaries.length})</Box>
                     </Box>
-                  </Box>
-                }
-              />
-              <Tab
-                label={
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <AssignmentIcon fontSize={isTablet ? 'small' : 'medium'} />
-                    <Box>
-                      Jobs Ready ({pendingJobs.length})
+                  }
+                />
+                <Tab
+                  label={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <AssignmentIcon
+                        fontSize={isTablet ? 'small' : 'medium'}
+                      />
+                      <Box>Jobs Ready ({pendingJobs.length})</Box>
                     </Box>
-                  </Box>
-                }
-              />
-              <Tab
-                label={
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <PaymentIcon fontSize={isTablet ? 'small' : 'medium'} />
-                    <Box>
-                      History ({payments.length})
+                  }
+                />
+                <Tab
+                  label={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <PaymentIcon fontSize={isTablet ? 'small' : 'medium'} />
+                      <Box>History ({payments.length})</Box>
                     </Box>
-                  </Box>
-                }
-              />
-            </Tabs>
+                  }
+                />
+              </Tabs>
             </Paper>
           )}
 
@@ -485,275 +609,463 @@ export function PaymentsManagement() {
             <Box sx={{ py: 1, px: 0.5 }}>
               {/* Employee Cards - Compact Mobile View */}
               <Grid container spacing={1.5}>
-              {employeePaymentSummaries.map((employee) => {
-                const isExpanded = expandedCards.has(employee.id);
-                return (
-                  <Grid size={{ xs: 12 }} key={employee.id}>
-                    <Card
-                      sx={{
-                        transition: 'all 0.2s ease-in-out',
-                        border: `1px solid ${colors.neutral[200]}`,
-                        borderRadius: 2,
-                        '&:hover': {
-                          borderColor: colors.primary.main,
-                          boxShadow: 2,
-                        },
-                      }}
-                    >
-                      {/* Compact Header */}
-                      <CardContent sx={{ p: 1.5, pb: 1.5 }}>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                          <Avatar
+                {employeePaymentSummaries.map((employee) => {
+                  const isExpanded = expandedCards.has(employee.id);
+                  return (
+                    <Grid size={{ xs: 12 }} key={employee.id}>
+                      <Card
+                        sx={{
+                          transition: 'all 0.2s ease-in-out',
+                          border: `1px solid ${colors.neutral[200]}`,
+                          borderRadius: 2,
+                          '&:hover': {
+                            borderColor: colors.primary.main,
+                            boxShadow: 2,
+                          },
+                        }}
+                      >
+                        {/* Compact Header */}
+                        <CardContent sx={{ p: 1.5, pb: 1.5 }}>
+                          <Box
                             sx={{
-                              width: 48,
-                              height: 48,
-                              bgcolor: getAvatarColor(employee.email),
-                              fontSize: '1.1rem',
-                              fontWeight: 600,
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                              mb: 1,
                             }}
                           >
-                            {getEmployeeInitials(employee)}
-                          </Avatar>
-                          <Box sx={{ flex: 1, minWidth: 0 }}>
-                            <Typography variant="subtitle1" fontWeight="600" noWrap>
-                              {getEmployeeName(employee)}
-                            </Typography>
-                            <Chip
-                              label={employee.role?.name || 'STAFF'}
-                              size="small"
+                            <Avatar
                               sx={{
-                                height: 20,
-                                fontSize: '0.7rem',
-                                bgcolor: colors.neutral[100],
-                                border: `1px solid ${colors.neutral[300]}`,
-                              }}
-                            />
-                          </Box>
-                          <IconButton
-                            size="small"
-                            onClick={() => toggleCardExpanded(employee.id)}
-                            sx={{ ml: 'auto' }}
-                          >
-                            {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                          </IconButton>
-                        </Box>
-
-                        {/* Key Metrics - Always Visible */}
-                        <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
-                          <Box
-                            sx={{
-                              flex: 1,
-                              p: 1,
-                              bgcolor: colors.semantic.successLight + '15',
-                              border: `1px solid ${colors.semantic.successLight}`,
-                              borderRadius: 1,
-                              textAlign: 'center',
-                            }}
-                          >
-                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem', mb: 0.3 }}>
-                              Ready to Pay
-                            </Typography>
-                            <Typography variant="h6" fontWeight="bold" color="success.main" sx={{ fontSize: '1.1rem' }}>
-                              ${employee.totalReadyAmount.toFixed(0)}
-                            </Typography>
-                            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                              {employee.totalReadyJobs} jobs
-                            </Typography>
-                          </Box>
-                          <Box
-                            sx={{
-                              flex: 1,
-                              p: 1,
-                              bgcolor: colors.semantic.infoLight + '15',
-                              border: `1px solid ${colors.semantic.infoLight}`,
-                              borderRadius: 1,
-                              textAlign: 'center',
-                            }}
-                          >
-                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem', mb: 0.3 }}>
-                              Ready Hours
-                            </Typography>
-                            <Typography variant="h6" fontWeight="bold" color="info.main" sx={{ fontSize: '1.1rem' }}>
-                              ${employee.payrollReadyAmount.toFixed(0)}
-                            </Typography>
-                            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                              {employee.payrollReadyHours.toFixed(2)} hrs
-                            </Typography>
-                          </Box>
-                          <Box
-                            sx={{
-                              flex: 1,
-                              p: 1,
-                              bgcolor: colors.primary.light + '10',
-                              border: `1px solid ${colors.primary.light}`,
-                              borderRadius: 1,
-                              textAlign: 'center',
-                            }}
-                          >
-                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem', mb: 0.3 }}>
-                              MTD Earnings
-                            </Typography>
-                            <Typography variant="h6" fontWeight="bold" color="primary.main" sx={{ fontSize: '1.1rem' }}>
-                              ${employee.mtdEarnings.toFixed(0)}
-                            </Typography>
-                            <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.7rem' }}>
-                              {employee.totalPaidJobs} paid
-                            </Typography>
-                          </Box>
-                        </Box>
-
-                        {/* Expandable Details */}
-                        {isExpanded && (
-                          <Box sx={{ mt: 2, pt: 2, borderTop: `1px solid ${colors.neutral[200]}` }}>
-                            {/* Earnings Overview */}
-                            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1, mb: 2 }}>
-                              <Box sx={{ textAlign: 'center' }}>
-                                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
-                                  Today
-                                </Typography>
-                                <Typography variant="body2" fontWeight="600" color="info.main">
-                                  ${employee.todayEarnings.toFixed(2)}
-                                </Typography>
-                              </Box>
-                              <Box sx={{ textAlign: 'center' }}>
-                                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
-                                  MTD
-                                </Typography>
-                                <Typography variant="body2" fontWeight="600" color="primary.main">
-                                  ${employee.mtdEarnings.toFixed(2)}
-                                </Typography>
-                              </Box>
-                              <Box sx={{ textAlign: 'center' }}>
-                                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
-                                  YTD
-                                </Typography>
-                                <Typography variant="body2" fontWeight="600" color="success.main">
-                                  ${employee.ytdEarnings.toFixed(2)}
-                                </Typography>
-                              </Box>
-                            </Box>
-
-                            {/* Payment Status Counts */}
-                            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1, mb: 2 }}>
-                              <Box sx={{ textAlign: 'center', p: 1, bgcolor: colors.semantic.infoLight + '10', borderRadius: 1 }}>
-                                <Typography variant="h6" fontWeight="bold" color="info.main">
-                                  {employee.totalReadyJobs}
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary">
-                                  Ready
-                                </Typography>
-                              </Box>
-                              <Box sx={{ textAlign: 'center', p: 1, bgcolor: colors.semantic.warningLight + '10', borderRadius: 1 }}>
-                                <Typography variant="h6" fontWeight="bold" color="warning.main">
-                                  {employee.pendingPayments}
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary">
-                                  Pending
-                                </Typography>
-                              </Box>
-                              <Box sx={{ textAlign: 'center', p: 1, bgcolor: colors.semantic.successLight + '10', borderRadius: 1 }}>
-                                <Typography variant="h6" fontWeight="bold" color="success.main">
-                                  {employee.totalPaidJobs}
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary">
-                                  Paid
-                                </Typography>
-                              </Box>
-                            </Box>
-
-                            <Box
-                              sx={{
-                                p: 1.5,
-                                bgcolor: colors.semantic.infoLight + '10',
-                                borderRadius: 1,
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                                mb: 2,
+                                width: 48,
+                                height: 48,
+                                bgcolor: getAvatarColor(employee.email),
+                                fontSize: '1.1rem',
+                                fontWeight: 600,
                               }}
                             >
-                              <Box>
-                                <Typography variant="body2" color="text.secondary" fontWeight="600">
-                                  Approved Hours Ready
-                                </Typography>
-                                <Typography variant="caption" color="text.secondary">
-                                  {employee.payrollProcessedHours.toFixed(2)} hrs processed this period
-                                </Typography>
-                              </Box>
-                              <Typography variant="h6" fontWeight="bold" color="info.main">
+                              {getEmployeeInitials(employee)}
+                            </Avatar>
+                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                              <Typography
+                                variant="subtitle1"
+                                fontWeight="600"
+                                noWrap
+                              >
+                                {getEmployeeName(employee)}
+                              </Typography>
+                              <Chip
+                                label={employee.role?.name || 'STAFF'}
+                                size="small"
+                                sx={{
+                                  height: 20,
+                                  fontSize: '0.7rem',
+                                  bgcolor: colors.neutral[100],
+                                  border: `1px solid ${colors.neutral[300]}`,
+                                }}
+                              />
+                            </Box>
+                            <IconButton
+                              size="small"
+                              onClick={() => toggleCardExpanded(employee.id)}
+                              sx={{ ml: 'auto' }}
+                            >
+                              {isExpanded ? (
+                                <ExpandLessIcon />
+                              ) : (
+                                <ExpandMoreIcon />
+                              )}
+                            </IconButton>
+                          </Box>
+
+                          {/* Key Metrics - Always Visible */}
+                          <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
+                            <Box
+                              sx={{
+                                flex: 1,
+                                p: 1,
+                                bgcolor: colors.semantic.successLight + '15',
+                                border: `1px solid ${colors.semantic.successLight}`,
+                                borderRadius: 1,
+                                textAlign: 'center',
+                              }}
+                            >
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{
+                                  display: 'block',
+                                  fontSize: '0.65rem',
+                                  mb: 0.3,
+                                }}
+                              >
+                                Ready to Pay
+                              </Typography>
+                              <Typography
+                                variant="h6"
+                                fontWeight="bold"
+                                color="success.main"
+                                sx={{ fontSize: '1.1rem' }}
+                              >
+                                ${employee.totalReadyAmount.toFixed(0)}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ fontSize: '0.7rem' }}
+                              >
+                                {employee.totalReadyJobs} jobs
+                              </Typography>
+                            </Box>
+                            <Box
+                              sx={{
+                                flex: 1,
+                                p: 1,
+                                bgcolor: colors.semantic.infoLight + '15',
+                                border: `1px solid ${colors.semantic.infoLight}`,
+                                borderRadius: 1,
+                                textAlign: 'center',
+                              }}
+                            >
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{
+                                  display: 'block',
+                                  fontSize: '0.65rem',
+                                  mb: 0.3,
+                                }}
+                              >
+                                Ready Hours
+                              </Typography>
+                              <Typography
+                                variant="h6"
+                                fontWeight="bold"
+                                color="info.main"
+                                sx={{ fontSize: '1.1rem' }}
+                              >
+                                ${employee.payrollReadyAmount.toFixed(0)}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ fontSize: '0.7rem' }}
+                              >
                                 {employee.payrollReadyHours.toFixed(2)} hrs
                               </Typography>
                             </Box>
-
-                            {/* Total Paid */}
                             <Box
                               sx={{
-                                p: 1.5,
-                                bgcolor: colors.neutral[50],
+                                flex: 1,
+                                p: 1,
+                                bgcolor: colors.primary.light + '10',
+                                border: `1px solid ${colors.primary.light}`,
                                 borderRadius: 1,
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                                mb: 2,
+                                textAlign: 'center',
                               }}
                             >
-                              <Typography variant="body2" color="text.secondary" fontWeight="600">
-                                Total Paid (All Time)
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{
+                                  display: 'block',
+                                  fontSize: '0.65rem',
+                                  mb: 0.3,
+                                }}
+                              >
+                                MTD Earnings
                               </Typography>
-                              <Typography variant="h6" fontWeight="bold" color="primary.main">
-                                ${employee.totalPaidAmount.toFixed(2)}
+                              <Typography
+                                variant="h6"
+                                fontWeight="bold"
+                                color="primary.main"
+                                sx={{ fontSize: '1.1rem' }}
+                              >
+                                ${employee.mtdEarnings.toFixed(0)}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                color="text.secondary"
+                                sx={{ fontSize: '0.7rem' }}
+                              >
+                                {employee.totalPaidJobs} paid
                               </Typography>
                             </Box>
                           </Box>
-                        )}
 
-                        {/* Process Payment Button */}
-                        <Button
-                          fullWidth
-                          size="small"
-                          variant="contained"
-                          startIcon={<PaymentIcon />}
-                          onClick={() => handleProcessJobsOneByOne(employee.id)}
-                          disabled={employee.totalReadyJobs === 0}
-                          sx={{
-                            background: employee.totalReadyJobs > 0
-                              ? `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`
-                              : colors.neutral[300],
-                            fontWeight: 600,
-                            '&:hover': {
-                              background: employee.totalReadyJobs > 0
-                                ? `linear-gradient(135deg, ${colors.semantic.successDark} 0%, ${colors.semantic.success} 100%)`
-                                : colors.neutral[300],
-                            },
-                            '&.Mui-disabled': {
-                              background: colors.neutral[300],
-                              color: colors.neutral[500],
-                            },
-                          }}
-                        >
-                          Process {employee.totalReadyJobs > 0 ? `${employee.totalReadyJobs} Jobs` : 'Jobs'}
-                        </Button>
-                        <Button
-                          fullWidth
-                          size="small"
-                          variant="outlined"
-                          startIcon={<AccessTimeIcon />}
-                          onClick={() => handleProcessTimePayroll(employee)}
-                          disabled={employee.payrollReadyHours <= 0}
-                          sx={{ mt: 1, fontWeight: 600 }}
-                        >
-                          Process {employee.payrollReadyHours > 0 ? `${employee.payrollReadyHours.toFixed(2)} Hrs` : 'Hours'}
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  </Grid>
-                );
-              })}
-            </Grid>
+                          {/* Expandable Details */}
+                          {isExpanded && (
+                            <Box
+                              sx={{
+                                mt: 2,
+                                pt: 2,
+                                borderTop: `1px solid ${colors.neutral[200]}`,
+                              }}
+                            >
+                              {/* Earnings Overview */}
+                              <Box
+                                sx={{
+                                  display: 'grid',
+                                  gridTemplateColumns: '1fr 1fr 1fr',
+                                  gap: 1,
+                                  mb: 2,
+                                }}
+                              >
+                                <Box sx={{ textAlign: 'center' }}>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{ fontSize: '0.65rem' }}
+                                  >
+                                    Today
+                                  </Typography>
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight="600"
+                                    color="info.main"
+                                  >
+                                    ${employee.todayEarnings.toFixed(2)}
+                                  </Typography>
+                                </Box>
+                                <Box sx={{ textAlign: 'center' }}>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{ fontSize: '0.65rem' }}
+                                  >
+                                    MTD
+                                  </Typography>
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight="600"
+                                    color="primary.main"
+                                  >
+                                    ${employee.mtdEarnings.toFixed(2)}
+                                  </Typography>
+                                </Box>
+                                <Box sx={{ textAlign: 'center' }}>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{ fontSize: '0.65rem' }}
+                                  >
+                                    YTD
+                                  </Typography>
+                                  <Typography
+                                    variant="body2"
+                                    fontWeight="600"
+                                    color="success.main"
+                                  >
+                                    ${employee.ytdEarnings.toFixed(2)}
+                                  </Typography>
+                                </Box>
+                              </Box>
+
+                              {/* Payment Status Counts */}
+                              <Box
+                                sx={{
+                                  display: 'grid',
+                                  gridTemplateColumns: '1fr 1fr 1fr',
+                                  gap: 1,
+                                  mb: 2,
+                                }}
+                              >
+                                <Box
+                                  sx={{
+                                    textAlign: 'center',
+                                    p: 1,
+                                    bgcolor: colors.semantic.infoLight + '10',
+                                    borderRadius: 1,
+                                  }}
+                                >
+                                  <Typography
+                                    variant="h6"
+                                    fontWeight="bold"
+                                    color="info.main"
+                                  >
+                                    {employee.totalReadyJobs}
+                                  </Typography>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                  >
+                                    Ready
+                                  </Typography>
+                                </Box>
+                                <Box
+                                  sx={{
+                                    textAlign: 'center',
+                                    p: 1,
+                                    bgcolor:
+                                      colors.semantic.warningLight + '10',
+                                    borderRadius: 1,
+                                  }}
+                                >
+                                  <Typography
+                                    variant="h6"
+                                    fontWeight="bold"
+                                    color="warning.main"
+                                  >
+                                    {employee.pendingPayments}
+                                  </Typography>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                  >
+                                    Pending
+                                  </Typography>
+                                </Box>
+                                <Box
+                                  sx={{
+                                    textAlign: 'center',
+                                    p: 1,
+                                    bgcolor:
+                                      colors.semantic.successLight + '10',
+                                    borderRadius: 1,
+                                  }}
+                                >
+                                  <Typography
+                                    variant="h6"
+                                    fontWeight="bold"
+                                    color="success.main"
+                                  >
+                                    {employee.totalPaidJobs}
+                                  </Typography>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                  >
+                                    Paid
+                                  </Typography>
+                                </Box>
+                              </Box>
+
+                              <Box
+                                sx={{
+                                  p: 1.5,
+                                  bgcolor: colors.semantic.infoLight + '10',
+                                  borderRadius: 1,
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  alignItems: 'center',
+                                  mb: 2,
+                                }}
+                              >
+                                <Box>
+                                  <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                    fontWeight="600"
+                                  >
+                                    Approved Hours Ready
+                                  </Typography>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                  >
+                                    {employee.payrollProcessedHours.toFixed(2)}{' '}
+                                    hrs processed this period
+                                  </Typography>
+                                </Box>
+                                <Typography
+                                  variant="h6"
+                                  fontWeight="bold"
+                                  color="info.main"
+                                >
+                                  {employee.payrollReadyHours.toFixed(2)} hrs
+                                </Typography>
+                              </Box>
+
+                              {/* Total Paid */}
+                              <Box
+                                sx={{
+                                  p: 1.5,
+                                  bgcolor: colors.neutral[50],
+                                  borderRadius: 1,
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  alignItems: 'center',
+                                  mb: 2,
+                                }}
+                              >
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                  fontWeight="600"
+                                >
+                                  Total Paid (All Time)
+                                </Typography>
+                                <Typography
+                                  variant="h6"
+                                  fontWeight="bold"
+                                  color="primary.main"
+                                >
+                                  ${employee.totalPaidAmount.toFixed(2)}
+                                </Typography>
+                              </Box>
+                            </Box>
+                          )}
+
+                          {/* Process Payment Button */}
+                          <Button
+                            fullWidth
+                            size="small"
+                            variant="contained"
+                            startIcon={<PaymentIcon />}
+                            onClick={() =>
+                              handleProcessJobsOneByOne(employee.id)
+                            }
+                            disabled={employee.totalReadyJobs === 0}
+                            sx={{
+                              background:
+                                employee.totalReadyJobs > 0
+                                  ? `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`
+                                  : colors.neutral[300],
+                              fontWeight: 600,
+                              '&:hover': {
+                                background:
+                                  employee.totalReadyJobs > 0
+                                    ? `linear-gradient(135deg, ${colors.semantic.successDark} 0%, ${colors.semantic.success} 100%)`
+                                    : colors.neutral[300],
+                              },
+                              '&.Mui-disabled': {
+                                background: colors.neutral[300],
+                                color: colors.neutral[500],
+                              },
+                            }}
+                          >
+                            Process{' '}
+                            {employee.totalReadyJobs > 0
+                              ? `${employee.totalReadyJobs} Jobs`
+                              : 'Jobs'}
+                          </Button>
+                          <Button
+                            fullWidth
+                            size="small"
+                            variant="outlined"
+                            startIcon={<AccessTimeIcon />}
+                            onClick={() => handleProcessTimePayroll(employee)}
+                            disabled={employee.payrollReadyHours <= 0}
+                            sx={{ mt: 1, fontWeight: 600 }}
+                          >
+                            Process{' '}
+                            {employee.payrollReadyHours > 0
+                              ? `${employee.payrollReadyHours.toFixed(2)} Hrs`
+                              : 'Hours'}
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    </Grid>
+                  );
+                })}
+              </Grid>
 
               {employeePaymentSummaries.length === 0 && (
-                <Paper sx={{ p: 4, textAlign: 'center', mx: 1.5, borderRadius: 0 }}>
-                  <GroupIcon sx={{ fontSize: 64, color: colors.neutral[400], mb: 2 }} />
+                <Paper
+                  sx={{ p: 4, textAlign: 'center', mx: 1.5, borderRadius: 0 }}
+                >
+                  <GroupIcon
+                    sx={{ fontSize: 64, color: colors.neutral[400], mb: 2 }}
+                  />
                   <Typography variant="h6" color="text.secondary">
                     No employees found
                   </Typography>
@@ -782,7 +1094,14 @@ export function PaymentsManagement() {
                         >
                           {/* Compact Header */}
                           <CardContent sx={{ p: 2, pb: 1.5 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 1.5,
+                                mb: 1.5,
+                              }}
+                            >
                               <Avatar
                                 sx={{
                                   width: 48,
@@ -795,7 +1114,11 @@ export function PaymentsManagement() {
                                 {getEmployeeInitials(employee)}
                               </Avatar>
                               <Box sx={{ flex: 1, minWidth: 0 }}>
-                                <Typography variant="subtitle1" fontWeight="600" noWrap>
+                                <Typography
+                                  variant="subtitle1"
+                                  fontWeight="600"
+                                  noWrap
+                                >
                                   {getEmployeeName(employee)}
                                 </Typography>
                                 <Chip
@@ -814,7 +1137,11 @@ export function PaymentsManagement() {
                                 onClick={() => toggleCardExpanded(employee.id)}
                                 sx={{ ml: 'auto' }}
                               >
-                                {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                                {isExpanded ? (
+                                  <ExpandLessIcon />
+                                ) : (
+                                  <ExpandMoreIcon />
+                                )}
                               </IconButton>
                             </Box>
 
@@ -830,13 +1157,28 @@ export function PaymentsManagement() {
                                   textAlign: 'center',
                                 }}
                               >
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem', mb: 0.5 }}>
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{
+                                    display: 'block',
+                                    fontSize: '0.65rem',
+                                    mb: 0.5,
+                                  }}
+                                >
                                   Ready to Pay
                                 </Typography>
-                                <Typography variant="h6" fontWeight="bold" color="success.main">
+                                <Typography
+                                  variant="h6"
+                                  fontWeight="bold"
+                                  color="success.main"
+                                >
                                   ${employee.totalReadyAmount.toFixed(0)}
                                 </Typography>
-                                <Typography variant="caption" color="text.secondary">
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
                                   {employee.totalReadyJobs} jobs
                                 </Typography>
                               </Box>
@@ -850,13 +1192,28 @@ export function PaymentsManagement() {
                                   textAlign: 'center',
                                 }}
                               >
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem', mb: 0.5 }}>
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{
+                                    display: 'block',
+                                    fontSize: '0.65rem',
+                                    mb: 0.5,
+                                  }}
+                                >
                                   Ready Hours
                                 </Typography>
-                                <Typography variant="h6" fontWeight="bold" color="info.main">
+                                <Typography
+                                  variant="h6"
+                                  fontWeight="bold"
+                                  color="info.main"
+                                >
                                   ${employee.payrollReadyAmount.toFixed(0)}
                                 </Typography>
-                                <Typography variant="caption" color="text.secondary">
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
                                   {employee.payrollReadyHours.toFixed(2)} hrs
                                 </Typography>
                               </Box>
@@ -870,13 +1227,28 @@ export function PaymentsManagement() {
                                   textAlign: 'center',
                                 }}
                               >
-                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem', mb: 0.5 }}>
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{
+                                    display: 'block',
+                                    fontSize: '0.65rem',
+                                    mb: 0.5,
+                                  }}
+                                >
                                   MTD Earnings
                                 </Typography>
-                                <Typography variant="h6" fontWeight="bold" color="primary.main">
+                                <Typography
+                                  variant="h6"
+                                  fontWeight="bold"
+                                  color="primary.main"
+                                >
                                   ${employee.mtdEarnings.toFixed(0)}
                                 </Typography>
-                                <Typography variant="caption" color="text.secondary">
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
                                   {employee.totalPaidJobs} paid
                                 </Typography>
                               </Box>
@@ -884,58 +1256,146 @@ export function PaymentsManagement() {
 
                             {/* Expandable Details */}
                             {isExpanded && (
-                              <Box sx={{ mt: 2, pt: 2, borderTop: `1px solid ${colors.neutral[200]}` }}>
+                              <Box
+                                sx={{
+                                  mt: 2,
+                                  pt: 2,
+                                  borderTop: `1px solid ${colors.neutral[200]}`,
+                                }}
+                              >
                                 {/* Earnings Overview */}
-                                <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1, mb: 2 }}>
+                                <Box
+                                  sx={{
+                                    display: 'grid',
+                                    gridTemplateColumns: '1fr 1fr 1fr',
+                                    gap: 1,
+                                    mb: 2,
+                                  }}
+                                >
                                   <Box sx={{ textAlign: 'center' }}>
-                                    <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                      sx={{ fontSize: '0.65rem' }}
+                                    >
                                       Today
                                     </Typography>
-                                    <Typography variant="body2" fontWeight="600" color="info.main">
+                                    <Typography
+                                      variant="body2"
+                                      fontWeight="600"
+                                      color="info.main"
+                                    >
                                       ${employee.todayEarnings.toFixed(2)}
                                     </Typography>
                                   </Box>
                                   <Box sx={{ textAlign: 'center' }}>
-                                    <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                      sx={{ fontSize: '0.65rem' }}
+                                    >
                                       MTD
                                     </Typography>
-                                    <Typography variant="body2" fontWeight="600" color="primary.main">
+                                    <Typography
+                                      variant="body2"
+                                      fontWeight="600"
+                                      color="primary.main"
+                                    >
                                       ${employee.mtdEarnings.toFixed(2)}
                                     </Typography>
                                   </Box>
                                   <Box sx={{ textAlign: 'center' }}>
-                                    <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                      sx={{ fontSize: '0.65rem' }}
+                                    >
                                       YTD
                                     </Typography>
-                                    <Typography variant="body2" fontWeight="600" color="success.main">
+                                    <Typography
+                                      variant="body2"
+                                      fontWeight="600"
+                                      color="success.main"
+                                    >
                                       ${employee.ytdEarnings.toFixed(2)}
                                     </Typography>
                                   </Box>
                                 </Box>
 
                                 {/* Payment Status Counts */}
-                                <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 1, mb: 2 }}>
-                                  <Box sx={{ textAlign: 'center', p: 1, bgcolor: colors.semantic.infoLight + '10', borderRadius: 1 }}>
-                                    <Typography variant="h6" fontWeight="bold" color="info.main">
+                                <Box
+                                  sx={{
+                                    display: 'grid',
+                                    gridTemplateColumns: '1fr 1fr 1fr',
+                                    gap: 1,
+                                    mb: 2,
+                                  }}
+                                >
+                                  <Box
+                                    sx={{
+                                      textAlign: 'center',
+                                      p: 1,
+                                      bgcolor: colors.semantic.infoLight + '10',
+                                      borderRadius: 1,
+                                    }}
+                                  >
+                                    <Typography
+                                      variant="h6"
+                                      fontWeight="bold"
+                                      color="info.main"
+                                    >
                                       {employee.totalReadyJobs}
                                     </Typography>
-                                    <Typography variant="caption" color="text.secondary">
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                    >
                                       Ready
                                     </Typography>
                                   </Box>
-                                  <Box sx={{ textAlign: 'center', p: 1, bgcolor: colors.semantic.warningLight + '10', borderRadius: 1 }}>
-                                    <Typography variant="h6" fontWeight="bold" color="warning.main">
+                                  <Box
+                                    sx={{
+                                      textAlign: 'center',
+                                      p: 1,
+                                      bgcolor:
+                                        colors.semantic.warningLight + '10',
+                                      borderRadius: 1,
+                                    }}
+                                  >
+                                    <Typography
+                                      variant="h6"
+                                      fontWeight="bold"
+                                      color="warning.main"
+                                    >
                                       {employee.pendingPayments}
                                     </Typography>
-                                    <Typography variant="caption" color="text.secondary">
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                    >
                                       Pending
                                     </Typography>
                                   </Box>
-                                  <Box sx={{ textAlign: 'center', p: 1, bgcolor: colors.semantic.successLight + '10', borderRadius: 1 }}>
-                                    <Typography variant="h6" fontWeight="bold" color="success.main">
+                                  <Box
+                                    sx={{
+                                      textAlign: 'center',
+                                      p: 1,
+                                      bgcolor:
+                                        colors.semantic.successLight + '10',
+                                      borderRadius: 1,
+                                    }}
+                                  >
+                                    <Typography
+                                      variant="h6"
+                                      fontWeight="bold"
+                                      color="success.main"
+                                    >
                                       {employee.totalPaidJobs}
                                     </Typography>
-                                    <Typography variant="caption" color="text.secondary">
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                    >
                                       Paid
                                     </Typography>
                                   </Box>
@@ -953,14 +1413,28 @@ export function PaymentsManagement() {
                                   }}
                                 >
                                   <Box>
-                                    <Typography variant="body2" color="text.secondary" fontWeight="600">
+                                    <Typography
+                                      variant="body2"
+                                      color="text.secondary"
+                                      fontWeight="600"
+                                    >
                                       Approved Hours Ready
                                     </Typography>
-                                    <Typography variant="caption" color="text.secondary">
-                                      {employee.payrollProcessedHours.toFixed(2)} hrs processed this period
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                    >
+                                      {employee.payrollProcessedHours.toFixed(
+                                        2
+                                      )}{' '}
+                                      hrs processed this period
                                     </Typography>
                                   </Box>
-                                  <Typography variant="h6" fontWeight="bold" color="info.main">
+                                  <Typography
+                                    variant="h6"
+                                    fontWeight="bold"
+                                    color="info.main"
+                                  >
                                     {employee.payrollReadyHours.toFixed(2)} hrs
                                   </Typography>
                                 </Box>
@@ -977,10 +1451,18 @@ export function PaymentsManagement() {
                                     mb: 2,
                                   }}
                                 >
-                                  <Typography variant="body2" color="text.secondary" fontWeight="600">
+                                  <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                    fontWeight="600"
+                                  >
                                     Total Paid (All Time)
                                   </Typography>
-                                  <Typography variant="h6" fontWeight="bold" color="primary.main">
+                                  <Typography
+                                    variant="h6"
+                                    fontWeight="bold"
+                                    color="primary.main"
+                                  >
                                     ${employee.totalPaidAmount.toFixed(2)}
                                   </Typography>
                                 </Box>
@@ -993,17 +1475,21 @@ export function PaymentsManagement() {
                               size="small"
                               variant="contained"
                               startIcon={<PaymentIcon />}
-                              onClick={() => handleProcessJobsOneByOne(employee.id)}
+                              onClick={() =>
+                                handleProcessJobsOneByOne(employee.id)
+                              }
                               disabled={employee.totalReadyJobs === 0}
                               sx={{
-                                background: employee.totalReadyJobs > 0
-                                  ? `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`
-                                  : colors.neutral[300],
+                                background:
+                                  employee.totalReadyJobs > 0
+                                    ? `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`
+                                    : colors.neutral[300],
                                 fontWeight: 600,
                                 '&:hover': {
-                                  background: employee.totalReadyJobs > 0
-                                    ? `linear-gradient(135deg, ${colors.semantic.successDark} 0%, ${colors.semantic.success} 100%)`
-                                    : colors.neutral[300],
+                                  background:
+                                    employee.totalReadyJobs > 0
+                                      ? `linear-gradient(135deg, ${colors.semantic.successDark} 0%, ${colors.semantic.success} 100%)`
+                                      : colors.neutral[300],
                                 },
                                 '&.Mui-disabled': {
                                   background: colors.neutral[300],
@@ -1011,7 +1497,10 @@ export function PaymentsManagement() {
                                 },
                               }}
                             >
-                              Process {employee.totalReadyJobs > 0 ? `${employee.totalReadyJobs} Jobs` : 'Jobs'}
+                              Process{' '}
+                              {employee.totalReadyJobs > 0
+                                ? `${employee.totalReadyJobs} Jobs`
+                                : 'Jobs'}
                             </Button>
                             <Button
                               fullWidth
@@ -1022,7 +1511,10 @@ export function PaymentsManagement() {
                               disabled={employee.payrollReadyHours <= 0}
                               sx={{ mt: 1, fontWeight: 600 }}
                             >
-                              Process {employee.payrollReadyHours > 0 ? `${employee.payrollReadyHours.toFixed(2)} Hrs` : 'Hours'}
+                              Process{' '}
+                              {employee.payrollReadyHours > 0
+                                ? `${employee.payrollReadyHours.toFixed(2)} Hrs`
+                                : 'Hours'}
                             </Button>
                           </CardContent>
                         </Card>
@@ -1033,7 +1525,9 @@ export function PaymentsManagement() {
 
                 {employeePaymentSummaries.length === 0 && (
                   <Paper sx={{ p: 4, textAlign: 'center' }}>
-                    <GroupIcon sx={{ fontSize: 64, color: colors.neutral[400], mb: 2 }} />
+                    <GroupIcon
+                      sx={{ fontSize: 64, color: colors.neutral[400], mb: 2 }}
+                    />
                     <Typography variant="h6" color="text.secondary">
                       No employees found
                     </Typography>
@@ -1041,239 +1535,332 @@ export function PaymentsManagement() {
                 )}
               </TabPanel>
 
-          <TabPanel value={tabValue} index={1}>
-            {/* Pending Jobs Table */}
-            <TableContainer>
-              <Table>
-                <TableHead>
-                  <TableRow sx={{ backgroundColor: colors.neutral[50] }}>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Job</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Employee</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Amount</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Completed</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }} align="center">Actions</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {pendingJobs.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                        <Typography color="textSecondary">
-                          No jobs ready for payment.
-                        </Typography>
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    pendingJobs.map((job) => (
-                      <TableRow key={job.id} hover>
-                        <TableCell>
-                          <Box>
-                            <Typography fontWeight="medium">{job.title}</Typography>
-                            {job.description && (
-                              <Typography variant="body2" color="textSecondary" noWrap>
-                                {job.description}
-                              </Typography>
-                            )}
-                          </Box>
+              <TabPanel value={tabValue} index={1}>
+                {/* Pending Jobs Table */}
+                <TableContainer>
+                  <Table>
+                    <TableHead>
+                      <TableRow sx={{ backgroundColor: colors.neutral[50] }}>
+                        <TableCell sx={{ fontWeight: 'bold' }}>Job</TableCell>
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Employee
                         </TableCell>
-                        <TableCell>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            {getEmployeeName(job.employee)}
-                          </Box>
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Amount
                         </TableCell>
-                        <TableCell>
-                          <Typography fontWeight="medium" color="success.main">
-                            ${job.payAmount.toFixed(2)}
-                          </Typography>
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Completed
                         </TableCell>
-                        <TableCell>
-                          {job.completedAt ? format(new Date(job.completedAt), 'MMM dd, yyyy') : '-'}
-                        </TableCell>
-                        <TableCell align="center">
-                          <Button
-                            variant="contained"
-                            size="small"
-                            startIcon={<PaymentIcon />}
-                            onClick={() => {
-                              setSelectedJob(job);
-                              setProcessDialogOpen(true);
-                            }}
-                            sx={{
-                              background: `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`,
-                            }}
-                          >
-                            Process Payment
-                          </Button>
+                        <TableCell sx={{ fontWeight: 'bold' }} align="center">
+                          Actions
                         </TableCell>
                       </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </TabPanel>
-
-          <TabPanel value={tabValue} index={2}>
-            {/* Filters */}
-            <Box sx={{ mb: 3 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
-                <FilterIcon sx={{ color: colors.primary.main }} />
-                <Typography variant="h6">Filters</Typography>
-                <Button size="small" onClick={clearFilters}>Clear All</Button>
-              </Box>
-              <Grid container spacing={2}>
-                <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-                  <FormControl fullWidth size="small">
-                    <InputLabel>Employee</InputLabel>
-                    <Select
-                      value={filters.employeeId}
-                      onChange={(e) => setFilters(prev => ({ ...prev, employeeId: e.target.value }))}
-                      label="Employee"
-                    >
-                      <MenuItem value="">All Employees</MenuItem>
-                      {employees.map((employee) => (
-                        <MenuItem key={employee.id} value={employee.id}>
-                          {getEmployeeName(employee)}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </Grid>
-                <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-                  <FormControl fullWidth size="small">
-                    <InputLabel>Status</InputLabel>
-                    <Select
-                      value={filters.status}
-                      onChange={(e) => setFilters(prev => ({ ...prev, status: e.target.value }))}
-                      label="Status"
-                    >
-                      <MenuItem value="">All Statuses</MenuItem>
-                      {Object.values(PaymentStatus).map((status) => (
-                        <MenuItem key={status} value={status}>
-                          {status}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </Grid>
-                <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-                  <FormControl fullWidth size="small">
-                    <InputLabel>Payment Method</InputLabel>
-                    <Select
-                      value={filters.paymentMethod}
-                      onChange={(e) => setFilters(prev => ({ ...prev, paymentMethod: e.target.value }))}
-                      label="Payment Method"
-                    >
-                      <MenuItem value="">All Methods</MenuItem>
-                      {Object.values(PaymentMethod).map((method) => (
-                        <MenuItem key={method} value={method}>
-                          {method.replace('_', ' ')}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </Grid>
-                <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-                  <DatePicker
-                    label="Start Date"
-                    value={filters.startDate}
-                    onChange={(date) => setFilters(prev => ({ ...prev, startDate: date }))}
-                    slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                  />
-                </Grid>
-                <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-                  <DatePicker
-                    label="End Date"
-                    value={filters.endDate}
-                    onChange={(date) => setFilters(prev => ({ ...prev, endDate: date }))}
-                    slotProps={{ textField: { size: 'small', fullWidth: true } }}
-                  />
-                </Grid>
-              </Grid>
-            </Box>
-
-            {/* Payments Table */}
-            <TableContainer>
-              <Table>
-                <TableHead>
-                  <TableRow sx={{ backgroundColor: colors.neutral[50] }}>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Payment</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Employee</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Job</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Amount</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Method</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Status</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }}>Date</TableCell>
-                    <TableCell sx={{ fontWeight: 'bold' }} align="center">Actions</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {payments.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
-                        <Typography color="textSecondary">
-                          No payments found.
-                        </Typography>
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    payments.map((payment) => (
-                      <TableRow key={payment.id} hover>
-                        <TableCell>
-                          <Box>
-                            <Typography fontWeight="medium">Payment #{payment.id.slice(-8)}</Typography>
-                            {payment.reference && (
-                              <Typography variant="body2" color="textSecondary">
-                                Ref: {payment.reference}
+                    </TableHead>
+                    <TableBody>
+                      {pendingJobs.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                            <Typography color="textSecondary">
+                              No jobs ready for payment.
+                            </Typography>
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        pendingJobs.map((job) => (
+                          <TableRow key={job.id} hover>
+                            <TableCell>
+                              <Box>
+                                <Typography fontWeight="medium">
+                                  {job.title}
+                                </Typography>
+                                {job.description && (
+                                  <Typography
+                                    variant="body2"
+                                    color="textSecondary"
+                                    noWrap
+                                  >
+                                    {job.description}
+                                  </Typography>
+                                )}
+                              </Box>
+                            </TableCell>
+                            <TableCell>
+                              <Box
+                                sx={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  gap: 1,
+                                }}
+                              >
+                                {getEmployeeName(job.employee)}
+                              </Box>
+                            </TableCell>
+                            <TableCell>
+                              <Typography
+                                fontWeight="medium"
+                                color="success.main"
+                              >
+                                ${job.payAmount.toFixed(2)}
                               </Typography>
-                            )}
-                          </Box>
+                            </TableCell>
+                            <TableCell>
+                              {job.completedAt
+                                ? format(
+                                    new Date(job.completedAt),
+                                    'MMM dd, yyyy'
+                                  )
+                                : '-'}
+                            </TableCell>
+                            <TableCell align="center">
+                              <Button
+                                variant="contained"
+                                size="small"
+                                startIcon={<PaymentIcon />}
+                                onClick={() => {
+                                  setSelectedJob(job);
+                                  setProcessDialogOpen(true);
+                                }}
+                                sx={{
+                                  background: `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`,
+                                }}
+                              >
+                                Process Payment
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </TabPanel>
+
+              <TabPanel value={tabValue} index={2}>
+                {/* Filters */}
+                <Box sx={{ mb: 3 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 2,
+                      mb: 2,
+                    }}
+                  >
+                    <FilterIcon sx={{ color: colors.primary.main }} />
+                    <Typography variant="h6">Filters</Typography>
+                    <Button size="small" onClick={clearFilters}>
+                      Clear All
+                    </Button>
+                  </Box>
+                  <Grid container spacing={2}>
+                    <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+                      <FormControl fullWidth size="small">
+                        <InputLabel>Employee</InputLabel>
+                        <Select
+                          value={filters.employeeId}
+                          onChange={(e) =>
+                            setFilters((prev) => ({
+                              ...prev,
+                              employeeId: e.target.value,
+                            }))
+                          }
+                          label="Employee"
+                        >
+                          <MenuItem value="">All Employees</MenuItem>
+                          {employees.map((employee) => (
+                            <MenuItem key={employee.id} value={employee.id}>
+                              {getEmployeeName(employee)}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+                      <FormControl fullWidth size="small">
+                        <InputLabel>Status</InputLabel>
+                        <Select
+                          value={filters.status}
+                          onChange={(e) =>
+                            setFilters((prev) => ({
+                              ...prev,
+                              status: e.target.value,
+                            }))
+                          }
+                          label="Status"
+                        >
+                          <MenuItem value="">All Statuses</MenuItem>
+                          {Object.values(PaymentStatus).map((status) => (
+                            <MenuItem key={status} value={status}>
+                              {status}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+                      <FormControl fullWidth size="small">
+                        <InputLabel>Payment Method</InputLabel>
+                        <Select
+                          value={filters.paymentMethod}
+                          onChange={(e) =>
+                            setFilters((prev) => ({
+                              ...prev,
+                              paymentMethod: e.target.value,
+                            }))
+                          }
+                          label="Payment Method"
+                        >
+                          <MenuItem value="">All Methods</MenuItem>
+                          {Object.values(PaymentMethod).map((method) => (
+                            <MenuItem key={method} value={method}>
+                              {method.replace('_', ' ')}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+                      <DatePicker
+                        label="Start Date"
+                        value={filters.startDate}
+                        onChange={(date) =>
+                          setFilters((prev) => ({ ...prev, startDate: date }))
+                        }
+                        slotProps={{
+                          textField: { size: 'small', fullWidth: true },
+                        }}
+                      />
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+                      <DatePicker
+                        label="End Date"
+                        value={filters.endDate}
+                        onChange={(date) =>
+                          setFilters((prev) => ({ ...prev, endDate: date }))
+                        }
+                        slotProps={{
+                          textField: { size: 'small', fullWidth: true },
+                        }}
+                      />
+                    </Grid>
+                  </Grid>
+                </Box>
+
+                {/* Payments Table */}
+                <TableContainer>
+                  <Table>
+                    <TableHead>
+                      <TableRow sx={{ backgroundColor: colors.neutral[50] }}>
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Payment
                         </TableCell>
-                        <TableCell>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            {getEmployeeName(payment.employee)}
-                          </Box>
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Employee
                         </TableCell>
-                        <TableCell>
-                          {payment.job?.title || 'Unknown Job'}
+                        <TableCell sx={{ fontWeight: 'bold' }}>Job</TableCell>
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Amount
                         </TableCell>
-                        <TableCell>
-                          <Typography fontWeight="medium" color="success.main">
-                            ${payment.amount.toFixed(2)}
-                          </Typography>
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Method
                         </TableCell>
-                        <TableCell>
-                          <Chip
-                            label={payment.paymentMethod.replace('_', ' ')}
-                            size="small"
-                            variant="outlined"
-                          />
+                        <TableCell sx={{ fontWeight: 'bold' }}>
+                          Status
                         </TableCell>
-                        <TableCell>
-                          <Chip
-                            label={payment.status}
-                            color={getStatusColor(payment.status)}
-                            size="small"
-                          />
-                        </TableCell>
-                        <TableCell>
-                          {payment.paidAt ? format(new Date(payment.paidAt), 'MMM dd, yyyy') :
-                           format(new Date(payment.createdAt), 'MMM dd, yyyy')}
-                        </TableCell>
-                        <TableCell align="center">
-                          <IconButton
-                            size="small"
-                            onClick={(e) => handleMenuOpen(e, payment)}
-                          >
-                            <MoreVertIcon />
-                          </IconButton>
+                        <TableCell sx={{ fontWeight: 'bold' }}>Date</TableCell>
+                        <TableCell sx={{ fontWeight: 'bold' }} align="center">
+                          Actions
                         </TableCell>
                       </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
+                    </TableHead>
+                    <TableBody>
+                      {payments.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
+                            <Typography color="textSecondary">
+                              No payments found.
+                            </Typography>
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        payments.map((payment) => (
+                          <TableRow key={payment.id} hover>
+                            <TableCell>
+                              <Box>
+                                <Typography fontWeight="medium">
+                                  Payment #{payment.id.slice(-8)}
+                                </Typography>
+                                {payment.reference && (
+                                  <Typography
+                                    variant="body2"
+                                    color="textSecondary"
+                                  >
+                                    Ref: {payment.reference}
+                                  </Typography>
+                                )}
+                              </Box>
+                            </TableCell>
+                            <TableCell>
+                              <Box
+                                sx={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  gap: 1,
+                                }}
+                              >
+                                {getEmployeeName(payment.employee)}
+                              </Box>
+                            </TableCell>
+                            <TableCell>
+                              {payment.job?.title || 'Unknown Job'}
+                            </TableCell>
+                            <TableCell>
+                              <Typography
+                                fontWeight="medium"
+                                color="success.main"
+                              >
+                                ${payment.amount.toFixed(2)}
+                              </Typography>
+                            </TableCell>
+                            <TableCell>
+                              <Chip
+                                label={payment.paymentMethod.replace('_', ' ')}
+                                size="small"
+                                variant="outlined"
+                              />
+                            </TableCell>
+                            <TableCell>
+                              <Chip
+                                label={payment.status}
+                                color={getStatusColor(payment.status)}
+                                size="small"
+                              />
+                            </TableCell>
+                            <TableCell>
+                              {payment.paidAt
+                                ? format(
+                                    new Date(payment.paidAt),
+                                    'MMM dd, yyyy'
+                                  )
+                                : format(
+                                    new Date(payment.createdAt),
+                                    'MMM dd, yyyy'
+                                  )}
+                            </TableCell>
+                            <TableCell align="center">
+                              <IconButton
+                                size="small"
+                                onClick={(e) => handleMenuOpen(e, payment)}
+                              >
+                                <MoreVertIcon />
+                              </IconButton>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
               </TabPanel>
             </>
           )}
@@ -1285,11 +1872,12 @@ export function PaymentsManagement() {
           open={Boolean(menuAnchor)}
           onClose={handleMenuClose}
         >
-          <MenuItem onClick={handleMenuClose}>
-            View Details
-          </MenuItem>
+          <MenuItem onClick={handleMenuClose}>View Details</MenuItem>
           {selectedPayment?.status === PaymentStatus.PAID && (
-            <MenuItem onClick={handleEditPaymentStatus} sx={{ color: 'warning.main' }}>
+            <MenuItem
+              onClick={handleEditPaymentStatus}
+              sx={{ color: 'warning.main' }}
+            >
               <EditIcon fontSize="small" sx={{ mr: 1 }} />
               Revert to PENDING
             </MenuItem>
@@ -1317,10 +1905,14 @@ export function PaymentsManagement() {
           onSuccess={handleProcessPayment}
           job={selectedJob}
           allJobs={processingAllJobs ? currentEmployeeJobs : undefined}
-          progressInfo={processingAllJobs ? {
-            current: currentJobIndex + 1,
-            total: currentEmployeeJobs.length
-          } : undefined}
+          progressInfo={
+            processingAllJobs
+              ? {
+                  current: currentJobIndex + 1,
+                  total: currentEmployeeJobs.length,
+                }
+              : undefined
+          }
         />
 
         {/* Confirmation Dialog */}

--- a/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
+++ b/apps/webApp/src/app/pages/admin/payroll/TimeClockManagement.tsx
@@ -160,10 +160,11 @@ export function TimeClockManagement() {
         }),
       ]);
       const myCurrent = await timeClockService.getMyCurrent();
-      const employees = userData.filter((user) =>
-        ['ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF'].includes(
-          user.role?.name || ''
-        )
+      const employees = userData.filter(
+        (user) =>
+          ['ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF'].includes(
+            user.role?.name || ''
+          ) && user.isActive
       );
       setUsers(employees);
       setCurrentEntries(currentData);

--- a/apps/webApp/src/app/pages/admin/reports/EmployeePaymentsReport.tsx
+++ b/apps/webApp/src/app/pages/admin/reports/EmployeePaymentsReport.tsx
@@ -67,7 +67,9 @@ export function EmployeePaymentsReport() {
   const [selectedEmployee, setSelectedEmployee] = useState<string>('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-  const [reportData, setReportData] = useState<EmployeePayrollData[] | null>(null);
+  const [reportData, setReportData] = useState<EmployeePayrollData[] | null>(
+    null
+  );
   const [loading, setLoading] = useState(false);
   const [loadingEmployees, setLoadingEmployees] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -88,9 +90,12 @@ export function EmployeePaymentsReport() {
       try {
         setLoadingEmployees(true);
         const users = await userService.getUsers();
-        // Filter to only show staff and admin users (employees)
+        // Filter to only show active employees (staff, admin, supervisor, foreman)
         const staffUsers = users.filter(
-          (u) => u.role?.name === 'STAFF' || u.role?.name === 'ADMIN' || u.role?.name === 'SUPERVISOR'
+          (u) =>
+            ['STAFF', 'ADMIN', 'SUPERVISOR', 'FOREMAN'].includes(
+              u.role?.name || ''
+            ) && u.isActive
         );
         setEmployees(staffUsers);
       } catch (err: unknown) {
@@ -143,20 +148,28 @@ export function EmployeePaymentsReport() {
   };
 
   // Calculate totals
-  const totalPayments = reportData?.reduce((sum, emp) => sum + emp.payments.length, 0) || 0;
-  const totalAmount = reportData?.reduce((sum, emp) => sum + emp.totalAmount, 0) || 0;
+  const totalPayments =
+    reportData?.reduce((sum, emp) => sum + emp.payments.length, 0) || 0;
+  const totalAmount =
+    reportData?.reduce((sum, emp) => sum + emp.totalAmount, 0) || 0;
 
   // Calculate daily summaries - group all payments by date
   const getDailySummaries = (): DailySummary[] => {
     if (!reportData) return [];
 
-    const dailyMap = new Map<string, { payments: number; totalAmount: number }>();
+    const dailyMap = new Map<
+      string,
+      { payments: number; totalAmount: number }
+    >();
 
     reportData.forEach((empData) => {
       empData.payments.forEach((payment) => {
         if (payment.paidAt) {
           const dateKey = new Date(payment.paidAt).toISOString().split('T')[0];
-          const existing = dailyMap.get(dateKey) || { payments: 0, totalAmount: 0 };
+          const existing = dailyMap.get(dateKey) || {
+            payments: 0,
+            totalAmount: 0,
+          };
           dailyMap.set(dateKey, {
             payments: existing.payments + 1,
             totalAmount: existing.totalAmount + Number(payment.amount),
@@ -246,7 +259,13 @@ export function EmployeePaymentsReport() {
               fullWidth
               variant="contained"
               size="large"
-              startIcon={loading ? <CircularProgress size={20} color="inherit" /> : <Assessment />}
+              startIcon={
+                loading ? (
+                  <CircularProgress size={20} color="inherit" />
+                ) : (
+                  <Assessment />
+                )
+              }
               onClick={handleGenerateReport}
               disabled={loading}
               sx={{ height: 56 }}
@@ -276,13 +295,22 @@ export function EmployeePaymentsReport() {
             {/* Summary Cards */}
             <Grid container spacing={2} sx={{ mb: 4 }}>
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                <Card sx={{
-                  height: '100%',
-                  background: `linear-gradient(135deg, ${colors.primary.main} 0%, ${colors.primary.dark} 100%)`,
-                  color: 'white'
-                }}>
+                <Card
+                  sx={{
+                    height: '100%',
+                    background: `linear-gradient(135deg, ${colors.primary.main} 0%, ${colors.primary.dark} 100%)`,
+                    color: 'white',
+                  }}
+                >
                   <CardContent>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        mb: 1,
+                      }}
+                    >
                       <Person />
                       <Typography variant="body2" sx={{ opacity: 0.9 }}>
                         Employees
@@ -296,13 +324,22 @@ export function EmployeePaymentsReport() {
               </Grid>
 
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                <Card sx={{
-                  height: '100%',
-                  background: `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`,
-                  color: 'white'
-                }}>
+                <Card
+                  sx={{
+                    height: '100%',
+                    background: `linear-gradient(135deg, ${colors.semantic.success} 0%, ${colors.semantic.successDark} 100%)`,
+                    color: 'white',
+                  }}
+                >
                   <CardContent>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        mb: 1,
+                      }}
+                    >
                       <AttachMoney />
                       <Typography variant="body2" sx={{ opacity: 0.9 }}>
                         Total Paid
@@ -316,13 +353,22 @@ export function EmployeePaymentsReport() {
               </Grid>
 
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                <Card sx={{
-                  height: '100%',
-                  background: `linear-gradient(135deg, ${colors.semantic.info} 0%, ${colors.semantic.infoDark} 100%)`,
-                  color: 'white'
-                }}>
+                <Card
+                  sx={{
+                    height: '100%',
+                    background: `linear-gradient(135deg, ${colors.semantic.info} 0%, ${colors.semantic.infoDark} 100%)`,
+                    color: 'white',
+                  }}
+                >
                   <CardContent>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        mb: 1,
+                      }}
+                    >
                       <Work />
                       <Typography variant="body2" sx={{ opacity: 0.9 }}>
                         Total Payments
@@ -336,13 +382,22 @@ export function EmployeePaymentsReport() {
               </Grid>
 
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                <Card sx={{
-                  height: '100%',
-                  background: `linear-gradient(135deg, ${colors.semantic.warning} 0%, ${colors.semantic.warningDark} 100%)`,
-                  color: 'white'
-                }}>
+                <Card
+                  sx={{
+                    height: '100%',
+                    background: `linear-gradient(135deg, ${colors.semantic.warning} 0%, ${colors.semantic.warningDark} 100%)`,
+                    color: 'white',
+                  }}
+                >
                   <CardContent>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        mb: 1,
+                      }}
+                    >
                       <CalendarToday />
                       <Typography variant="body2" sx={{ opacity: 0.9 }}>
                         Date Range
@@ -366,7 +421,9 @@ export function EmployeePaymentsReport() {
                         <Typography fontWeight="bold">Date</Typography>
                       </TableCell>
                       <TableCell align="center">
-                        <Typography fontWeight="bold">Number of Payments</Typography>
+                        <Typography fontWeight="bold">
+                          Number of Payments
+                        </Typography>
                       </TableCell>
                       <TableCell align="right">
                         <Typography fontWeight="bold">Total Amount</Typography>
@@ -377,7 +434,13 @@ export function EmployeePaymentsReport() {
                     {dailySummaries.map((summary) => (
                       <TableRow key={summary.date} hover>
                         <TableCell>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 1,
+                            }}
+                          >
                             <CalendarToday fontSize="small" color="action" />
                             <Typography fontWeight="500">
                               {formatDate(summary.date)}
@@ -386,14 +449,20 @@ export function EmployeePaymentsReport() {
                         </TableCell>
                         <TableCell align="center">
                           <Chip
-                            label={`${summary.payments} payment${summary.payments !== 1 ? 's' : ''}`}
+                            label={`${summary.payments} payment${
+                              summary.payments !== 1 ? 's' : ''
+                            }`}
                             size="small"
                             color="primary"
                             variant="outlined"
                           />
                         </TableCell>
                         <TableCell align="right">
-                          <Typography variant="h6" fontWeight="bold" color="success.main">
+                          <Typography
+                            variant="h6"
+                            fontWeight="bold"
+                            color="success.main"
+                          >
                             {formatCurrency(summary.totalAmount)}
                           </Typography>
                         </TableCell>
@@ -422,7 +491,8 @@ export function EmployeePaymentsReport() {
               No Report Generated
             </Typography>
             <Typography variant="body2">
-              Select an employee (or all employees) and date range, then click "Generate Report"
+              Select an employee (or all employees) and date range, then click
+              "Generate Report"
             </Typography>
           </Box>
         )}

--- a/apps/webApp/src/app/pages/admin/settings/CompensationSettings.tsx
+++ b/apps/webApp/src/app/pages/admin/settings/CompensationSettings.tsx
@@ -57,10 +57,11 @@ export function CompensationSettings() {
         setLoading(true);
         setError(null);
         const userData = await userService.getUsers();
-        const employees = userData.filter((user) =>
-          ['ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF'].includes(
-            user.role?.name || ''
-          )
+        const employees = userData.filter(
+          (user) =>
+            ['ADMIN', 'FOREMAN', 'SUPERVISOR', 'STAFF'].includes(
+              user.role?.name || ''
+            ) && user.isActive
         );
         setUsers(employees);
         if (employees[0]) setSelectedEmployeeId(employees[0].id);

--- a/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
+++ b/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
@@ -2092,6 +2092,7 @@ export function RODetail() {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, isAdmin, isSupervisor, isStaff, isForeman } = useAuth();
+  const { showApiError } = useErrorHelpers();
 
   const [ro, setRo] = useState<RepairOrder | null>(null);
   const [loading, setLoading] = useState(true);
@@ -2139,11 +2140,16 @@ export function RODetail() {
   }
 
   // An RO is only deletable while it carries nothing — the accident case the
-  // backend also enforces. Anything recorded against it makes it real work.
+  // backend also enforces. Anything recorded against it makes it real work,
+  // including photos (whose blobs would be orphaned) and the noVehicle flag,
+  // which marks a counter-service RO as deliberately vehicle-less rather than
+  // unfinished.
   const isEmptyRO =
     !ro.vehicle &&
+    !ro.noVehicle &&
     ro.services.length === 0 &&
     ro.inspections.length === 0 &&
+    ro.media.length === 0 &&
     !ro.invoice &&
     !ro.quotation;
 
@@ -2152,10 +2158,10 @@ export function RODetail() {
     try {
       await repairOrderRequests.remove(ro.id, deleteAppointment);
       navigate(`${baseRoute}/repair-orders`);
-    } catch (err: any) {
-      setError(
-        err?.response?.data?.message || 'Failed to delete this repair order'
-      );
+    } catch (error) {
+      // Not setError: that channel is the page-load failure, and rendering it
+      // replaces the whole repair order with a bare alert.
+      showApiError(error, 'Failed to delete this repair order.');
       setDeleteOpen(false);
     } finally {
       setDeleting(false);
@@ -2225,7 +2231,7 @@ export function RODetail() {
           />
           <Typography variant="caption" color="text.secondary" display="block">
             {deleteAppointment
-              ? "The customer's booking will be deleted too."
+              ? "The customer's booking will be deleted too. A booking that has been paid, completed, invoiced or paid out to staff cannot be deleted — delete the repair order on its own instead."
               : 'The appointment stays and goes back to Scheduled.'}
           </Typography>
         </DialogContent>

--- a/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
+++ b/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
@@ -5,6 +5,7 @@ import {
   Autocomplete,
   Box,
   Button,
+  Checkbox,
   Chip,
   CircularProgress,
   Dialog,
@@ -13,6 +14,7 @@ import {
   DialogTitle,
   Divider,
   FormControl,
+  FormControlLabel,
   Grid,
   IconButton,
   InputLabel,
@@ -37,6 +39,8 @@ import {
   Assignment as InspectIcon,
   Build as ServicesIcon,
   Chat as ChatIcon,
+  Delete as DeleteIcon,
+  EventRepeat as EventRepeatIcon,
   DirectionsCar,
   Edit,
   Email as EmailIcon,
@@ -59,6 +63,11 @@ import { ROPhotoSection } from '../../components/repair-orders/ROPhotoSection';
 import { PreInspectionSection } from '../../components/repair-orders/PreInspectionSection';
 import EmailPromptDialog from '../../components/common/EmailPromptDialog';
 import { AssignEmployeesDialog } from '../../components/repair-orders/AssignEmployeesDialog';
+import { AppointmentDialog } from '../../components/appointments/AppointmentDialog';
+import {
+  appointmentService,
+  Appointment,
+} from '../../requests/appointment.requests';
 import { ROItemsList } from '../../components/repair-orders/ROItemsList';
 import { useAuth } from '../../hooks/useAuth';
 import { useErrorHelpers } from '../../contexts/ErrorContext';
@@ -159,6 +168,16 @@ function CurrentTab({
   const [savingConcern, setSavingConcern] = useState(false);
   const [savingNotes, setSavingNotes] = useState(false);
   const [savingStatus, setSavingStatus] = useState(false);
+  // Moving the appointment to another day: the full appointment (the RO only
+  // carries a summary of it) and the slot proposed for it.
+  const [movingAppointment, setMovingAppointment] =
+    useState<Appointment | null>(null);
+  const [moveTo, setMoveTo] = useState<{
+    date: Date;
+    time: string;
+    employeeIds: string[];
+  } | null>(null);
+  const [loadingMove, setLoadingMove] = useState(false);
   const [closing, setClosing] = useState(false);
   const [reopening, setReopening] = useState(false);
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
@@ -396,6 +415,42 @@ function CurrentTab({
       showApiError(error, 'Failed to reopen repair order.');
     } finally {
       setReopening(false);
+    }
+  };
+
+  /**
+   * Carry unfinished work over to another day: open the appointment dialog on
+   * the RO's own appointment, proposing the day after it at 9 AM with the
+   * crew currently on the RO. Nothing is saved until the dialog is submitted,
+   * so the proposal is only a starting point.
+   */
+  const handleMoveAppointment = async () => {
+    if (!ro.appointment) return;
+    setLoadingMove(true);
+    try {
+      const full = await appointmentService.getAppointment(ro.appointment.id);
+
+      // The day after the one it is booked for, but never a day that has
+      // already passed — an RO left open for a week still moves to tomorrow.
+      const booked = new Date(
+        `${ro.appointment.scheduledDate.split('T')[0]}T00:00:00`
+      );
+      const next = new Date(booked);
+      next.setDate(next.getDate() + 1);
+      const tomorrow = new Date();
+      tomorrow.setHours(0, 0, 0, 0);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      setMoveTo({
+        date: next > tomorrow ? next : tomorrow,
+        time: '09:00',
+        employeeIds: ro.employees.map((e) => e.userId),
+      });
+      setMovingAppointment(full);
+    } catch (error) {
+      showApiError(error, 'Failed to load the appointment.');
+    } finally {
+      setLoadingMove(false);
     }
   };
 
@@ -1000,11 +1055,31 @@ function CurrentTab({
         {ro.appointment && (
           <>
             <Divider sx={{ my: 1.5 }} />
-            <Typography variant="body2" color="text.secondary">
-              Appointment:{' '}
-              {new Date(ro.appointment.scheduledDate).toLocaleDateString()} @{' '}
-              {ro.appointment.scheduledTime} · {ro.appointment.serviceType}
-            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                flexWrap: 'wrap',
+              }}
+            >
+              <Typography variant="body2" color="text.secondary">
+                Appointment:{' '}
+                {new Date(ro.appointment.scheduledDate).toLocaleDateString()} @{' '}
+                {ro.appointment.scheduledTime} · {ro.appointment.serviceType}
+              </Typography>
+              {canEdit && (
+                <Button
+                  size="small"
+                  startIcon={<EventRepeatIcon />}
+                  onClick={handleMoveAppointment}
+                  disabled={loadingMove}
+                  sx={{ ml: 'auto' }}
+                >
+                  {loadingMove ? 'Opening…' : 'Move to Next Day'}
+                </Button>
+              )}
+            </Box>
           </>
         )}
       </Paper>
@@ -1752,6 +1827,32 @@ function CurrentTab({
         onSaved={(updated) => onROChange({ ...ro, ...updated })}
       />
 
+      {movingAppointment && moveTo && (
+        <AppointmentDialog
+          open
+          appointment={movingAppointment}
+          rescheduleTo={moveTo}
+          onClose={() => {
+            setMovingAppointment(null);
+            setMoveTo(null);
+          }}
+          onSuccess={async () => {
+            setMovingAppointment(null);
+            setMoveTo(null);
+            // The RO carries a copy of the appointment's date and time, so it
+            // has to come back from the server to show the new slot.
+            try {
+              onROChange(await repairOrderRequests.getById(ro.id));
+            } catch (error) {
+              showApiError(
+                error,
+                'Appointment moved, but the repair order could not be reloaded.'
+              );
+            }
+          }}
+        />
+      )}
+
       {/* Quotation created success dialog */}
       <Dialog
         open={Boolean(createdQuotationId)}
@@ -1996,6 +2097,9 @@ export function RODetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState(0);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteAppointment, setDeleteAppointment] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const baseRoute = location.pathname.startsWith('/staff')
     ? '/staff'
@@ -2034,6 +2138,30 @@ export function RODetail() {
     );
   }
 
+  // An RO is only deletable while it carries nothing — the accident case the
+  // backend also enforces. Anything recorded against it makes it real work.
+  const isEmptyRO =
+    !ro.vehicle &&
+    ro.services.length === 0 &&
+    ro.inspections.length === 0 &&
+    !ro.invoice &&
+    !ro.quotation;
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await repairOrderRequests.remove(ro.id, deleteAppointment);
+      navigate(`${baseRoute}/repair-orders`);
+    } catch (err: any) {
+      setError(
+        err?.response?.data?.message || 'Failed to delete this repair order'
+      );
+      setDeleteOpen(false);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   return (
     <Box sx={{ p: { xs: 2, md: 3 }, width: '100%' }}>
       {/* Back + header */}
@@ -2057,7 +2185,59 @@ export function RODetail() {
             {ro.vehicle ? ` · ${vehicleLabel(ro)}` : ''}
           </Typography>
         </Box>
+        {isAdmin && isEmptyRO && (
+          <Button
+            size="small"
+            color="error"
+            startIcon={<DeleteIcon />}
+            onClick={() => {
+              setDeleteAppointment(false);
+              setDeleteOpen(true);
+            }}
+            sx={{ ml: 'auto' }}
+          >
+            Delete RO
+          </Button>
+        )}
       </Box>
+
+      <Dialog
+        open={deleteOpen}
+        onClose={() => !deleting && setDeleteOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Delete {ro.roNumber}?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary">
+            This repair order has no vehicle and no services on it. Deleting it
+            cannot be undone.
+          </Typography>
+          <FormControlLabel
+            sx={{ mt: 2 }}
+            control={
+              <Checkbox
+                checked={deleteAppointment}
+                onChange={(e) => setDeleteAppointment(e.target.checked)}
+              />
+            }
+            label="Also delete the appointment it was created from"
+          />
+          <Typography variant="caption" color="text.secondary" display="block">
+            {deleteAppointment
+              ? "The customer's booking will be deleted too."
+              : 'The appointment stays and goes back to Scheduled.'}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteOpen(false)} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button color="error" onClick={handleDelete} disabled={deleting}>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Tabs */}
       <Tabs

--- a/apps/webApp/src/app/requests/repair-order.requests.ts
+++ b/apps/webApp/src/app/requests/repair-order.requests.ts
@@ -224,6 +224,17 @@ export const repairOrderRequests = {
       .post<RepairOrder>(`/repair-orders/${id}/reopen`)
       .then((r) => r.data),
 
+  // Admin-only, and only for an RO raised by mistake — one with no vehicle and
+  // no services on it. deleteAppointment removes the booking it was opened
+  // against; left off, the appointment survives and returns to SCHEDULED.
+  remove: (
+    id: string,
+    deleteAppointment = false
+  ): Promise<{ deleted: true; appointmentDeleted: boolean }> =>
+    apiClient
+      .delete(`/repair-orders/${id}`, { params: { deleteAppointment } })
+      .then((r) => r.data),
+
   // Create a quotation from the RO items flagged as quotation
   createQuotation: (id: string) =>
     apiClient.post(`/repair-orders/${id}/create-quotation`).then((r) => r.data),

--- a/libs/data/src/lib/appointment.dto.ts
+++ b/libs/data/src/lib/appointment.dto.ts
@@ -262,6 +262,16 @@ export class UpdateAppointmentDto {
   @IsOptional()
   @IsString()
   endTime?: string;
+
+  /**
+   * Set false to move an appointment without texting the customer — carrying
+   * unfinished work over to another day is an internal scheduling change, not
+   * news for them. Defaults to notifying, so every existing caller is
+   * unaffected.
+   */
+  @IsOptional()
+  @IsBoolean()
+  notifyCustomer?: boolean;
 }
 
 // Response DTO

--- a/server/src/appointments/appointments.service.spec.ts
+++ b/server/src/appointments/appointments.service.spec.ts
@@ -1,0 +1,74 @@
+import { AppointmentsService } from './appointments.service';
+
+/**
+ * Whether moving an appointment texts the customer. A move the shop makes for
+ * its own reasons — unfinished work carried over to the next day — must stay
+ * silent, while an ordinary reschedule still tells the customer.
+ */
+describe('AppointmentsService update — customer notification', () => {
+  let service: AppointmentsService;
+  let prisma: any;
+  let smsService: any;
+
+  const existing = {
+    id: 'apt-1',
+    customerId: 'cust-1',
+    scheduledDate: new Date('2026-08-17T00:00:00.000Z'),
+    scheduledTime: '13:00',
+    status: 'IN_PROGRESS',
+    employees: [],
+    employeeId: null,
+    paymentAmount: null,
+    expectedAmount: null,
+  };
+
+  beforeEach(() => {
+    prisma = {
+      appointment: {
+        findUnique: jest.fn().mockResolvedValue(existing),
+        update: jest.fn().mockResolvedValue({ ...existing }),
+      },
+      appointmentEmployee: { deleteMany: jest.fn(), createMany: jest.fn() },
+    };
+    smsService = {
+      sendAppointmentUpdate: jest.fn().mockResolvedValue(undefined),
+    };
+    service = new AppointmentsService(
+      prisma,
+      {} as any,
+      smsService,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+  });
+
+  it('texts the customer when the appointment is moved to another day', async () => {
+    await service.update('apt-1', {
+      scheduledDate: '2026-08-18',
+      scheduledTime: '09:00',
+    } as any);
+
+    expect(smsService.sendAppointmentUpdate).toHaveBeenCalledWith('apt-1');
+  });
+
+  it('stays silent when the caller opts out', async () => {
+    await service.update('apt-1', {
+      scheduledDate: '2026-08-18',
+      scheduledTime: '09:00',
+      notifyCustomer: false,
+    } as any);
+
+    expect(smsService.sendAppointmentUpdate).not.toHaveBeenCalled();
+  });
+
+  it('never writes notifyCustomer to the database — it is not a column', async () => {
+    await service.update('apt-1', {
+      scheduledDate: '2026-08-18',
+      notifyCustomer: false,
+    } as any);
+
+    const [[{ data }]] = prisma.appointment.update.mock.calls;
+    expect(data).not.toHaveProperty('notifyCustomer');
+  });
+});

--- a/server/src/appointments/appointments.service.ts
+++ b/server/src/appointments/appointments.service.ts
@@ -680,6 +680,8 @@ export class AppointmentsService {
     delete updateData.employeeIds;
     // Remove completionEmployeeIds — handled separately to auto-create payroll jobs
     delete updateData.completionEmployeeIds;
+    // notifyCustomer only decides whether we text; it is not a column
+    delete updateData.notifyCustomer;
 
     // Update appointment and employees if provided
     if (employeeIds && employeeIds.length > 0) {
@@ -711,7 +713,11 @@ export class AppointmentsService {
     const timeChanged =
       dto.scheduledTime && dto.scheduledTime !== appointment.scheduledTime;
 
-    if (dateChanged || timeChanged) {
+    // Callers moving an appointment for internal reasons — unfinished work
+    // carried over to another day — opt out of the customer text.
+    const notifyCustomer = dto.notifyCustomer !== false;
+
+    if ((dateChanged || timeChanged) && notifyCustomer) {
       console.log(
         `[SMS] Date/time changed - sending update SMS. Date: ${originalDateStr} -> ${newDateStr}, Time: ${appointment.scheduledTime} -> ${dto.scheduledTime}`
       );
@@ -720,6 +726,8 @@ export class AppointmentsService {
           `[SMS] Failed to send appointment update SMS: ${err.message}`
         );
       });
+    } else if (!notifyCustomer) {
+      console.log(`[SMS] Caller opted out of notifying the customer`);
     } else {
       console.log(`[SMS] No date/time change detected - skipping SMS`);
     }

--- a/server/src/jobs/jobs.service.ts
+++ b/server/src/jobs/jobs.service.ts
@@ -22,7 +22,7 @@ export class JobsService {
 
   async create(createJobDto: CreateJobDto, userId: string): Promise<Job> {
     try {
-      // Validate that the employee exists and has STAFF, ADMIN, or SUPERVISOR role
+      // Validate that the employee exists and has a job-eligible role
       const employee = await this.jobRepository['prisma'].user.findUnique({
         where: { id: createJobDto.employeeId },
         include: { role: true },
@@ -39,7 +39,7 @@ export class JobsService {
         employee.role.name !== 'FOREMAN'
       ) {
         throw new BadRequestException(
-          'Jobs can only be assigned to staff, admin, or supervisor users'
+          'Jobs can only be assigned to staff, admin, supervisor, or foreman users'
         );
       }
 

--- a/server/src/repair-orders/repair-orders.controller.ts
+++ b/server/src/repair-orders/repair-orders.controller.ts
@@ -102,6 +102,20 @@ export class RepairOrdersController {
     return this.roService.update(id, dto, user.role.name);
   }
 
+  /**
+   * Delete a repair order raised by mistake. Admin only, and only while the RO
+   * carries nothing — see the service for what disqualifies one. Pass
+   * deleteAppointment=true to remove the appointment it was opened against.
+   */
+  @Delete(':id')
+  @Roles('ADMIN')
+  remove(
+    @Param('id') id: string,
+    @Query('deleteAppointment') deleteAppointment?: string
+  ) {
+    return this.roService.remove(id, deleteAppointment === 'true');
+  }
+
   @Post(':id/close')
   @Roles('ADMIN', 'FOREMAN', 'SUPERVISOR')
   closeAndConvert(

--- a/server/src/repair-orders/repair-orders.service.spec.ts
+++ b/server/src/repair-orders/repair-orders.service.spec.ts
@@ -145,3 +145,113 @@ describe('RepairOrdersService vehicle mileage sync', () => {
     });
   });
 });
+
+/**
+ * Deleting a repair order raised by mistake. The guards matter more than the
+ * delete itself: an RO carrying real work must survive the attempt, and the
+ * appointment behind it is only removed when the caller asks.
+ */
+describe('RepairOrdersService remove', () => {
+  let service: RepairOrdersService;
+  let tx: any;
+  let prisma: any;
+
+  const emptyRO = {
+    id: 'ro-1',
+    appointmentId: 'apt-1',
+    vehicleId: null,
+    quotationId: null,
+    services: [],
+    inspections: [],
+    invoice: null,
+  };
+
+  const setup = (ro: any) => {
+    tx = {
+      repairOrder: { delete: jest.fn() },
+      appointment: { delete: jest.fn(), updateMany: jest.fn() },
+    };
+    prisma = {
+      $transaction: jest.fn((cb: any) => cb(tx)),
+      repairOrder: { findUnique: jest.fn().mockResolvedValue(ro) },
+    };
+    service = new RepairOrdersService(
+      prisma,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+  };
+
+  it('deletes the RO and leaves the appointment behind, back on the schedule', async () => {
+    setup(emptyRO);
+
+    const result = await service.remove('ro-1', false);
+
+    expect(tx.repairOrder.delete).toHaveBeenCalledWith({
+      where: { id: 'ro-1' },
+    });
+    expect(tx.appointment.delete).not.toHaveBeenCalled();
+    expect(tx.appointment.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apt-1', status: 'IN_PROGRESS' },
+      data: { status: 'SCHEDULED' },
+    });
+    expect(result).toEqual({ deleted: true, appointmentDeleted: false });
+  });
+
+  it('deletes the appointment when asked, taking the RO with it', async () => {
+    setup(emptyRO);
+
+    const result = await service.remove('ro-1', true);
+
+    expect(tx.appointment.delete).toHaveBeenCalledWith({
+      where: { id: 'apt-1' },
+    });
+    // The RO cascades from the appointment; deleting it directly would be a
+    // second delete of a row that is already gone.
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({ deleted: true, appointmentDeleted: true });
+  });
+
+  it('refuses an RO that has a vehicle on it', async () => {
+    setup({ ...emptyRO, vehicleId: 'veh-1' });
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(/no vehicle/i);
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses an RO that has services on it', async () => {
+    setup({ ...emptyRO, services: [{ id: 'svc-1' }] });
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(/no services/i);
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses an RO that has been invoiced', async () => {
+    setup({ ...emptyRO, invoice: { id: 'inv-1' } });
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(/invoice/i);
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses an RO that has an inspection', async () => {
+    setup({ ...emptyRO, inspections: [{ id: 'insp-1' }] });
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(/inspection/i);
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses an RO that has a quotation', async () => {
+    setup({ ...emptyRO, quotationId: 'quo-1' });
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(/quotation/i);
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses an RO that does not exist', async () => {
+    setup(null);
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(/not found/i);
+  });
+});

--- a/server/src/repair-orders/repair-orders.service.spec.ts
+++ b/server/src/repair-orders/repair-orders.service.spec.ts
@@ -160,13 +160,24 @@ describe('RepairOrdersService remove', () => {
     id: 'ro-1',
     appointmentId: 'apt-1',
     vehicleId: null,
+    noVehicle: false,
     quotationId: null,
     services: [],
     inspections: [],
     invoice: null,
+    media: [],
   };
 
-  const setup = (ro: any) => {
+  // An appointment nobody has worked yet: no payment, no invoice, no payroll.
+  const untouchedAppointment = {
+    status: 'IN_PROGRESS',
+    paymentAmount: null,
+    productSaleAmount: null,
+    invoice: null,
+    jobs: [],
+  };
+
+  const setup = (ro: any, appointment: any = untouchedAppointment) => {
     tx = {
       repairOrder: { delete: jest.fn() },
       appointment: { delete: jest.fn(), updateMany: jest.fn() },
@@ -174,6 +185,7 @@ describe('RepairOrdersService remove', () => {
     prisma = {
       $transaction: jest.fn((cb: any) => cb(tx)),
       repairOrder: { findUnique: jest.fn().mockResolvedValue(ro) },
+      appointment: { findUnique: jest.fn().mockResolvedValue(appointment) },
     };
     service = new RepairOrdersService(
       prisma,
@@ -253,5 +265,167 @@ describe('RepairOrdersService remove', () => {
     setup(null);
 
     await expect(service.remove('ro-1', false)).rejects.toThrow(/not found/i);
+  });
+});
+
+/**
+ * Deleting the appointment along with the RO. The appointment has to clear its
+ * own bar: money is recorded against it, not against the RO, so the RO being
+ * empty says nothing about whether the booking has been worked.
+ */
+describe('RepairOrdersService remove — deleting the appointment too', () => {
+  let service: RepairOrdersService;
+  let tx: any;
+  let prisma: any;
+
+  const emptyRO = {
+    id: 'ro-1',
+    appointmentId: 'apt-1',
+    vehicleId: null,
+    noVehicle: false,
+    quotationId: null,
+    services: [],
+    inspections: [],
+    invoice: null,
+    media: [],
+  };
+
+  const setup = (appointment: any) => {
+    tx = {
+      repairOrder: { delete: jest.fn() },
+      appointment: { delete: jest.fn(), updateMany: jest.fn() },
+    };
+    prisma = {
+      $transaction: jest.fn((cb: any) => cb(tx)),
+      repairOrder: { findUnique: jest.fn().mockResolvedValue(emptyRO) },
+      appointment: { findUnique: jest.fn().mockResolvedValue(appointment) },
+    };
+    service = new RepairOrdersService(
+      prisma,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+  };
+
+  const untouched = {
+    status: 'IN_PROGRESS',
+    paymentAmount: null,
+    productSaleAmount: null,
+    invoice: null,
+    jobs: [],
+  };
+
+  it('deletes a booking nobody has worked', async () => {
+    setup(untouched);
+
+    await service.remove('ro-1', true);
+
+    expect(tx.appointment.delete).toHaveBeenCalledWith({
+      where: { id: 'apt-1' },
+    });
+  });
+
+  it('refuses a booking that has taken money — the RO being empty does not make the cash disappear', async () => {
+    setup({ ...untouched, paymentAmount: 240 });
+
+    await expect(service.remove('ro-1', true)).rejects.toThrow(/payment/i);
+    expect(tx.appointment.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses a booking with a product sale recorded', async () => {
+    setup({ ...untouched, productSaleAmount: 80 });
+
+    await expect(service.remove('ro-1', true)).rejects.toThrow(/payment/i);
+    expect(tx.appointment.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses a completed booking', async () => {
+    setup({ ...untouched, status: 'COMPLETED' });
+
+    await expect(service.remove('ro-1', true)).rejects.toThrow(/completed/i);
+    expect(tx.appointment.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses a booking that has been invoiced', async () => {
+    setup({ ...untouched, invoice: { id: 'inv-1' } });
+
+    await expect(service.remove('ro-1', true)).rejects.toThrow(/invoice/i);
+    expect(tx.appointment.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses a booking staff have been paid out for', async () => {
+    setup({ ...untouched, jobs: [{ id: 'job-1' }] });
+
+    await expect(service.remove('ro-1', true)).rejects.toThrow(/payroll/i);
+    expect(tx.appointment.delete).not.toHaveBeenCalled();
+  });
+
+  it('leaves the appointment alone entirely when it is not being deleted', async () => {
+    setup({ ...untouched, paymentAmount: 240, status: 'COMPLETED' });
+
+    // A paid booking blocks deleting the booking, not deleting the RO.
+    await service.remove('ro-1', false);
+
+    expect(tx.repairOrder.delete).toHaveBeenCalled();
+    expect(tx.appointment.delete).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The guard on the RO itself. Photos and the deliberate no-vehicle flag both
+ * mean the RO is real, not raised by mistake.
+ */
+describe('RepairOrdersService remove — RO carries something', () => {
+  let service: RepairOrdersService;
+  let tx: any;
+  let prisma: any;
+
+  const setup = (ro: any) => {
+    tx = {
+      repairOrder: { delete: jest.fn() },
+      appointment: { delete: jest.fn(), updateMany: jest.fn() },
+    };
+    prisma = {
+      $transaction: jest.fn((cb: any) => cb(tx)),
+      repairOrder: { findUnique: jest.fn().mockResolvedValue(ro) },
+      appointment: { findUnique: jest.fn() },
+    };
+    service = new RepairOrdersService(
+      prisma,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+  };
+
+  const base = {
+    id: 'ro-1',
+    appointmentId: 'apt-1',
+    vehicleId: null,
+    noVehicle: false,
+    quotationId: null,
+    services: [],
+    inspections: [],
+    invoice: null,
+    media: [],
+  };
+
+  it('refuses an RO with photos — their blobs would be orphaned', async () => {
+    setup({ ...base, media: [{ id: 'media-1' }] });
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(/photos/i);
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses a counter-service RO deliberately marked as having no vehicle', async () => {
+    setup({ ...base, noVehicle: true });
+
+    await expect(service.remove('ro-1', false)).rejects.toThrow(
+      /counter service/i
+    );
+    expect(tx.repairOrder.delete).not.toHaveBeenCalled();
   });
 });

--- a/server/src/repair-orders/repair-orders.service.ts
+++ b/server/src/repair-orders/repair-orders.service.ts
@@ -327,6 +327,7 @@ export class RepairOrdersService {
         services: { select: { id: true } },
         inspections: { select: { id: true } },
         invoice: { select: { id: true } },
+        media: { select: { id: true } },
       },
     });
 
@@ -335,6 +336,18 @@ export class RepairOrdersService {
     if (ro.vehicleId) {
       throw new BadRequestException(
         'Only a repair order with no vehicle can be deleted. Remove the vehicle first if this one was raised by mistake.'
+      );
+    }
+    if (ro.noVehicle) {
+      throw new BadRequestException(
+        'This repair order was deliberately marked as having no vehicle (counter service) and cannot be deleted.'
+      );
+    }
+    if (ro.media.length) {
+      // The blobs behind these rows would be orphaned: ROMedia cascades with
+      // the RO, and nothing else holds their blobName.
+      throw new BadRequestException(
+        'This repair order has photos on it and cannot be deleted. Remove them first if it was raised by mistake.'
       );
     }
     if (ro.services.length) {
@@ -358,6 +371,53 @@ export class RepairOrdersService {
       );
     }
 
+    if (deleteAppointment) {
+      // The appointment has to clear its own bar, not the RO's. Payment is
+      // recorded against the appointment — paymentAmount, paymentBreakdown,
+      // productSaleAmount — and the payroll jobs raised on completion point at
+      // it with onDelete SetNull, so deleting one that has been worked would
+      // drop money out of the day's cash report and silently detach payroll.
+      const appointment = await this.prisma.appointment.findUnique({
+        where: { id: ro.appointmentId },
+        select: {
+          status: true,
+          paymentAmount: true,
+          productSaleAmount: true,
+          invoice: { select: { id: true } },
+          jobs: { select: { id: true } },
+        },
+      });
+
+      if (!appointment) {
+        throw new NotFoundException(
+          `Appointment ${ro.appointmentId} not found`
+        );
+      }
+      if (
+        appointment.paymentAmount != null ||
+        appointment.productSaleAmount != null
+      ) {
+        throw new BadRequestException(
+          'This appointment has a payment recorded against it and cannot be deleted. Delete the repair order on its own.'
+        );
+      }
+      if (appointment.status === 'COMPLETED') {
+        throw new BadRequestException(
+          'This appointment is completed and cannot be deleted. Delete the repair order on its own.'
+        );
+      }
+      if (appointment.invoice) {
+        throw new BadRequestException(
+          'This appointment has an invoice and cannot be deleted. Delete the repair order on its own.'
+        );
+      }
+      if (appointment.jobs.length) {
+        throw new BadRequestException(
+          'This appointment has payroll jobs against it and cannot be deleted. Delete the repair order on its own.'
+        );
+      }
+    }
+
     await this.prisma.$transaction(async (tx) => {
       if (deleteAppointment) {
         // The RO goes with it: repair_orders.appointmentId is onDelete Cascade.
@@ -366,6 +426,11 @@ export class RepairOrdersService {
       }
 
       await tx.repairOrder.delete({ where: { id } });
+      // create() advances SCHEDULED or CONFIRMED to IN_PROGRESS and the
+      // original is not recorded, so this cannot be a true inverse. SCHEDULED
+      // is the safe guess of the two: understating it costs a re-confirmation,
+      // while writing CONFIRMED would claim a customer confirmation that may
+      // never have happened.
       await tx.appointment.updateMany({
         where: { id: ro.appointmentId, status: 'IN_PROGRESS' },
         data: { status: 'SCHEDULED' },

--- a/server/src/repair-orders/repair-orders.service.ts
+++ b/server/src/repair-orders/repair-orders.service.ts
@@ -222,10 +222,10 @@ export class RepairOrdersService {
     if (query.customerId) where.customerId = query.customerId;
     if (query.vehicleId) where.vehicleId = query.vehicleId;
 
-    // Staff only see their assigned ROs unless explicitly querying all
-    if (roleName === 'STAFF' && !query.employeeId) {
-      where.employees = { some: { userId } };
-    } else if (query.employeeId) {
+    // Every role sees the full RO list; narrowing to one employee is now an
+    // explicit filter rather than something forced on staff. See findOne for
+    // why the staff-only-their-own rule was dropped.
+    if (query.employeeId) {
       where.employees = { some: { userId: query.employeeId } };
     }
 
@@ -313,13 +313,11 @@ export class RepairOrdersService {
 
     if (!ro) throw new NotFoundException(`Repair order ${id} not found`);
 
-    if (
-      roleName === 'STAFF' &&
-      !ro.employees.some((e: any) => e.userId === userId)
-    ) {
-      throw new ForbiddenException('You are not assigned to this repair order');
-    }
-
+    // Staff can read any RO. The previous rule — staff only see ROs they are
+    // assigned to — locked a staff member out of the RO they had just created,
+    // because create() assigns only the crew carried over from the appointment
+    // and most appointments have no crew assigned. Revisit when per-RO access
+    // is designed properly; until then visibility is shop-wide.
     return this.applyMediaSasUrls(ro);
   }
 

--- a/server/src/repair-orders/repair-orders.service.ts
+++ b/server/src/repair-orders/repair-orders.service.ts
@@ -305,6 +305,76 @@ export class RepairOrdersService {
     });
   }
 
+  /**
+   * Delete a repair order raised by mistake — one carrying no vehicle and no
+   * services. Anything with real work recorded against it is refused: an
+   * invoice, an inspection or a generated quotation outlives the RO, and
+   * deleting it would orphan or lose them.
+   *
+   * The appointment is only removed when the caller asks for it. An RO opened
+   * against a genuine booking is the ordinary case and the booking should
+   * survive; when it does, its status is wound back from IN_PROGRESS, which
+   * opening the RO had set and which would otherwise describe work that no
+   * longer exists.
+   */
+  async remove(
+    id: string,
+    deleteAppointment: boolean
+  ): Promise<{ deleted: true; appointmentDeleted: boolean }> {
+    const ro = await this.prisma.repairOrder.findUnique({
+      where: { id },
+      include: {
+        services: { select: { id: true } },
+        inspections: { select: { id: true } },
+        invoice: { select: { id: true } },
+      },
+    });
+
+    if (!ro) throw new NotFoundException(`Repair order ${id} not found`);
+
+    if (ro.vehicleId) {
+      throw new BadRequestException(
+        'Only a repair order with no vehicle can be deleted. Remove the vehicle first if this one was raised by mistake.'
+      );
+    }
+    if (ro.services.length) {
+      throw new BadRequestException(
+        'Only a repair order with no services can be deleted. Remove its services first if this one was raised by mistake.'
+      );
+    }
+    if (ro.invoice) {
+      throw new BadRequestException(
+        'This repair order has an invoice and cannot be deleted.'
+      );
+    }
+    if (ro.inspections.length) {
+      throw new BadRequestException(
+        'This repair order has an inspection and cannot be deleted.'
+      );
+    }
+    if (ro.quotationId) {
+      throw new BadRequestException(
+        'This repair order has a quotation and cannot be deleted.'
+      );
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      if (deleteAppointment) {
+        // The RO goes with it: repair_orders.appointmentId is onDelete Cascade.
+        await tx.appointment.delete({ where: { id: ro.appointmentId } });
+        return;
+      }
+
+      await tx.repairOrder.delete({ where: { id } });
+      await tx.appointment.updateMany({
+        where: { id: ro.appointmentId, status: 'IN_PROGRESS' },
+        data: { status: 'SCHEDULED' },
+      });
+    });
+
+    return { deleted: true, appointmentDeleted: deleteAppointment };
+  }
+
   async findOne(id: string, roleName: string, userId: string): Promise<any> {
     const ro = await this.prisma.repairOrder.findUnique({
       where: { id },

--- a/server/src/time-clock/time-clock.service.ts
+++ b/server/src/time-clock/time-clock.service.ts
@@ -957,10 +957,17 @@ export class TimeClockService {
     // The employee summary rides along on each row so the accountant's view can
     // show names without also being granted GET /api/users, which would expose
     // far more than the payroll roster.
+    // The roster is who payroll can be raised for now, so it lists active
+    // employees only. Asking for one employee by id still resolves whatever
+    // their state — hours already worked by someone since deactivated must
+    // stay reachable so their final stub can be paid.
     const employees = await this.prisma.user.findMany({
       where: employeeId
         ? { id: employeeId }
-        : { role: { name: { in: STAFF_PAYROLL_ROLES as any[] } } },
+        : {
+            role: { name: { in: STAFF_PAYROLL_ROLES as any[] } },
+            isActive: true,
+          },
       include: { role: true },
       orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
     });


### PR DESCRIPTION
Six fixes found while working through the repair-order and payroll screens.

## Staff could not open the RO they had just created

`findOne` rejected any staff member absent from the RO's crew, but `create()` assigns only the crew carried over from the appointment — and most appointments have none — so the RO came out with zero employees and its own author got a 403. `findAll` hid it from their list for the same reason. Both rules are dropped; visibility is shop-wide for now. Per-RO access needs a real design, and the write path still leaves staff-created ROs with no crew recorded.

## Foremen were invisible in most pickers

FOREMAN was never added to several employee lists when the role was introduced, so a foreman assignable on an appointment vanished everywhere downstream: the RO crew dialog, job creation, the payment dialog, Payments Management and the payments report. The backends already accepted the role, so this was a UI-only gap.

The RO crew dialog also dropped anyone it could not offer from its pre-selection — and saving replaces the whole crew, so opening it and saving silently unassigned the foreman.

## Only active employees are offered

No picker filtered on `isActive`, including the pay-stub screen, where the payroll-hours roster doubles as the employee list. Selection is now active-only, with two exceptions so nothing owed disappears: Payments Management keeps a deactivated employee who is still owed, Jobs Management keeps one whose jobs are still pending, and asking payroll-hours for a single employee by id still resolves them so a final stub can be raised.

## Calendar: today was unfindable, cells were flooded with yellow

The month grid painted whole cells solid orange. That was an accident — the cell asked for `warning.lighter` at `sm` and up, a token this theme does not define, so the browser dropped the declaration as invalid CSS and the `xs` rule won at every width.

Today's border and number colour both lost to `hasAttentionNeeded`, which is tested first, so on a day needing attention today had no marker at all. It now gets a filled circle behind the date number and is the only day with a border of its own.

## Delete an RO raised by mistake

Admin can delete a repair order that carries nothing. Anything with real work against it is refused with a reason: an invoice, an inspection, a quotation, photos (whose blobs would be orphaned by the cascade), or the `noVehicle` flag that marks a deliberate counter-service RO.

The appointment behind it is only removed when the admin ticks the box, **and only if the booking is unworked** — no payment or product sale recorded, not completed, no invoice, no payroll jobs. Money is recorded against the appointment rather than the RO, so an empty RO says nothing about whether the booking took cash. Left alone, the appointment survives and winds back from `IN_PROGRESS` to `SCHEDULED`.

## Carry unfinished work to the next day

"Move to Next Day" on the RO opens the appointment dialog on the RO's own appointment, proposing the day after it at 9 AM with the crew currently on the RO. Everything else stays as booked, nothing is saved until submitted, and the proposed date is floored at tomorrow.

This does not text the customer: `UpdateAppointmentDto` gained `notifyCustomer`, defaulting to notifying so every existing caller is unchanged, and only the RO move opts out.

## Also

Default shop labour rate raised from \$100 to \$110/hr. Applies to a new LABOR line where the catalog carries no price; existing ROs and catalog-priced items are unaffected.

## Testing

- 553 server tests passing, including 26 for the RO delete guards and 3 for the SMS opt-out
- Typecheck and lint clean on both projects; both apps build
- No schema change, so no migration
- Reviewed via `/review`; the appointment-delete guard is the result of that review catching an unguarded delete that could have dropped collected cash

**Not verified in the browser** — the UI changes (calendar styling, delete dialog, move-to-next-day flow) are worth a click-through before merge.

Two known gaps, both deliberate: Employee Day Schedule still excludes foremen, and the payments report is now active-only so a terminated employee's history cannot be pulled from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)