### PR TITLE
Stop logging a JWT payload on every request (GA-68)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -24,3 +24,7 @@ TELNYX_API_KEY=your_telnyx_api_key_here
 TELNYX_PHONE_NUMBER=+1XXXXXXXXXX
 TELNYX_MESSAGING_PROFILE_ID=your_messaging_profile_id
 TELNYX_PUBLIC_KEY=your_telnyx_public_key_here
+# Auth debugging
+# Set to "true" to log per-request token validation and role checks.
+# Off by default: these logs are high-volume and carry decoded token claims.
+# AUTH_DEBUG=false

--- a/server/src/auth/auth-logging.ts
+++ b/server/src/auth/auth-logging.ts
@@ -1,0 +1,13 @@
+/**
+ * Verbose authentication logging is opt-in via `AUTH_DEBUG=true`.
+ *
+ * Deliberately not tied to NODE_ENV: local development runs with
+ * NODE_ENV=development and would still flood the console, and the data these
+ * logs carry (decoded JWT claims, Clerk user objects) does not belong on disk
+ * by default in any environment.
+ *
+ * Read at call time rather than module load so it can be toggled in tests.
+ */
+export function isAuthDebugEnabled(): boolean {
+  return process.env.AUTH_DEBUG === 'true';
+}

--- a/server/src/auth/guards/role.guard.spec.ts
+++ b/server/src/auth/guards/role.guard.spec.ts
@@ -1,0 +1,104 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RoleGuard } from './role.guard';
+
+describe('RoleGuard', () => {
+  let reflector: Reflector;
+  let guard: RoleGuard;
+
+  const contextFor = (user: unknown): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ method: 'GET', url: '/api/invoices', user }),
+      }),
+      getHandler: () => undefined,
+      getClass: () => undefined,
+    } as unknown as ExecutionContext);
+
+  const requireRoles = (roles: string[] | undefined) => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(roles);
+  };
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RoleGuard(reflector);
+  });
+
+  it('allows any request when the route declares no roles', () => {
+    requireRoles(undefined);
+
+    expect(guard.canActivate(contextFor(undefined))).toBe(true);
+  });
+
+  it('allows a user whose role is in the required list', () => {
+    requireRoles(['ADMIN', 'STAFF']);
+
+    expect(
+      guard.canActivate(contextFor({ id: 'u1', role: { name: 'STAFF' } }))
+    ).toBe(true);
+  });
+
+  it('denies a user whose role is not in the required list', () => {
+    requireRoles(['ADMIN']);
+
+    expect(
+      guard.canActivate(contextFor({ id: 'u1', role: { name: 'CUSTOMER' } }))
+    ).toBe(false);
+  });
+
+  it('denies an unauthenticated request', () => {
+    requireRoles(['ADMIN']);
+
+    expect(guard.canActivate(contextFor(undefined))).toBe(false);
+  });
+
+  it('denies a user carrying no role', () => {
+    requireRoles(['ADMIN']);
+
+    expect(guard.canActivate(contextFor({ id: 'u1' }))).toBe(false);
+  });
+
+  describe('logging', () => {
+    afterEach(() => {
+      delete process.env.AUTH_DEBUG;
+    });
+
+    it('stays silent on an allowed request by default', () => {
+      requireRoles(['STAFF']);
+      const debug = jest
+        .spyOn(guard['logger'], 'debug')
+        .mockImplementation(() => undefined);
+      const warn = jest
+        .spyOn(guard['logger'], 'warn')
+        .mockImplementation(() => undefined);
+
+      guard.canActivate(contextFor({ id: 'u1', role: { name: 'STAFF' } }));
+
+      expect(debug).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('logs allowed requests when AUTH_DEBUG is on', () => {
+      process.env.AUTH_DEBUG = 'true';
+      requireRoles(['STAFF']);
+      const debug = jest
+        .spyOn(guard['logger'], 'debug')
+        .mockImplementation(() => undefined);
+
+      guard.canActivate(contextFor({ id: 'u1', role: { name: 'STAFF' } }));
+
+      expect(debug).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns on a denial even when debug is off', () => {
+      requireRoles(['ADMIN']);
+      const warn = jest
+        .spyOn(guard['logger'], 'warn')
+        .mockImplementation(() => undefined);
+
+      guard.canActivate(contextFor({ id: 'u1', role: { name: 'CUSTOMER' } }));
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/server/src/auth/guards/role.guard.ts
+++ b/server/src/auth/guards/role.guard.ts
@@ -1,40 +1,51 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  Logger,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from '../decorators/roles.decorator';
+import { isAuthDebugEnabled } from '../auth-logging';
 
 @Injectable()
 export class RoleGuard implements CanActivate {
+  private readonly logger = new Logger(RoleGuard.name);
+
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()]
+    );
 
     if (!requiredRoles) {
       return true;
     }
 
-    const { user } = context.switchToHttp().getRequest();
     const request = context.switchToHttp().getRequest();
-
-    console.log('[ROLE GUARD] Checking access:', {
-      endpoint: `${request.method} ${request.url}`,
-      requiredRoles,
-      userRole: user?.role?.name,
-      userId: user?.id,
-      hasUser: !!user,
-      hasRole: !!user?.role,
-    });
+    const { user } = request;
+    const endpoint = `${request.method} ${request.url}`;
 
     if (!user || !user.role) {
-      console.log('[ROLE GUARD] REJECTED: No user or role');
+      this.logger.warn(`Denied ${endpoint}: request has no authenticated user`);
       return false;
     }
 
     const hasAccess = requiredRoles.includes(user.role.name);
-    console.log('[ROLE GUARD] Result:', hasAccess ? 'ALLOWED' : 'REJECTED');
+
+    // Only denials are logged by default. Logging every allowed request here
+    // put several lines on the console for each role-protected call, which
+    // buried real errors in the production log stream.
+    if (!hasAccess) {
+      this.logger.warn(
+        `Denied ${endpoint} for user ${user.id}: role ${user.role.name} ` +
+          `not in [${requiredRoles.join(', ')}]`
+      );
+    } else if (isAuthDebugEnabled()) {
+      this.logger.debug(`Allowed ${endpoint} for role ${user.role.name}`);
+    }
 
     return hasAccess;
   }

--- a/server/src/auth/strategies/clerk-jwt.strategy.ts
+++ b/server/src/auth/strategies/clerk-jwt.strategy.ts
@@ -1,20 +1,26 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { UserRepository } from '../../users/repositories/user.repository';
 import { passportJwtSecret } from 'jwks-rsa';
 import { PrismaService } from '@gt-automotive/database';
+import { isAuthDebugEnabled } from '../auth-logging';
 
 @Injectable()
 export class ClerkJwtStrategy extends PassportStrategy(Strategy, 'clerk-jwt') {
+  private readonly logger = new Logger(ClerkJwtStrategy.name);
+
   constructor(
     private userRepository: UserRepository,
     private prismaService: PrismaService,
-    private configService: ConfigService,
+    private configService: ConfigService
   ) {
-    const jwksUrl = configService.get<string>('CLERK_JWKS_URL', 'https://clerk.gt-automotives.com/.well-known/jwks.json');
-    
+    const jwksUrl = configService.get<string>(
+      'CLERK_JWKS_URL',
+      'https://clerk.gt-automotives.com/.well-known/jwks.json'
+    );
+
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -29,7 +35,11 @@ export class ClerkJwtStrategy extends PassportStrategy(Strategy, 'clerk-jwt') {
   }
 
   async validate(payload: any) {
-    console.log('Clerk JWT payload:', JSON.stringify(payload, null, 2));
+    // Never log the payload itself — it is the decoded token, and this runs on
+    // every authenticated request. Subject id only, and only when debugging.
+    if (isAuthDebugEnabled()) {
+      this.logger.debug(`Validating token for Clerk user ${payload?.sub}`);
+    }
 
     // Clerk JWT payload contains 'sub' as the Clerk user ID
     const clerkUserId = payload.sub;
@@ -45,26 +55,39 @@ export class ClerkJwtStrategy extends PassportStrategy(Strategy, 'clerk-jwt') {
       // Auto-create user if they don't exist by fetching from Clerk API
       let clerkUser;
       try {
-        const clerkSecretKey = this.configService.get<string>('CLERK_SECRET_KEY');
+        const clerkSecretKey =
+          this.configService.get<string>('CLERK_SECRET_KEY');
         if (clerkSecretKey) {
           const { createClerkClient } = await import('@clerk/clerk-sdk-node');
 
           const clerkClient = createClerkClient({
             secretKey: clerkSecretKey,
-            apiUrl: this.configService.get<string>('CLERK_API_URL') || 'https://api.clerk.com'
+            apiUrl:
+              this.configService.get<string>('CLERK_API_URL') ||
+              'https://api.clerk.com',
           });
 
           clerkUser = await clerkClient.users.getUser(clerkUserId);
-          console.log('Fetched user from Clerk API:', clerkUser);
         } else {
-          throw new UnauthorizedException('Clerk not configured - missing CLERK_SECRET_KEY');
+          throw new UnauthorizedException(
+            'Clerk not configured - missing CLERK_SECRET_KEY'
+          );
         }
       } catch (error) {
-        console.error('Error fetching user from Clerk:', error);
-        throw new UnauthorizedException('Failed to fetch user details from Clerk');
+        this.logger.error(
+          `Failed to fetch Clerk user ${clerkUserId}`,
+          error instanceof Error ? error.stack : String(error)
+        );
+        throw new UnauthorizedException(
+          'Failed to fetch user details from Clerk'
+        );
       }
 
-      if (!clerkUser || !clerkUser.emailAddresses || clerkUser.emailAddresses.length === 0) {
+      if (
+        !clerkUser ||
+        !clerkUser.emailAddresses ||
+        clerkUser.emailAddresses.length === 0
+      ) {
         throw new UnauthorizedException('User has no email addresses in Clerk');
       }
 
@@ -80,11 +103,13 @@ export class ClerkJwtStrategy extends PassportStrategy(Strategy, 'clerk-jwt') {
 
       // Look up the role ID by name
       const role = await this.prismaService.role.findUnique({
-        where: { name: roleName as any }
+        where: { name: roleName as any },
       });
 
       if (!role) {
-        throw new UnauthorizedException(`Role ${roleName} not found in database`);
+        throw new UnauthorizedException(
+          `Role ${roleName} not found in database`
+        );
       }
 
       try {
@@ -95,9 +120,12 @@ export class ClerkJwtStrategy extends PassportStrategy(Strategy, 'clerk-jwt') {
           lastName,
           roleId: role.id,
         });
-        console.log('Created new user from Clerk data:', user);
+        this.logger.log(`Provisioned user ${user.id} with role ${roleName}`);
       } catch (error) {
-        console.error('Error creating user:', error);
+        this.logger.error(
+          `Failed to provision user for Clerk id ${clerkUserId}`,
+          error instanceof Error ? error.stack : String(error)
+        );
         // If creation fails, maybe the user was created in parallel
         user = await this.userRepository.findByClerkId(clerkUserId);
         if (!user) {


### PR DESCRIPTION
Prerequisite for the messaging epic, but independently worth shipping — this is costing us today.

Jira: [GA-68](https://gt-automotives.atlassian.net/browse/GA-68) · Epic: [GA-67](https://gt-automotives.atlassian.net/browse/GA-67)

## The problem

`clerk-jwt.strategy.ts` pretty-printed the entire decoded token payload on every authenticated request:

```ts
console.log('Clerk JWT payload:', JSON.stringify(payload, null, 2));
```

`RoleGuard` added three more lines on every role-protected request. Together that is roughly **twenty log lines per API call**, ungated by environment.

Two things wrong with it. The payload is the decoded token, which does not belong on disk. And the volume buries real errors — the B1 App Service is already at 4-5GB of its 10GB, and the planned messaging poll would multiply request count by about a hundred.

## What changed

Verbose auth logging is now opt-in behind `AUTH_DEBUG`.

Deliberately **not** tied to `NODE_ENV`: local development runs as `development` and would still flood the console, and this data is unwanted on disk in every environment.

- **Denials still warn by default** — a denied request is rare and genuinely useful, so it keeps its log line and now carries the endpoint, user and required roles
- **Allowed requests are silent** unless `AUTH_DEBUG=true`
- **Provisioning logs keep identifiers, drop object dumps** — the auto-create path was logging whole Clerk user objects
- Both files converted to the `Logger` convention used elsewhere in the server

The four remaining `console.*` calls in the auth folder are rare-event logs (a startup warning, webhook events). They are not per-request and were left alone to keep this diff to its purpose.

## Verification

- `tsc --noEmit -p server/tsconfig.app.json` clean
- `nx lint server` — 0 errors
- `nx test server` — 579 tests, 34 suites, all passing
- New `role.guard.spec.ts` covers the restructured control flow, including that an allowed request logs nothing by default and a denial warns regardless

## Note

`yarn typecheck:server` checks **zero files** — `server/tsconfig.json` has empty `files` and `include`, so `tsc -p` there exits clean in under a second having read nothing. I typechecked against `server/tsconfig.app.json` instead. Worth its own ticket; not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)