### PR TITLE
Messaging backend: schema, module, and the visibility rule (GA-69)

### DIFF
--- a/libs/data/src/index.ts
+++ b/libs/data/src/index.ts
@@ -30,6 +30,7 @@ export * from './lib/sales-report.dto';
 export * from './lib/tax-report.dto';
 export * from './lib/tire-sale.dto';
 export * from './lib/repair-order.dto';
+export * from './lib/message.dto';
 export * from './lib/pay-stub.dto';
 
 // Export utility functions

--- a/libs/data/src/lib/message.dto.ts
+++ b/libs/data/src/lib/message.dto.ts
@@ -1,0 +1,153 @@
+import {
+  IsEnum,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+import {
+  ConversationEntity,
+  ConversationType,
+  MessageVisibility,
+} from './prisma-enums';
+
+export { ConversationEntity, ConversationType, MessageVisibility };
+
+/** Longest message we accept. Generous for a shop note, short of an essay. */
+export const MESSAGE_MAX_LENGTH = 4000;
+
+/**
+ * Sending a message.
+ *
+ * Deliberately carries no `visibility` and no mention list. Both are derived
+ * on the server from `body`, because a client that could set either could
+ * grant itself sight of someone else's private message.
+ */
+export class CreateMessageDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(MESSAGE_MAX_LENGTH)
+  body!: string;
+
+  /** Reply target. The reply inherits this message's visibility. */
+  @IsOptional()
+  @IsString()
+  parentMessageId?: string;
+}
+
+export class UpdateMessageDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(MESSAGE_MAX_LENGTH)
+  body!: string;
+}
+
+/** Query for the single poll endpoint. */
+export class PollQueryDto {
+  /** Thread currently open, if any. Counts come back either way. */
+  @IsOptional()
+  @IsString()
+  conversationId?: string;
+
+  /**
+   * The previous response's `serverTime`, echoed back verbatim. Never a client
+   * clock — skew against a UTC server would silently drop messages.
+   */
+  @IsOptional()
+  @IsISO8601()
+  since?: string;
+}
+
+export class MentionSearchDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  q?: string;
+}
+
+export class EntityThreadParamsDto {
+  @IsEnum(ConversationEntity)
+  entityType!: ConversationEntity;
+
+  @IsString()
+  entityId!: string;
+}
+
+// ---- Response shapes ----
+
+export interface MessageAuthorDto {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+}
+
+export interface MessageMentionDto {
+  userId: string;
+  firstName: string | null;
+  lastName: string | null;
+}
+
+export interface MessageReferenceDto {
+  entityType: ConversationEntity;
+  entityId: string;
+  label: string;
+}
+
+export interface MessageDto {
+  id: string;
+  conversationId: string;
+  parentMessageId: string | null;
+  body: string;
+  visibility: MessageVisibility;
+  author: MessageAuthorDto;
+  mentions: MessageMentionDto[];
+  references: MessageReferenceDto[];
+  /** A real instant. Format for America/Vancouver on the client. */
+  createdAt: string;
+  editedAt: string | null;
+  deletedAt: string | null;
+}
+
+export interface ConversationDto {
+  id: string;
+  type: ConversationType;
+  title: string | null;
+  entityType: ConversationEntity | null;
+  entityId: string | null;
+  updatedAt: string;
+  unreadCount: number;
+}
+
+export interface MentionInboxItemDto {
+  mentionId: string;
+  readAt: string | null;
+  message: MessageDto;
+  conversation: {
+    id: string;
+    entityType: ConversationEntity | null;
+    entityId: string | null;
+  };
+}
+
+/** One poll serves the open thread and every unread badge. */
+export interface PollResponseDto {
+  messages: MessageDto[];
+  unreadMentions: number;
+  conversationUnreads: Record<string, number>;
+  /** Send this back as `since` on the next poll. */
+  serverTime: string;
+}
+
+export interface MentionableUserDto {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  roleName: string;
+}
+
+export interface ReferenceableRODto {
+  id: string;
+  roNumber: string;
+  status: string;
+}

--- a/libs/data/src/lib/prisma-enums.ts
+++ b/libs/data/src/lib/prisma-enums.ts
@@ -419,3 +419,22 @@ export const CarfaxSyncStatus = {
 } as const;
 export type CarfaxSyncStatus = (typeof CarfaxSyncStatus)[keyof typeof CarfaxSyncStatus];
 
+export const ConversationType = {
+  GENERAL: 'GENERAL',
+  ENTITY: 'ENTITY',
+  DIRECT: 'DIRECT',
+} as const;
+export type ConversationType = (typeof ConversationType)[keyof typeof ConversationType];
+
+export const ConversationEntity = {
+  REPAIR_ORDER: 'REPAIR_ORDER',
+  APPOINTMENT: 'APPOINTMENT',
+} as const;
+export type ConversationEntity = (typeof ConversationEntity)[keyof typeof ConversationEntity];
+
+export const MessageVisibility = {
+  PUBLIC: 'PUBLIC',
+  MENTIONED_ONLY: 'MENTIONED_ONLY',
+} as const;
+export type MessageVisibility = (typeof MessageVisibility)[keyof typeof MessageVisibility];
+

--- a/libs/database/src/lib/prisma/migrations/20260820101846_add_messaging_tables/migration.sql
+++ b/libs/database/src/lib/prisma/migrations/20260820101846_add_messaging_tables/migration.sql
@@ -1,0 +1,126 @@
+
+-- CreateEnum
+CREATE TYPE "public"."ConversationType" AS ENUM ('GENERAL', 'ENTITY', 'DIRECT');
+
+-- CreateEnum
+CREATE TYPE "public"."ConversationEntity" AS ENUM ('REPAIR_ORDER', 'APPOINTMENT');
+
+-- CreateEnum
+CREATE TYPE "public"."MessageVisibility" AS ENUM ('PUBLIC', 'MENTIONED_ONLY');
+
+-- CreateTable
+CREATE TABLE "public"."Conversation" (
+    "id" TEXT NOT NULL,
+    "type" "public"."ConversationType" NOT NULL,
+    "title" TEXT,
+    "entityType" "public"."ConversationEntity",
+    "entityId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ConversationMember" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "lastReadAt" TIMESTAMP(3),
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ConversationMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Message" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "parentMessageId" TEXT,
+    "body" TEXT NOT NULL,
+    "visibility" "public"."MessageVisibility" NOT NULL DEFAULT 'PUBLIC',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "editedAt" TIMESTAMP(3),
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MessageMention" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3),
+
+    CONSTRAINT "MessageMention_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MessageReference" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "entityType" "public"."ConversationEntity" NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+
+    CONSTRAINT "MessageReference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Conversation_type_updatedAt_idx" ON "public"."Conversation"("type", "updatedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Conversation_entityType_entityId_key" ON "public"."Conversation"("entityType", "entityId");
+
+-- CreateIndex
+CREATE INDEX "ConversationMember_userId_idx" ON "public"."ConversationMember"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConversationMember_conversationId_userId_key" ON "public"."ConversationMember"("conversationId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Message_conversationId_createdAt_idx" ON "public"."Message"("conversationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Message_authorId_idx" ON "public"."Message"("authorId");
+
+-- CreateIndex
+CREATE INDEX "Message_parentMessageId_idx" ON "public"."Message"("parentMessageId");
+
+-- CreateIndex
+CREATE INDEX "MessageMention_userId_readAt_idx" ON "public"."MessageMention"("userId", "readAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessageMention_messageId_userId_key" ON "public"."MessageMention"("messageId", "userId");
+
+-- CreateIndex
+CREATE INDEX "MessageReference_entityType_entityId_idx" ON "public"."MessageReference"("entityType", "entityId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessageReference_messageId_entityType_entityId_key" ON "public"."MessageReference"("messageId", "entityType", "entityId");
+
+-- AddForeignKey
+ALTER TABLE "public"."ConversationMember" ADD CONSTRAINT "ConversationMember_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "public"."Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ConversationMember" ADD CONSTRAINT "ConversationMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "public"."Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Message" ADD CONSTRAINT "Message_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Message" ADD CONSTRAINT "Message_parentMessageId_fkey" FOREIGN KEY ("parentMessageId") REFERENCES "public"."Message"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageMention" ADD CONSTRAINT "MessageMention_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "public"."Message"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageMention" ADD CONSTRAINT "MessageMention_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageReference" ADD CONSTRAINT "MessageReference_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "public"."Message"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/database/src/lib/prisma/schema.prisma
+++ b/libs/database/src/lib/prisma/schema.prisma
@@ -40,6 +40,9 @@ model User {
   roServices           ROService[]            @relation("ROServiceCompletedBy") // Service items completed by this user
   roMedia              ROMedia[] // Photos uploaded by this user
   payStubs             PayStub[] // Pay stubs issued to this employee
+  messagesAuthored     Message[]              @relation("MessageAuthor") // Messages this user wrote
+  messageMentions      MessageMention[] // Messages this user was tagged in
+  conversationMembers  ConversationMember[] // Conversations this user belongs to
 }
 
 model Role {
@@ -1903,4 +1906,108 @@ enum CarfaxSyncStatus {
   SENT // Accepted by CARFAX
   FAILED // Send failed (eligible for retry)
   SKIPPED // Not reportable (e.g. no VIN, no reportable services, CARFAX disabled)
+}
+
+// ============================================================================
+// In-app messaging (GA-67)
+// Internal team chat with private @mentions, attached to repair orders and a
+// general channel. Never surfaced on printed or emailed customer documents.
+// ============================================================================
+
+model Conversation {
+  id         String              @id @default(cuid())
+  type       ConversationType
+  title      String? // General channel name; null for entity threads
+  entityType ConversationEntity? // What this thread hangs off, if anything
+  entityId   String? // RepairOrder.id or Appointment.id
+  createdAt  DateTime            @default(now())
+  updatedAt  DateTime            @updatedAt
+
+  messages Message[]
+  members  ConversationMember[]
+
+  @@unique([entityType, entityId]) // One thread per repair order
+  @@index([type, updatedAt])
+}
+
+model ConversationMember {
+  id             String    @id @default(cuid())
+  conversationId String
+  userId         String
+  lastReadAt     DateTime?
+  joinedAt       DateTime  @default(now())
+
+  conversation Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([conversationId, userId])
+  @@index([userId])
+}
+
+model Message {
+  id              String            @id @default(cuid())
+  conversationId  String
+  authorId        String
+  parentMessageId String? // Reply target; drives privacy inheritance
+  body            String // Holds @[Name](user:id) and #[RO-...](ro:id) tokens
+  visibility      MessageVisibility @default(PUBLIC) // Derived server-side, never client-set
+  createdAt       DateTime          @default(now())
+  editedAt        DateTime?
+  deletedAt       DateTime? // Soft delete keeps replies coherent
+
+  conversation Conversation       @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  author       User               @relation("MessageAuthor", fields: [authorId], references: [id])
+  parent       Message?           @relation("MessageReplies", fields: [parentMessageId], references: [id])
+  replies      Message[]          @relation("MessageReplies")
+  mentions     MessageMention[]
+  references   MessageReference[]
+
+  @@index([conversationId, createdAt]) // Primary poll cursor
+  @@index([authorId])
+  @@index([parentMessageId])
+}
+
+// The authoritative ACL for a private message. The inline token in Message.body
+// is only for rendering; access is decided by these rows.
+model MessageMention {
+  id        String    @id @default(cuid())
+  messageId String
+  userId    String
+  readAt    DateTime? // Drives the My Mentions unread badge
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([messageId, userId])
+  @@index([userId, readAt])
+}
+
+// A clickable repair-order reference embedded in a message.
+model MessageReference {
+  id         String             @id @default(cuid())
+  messageId  String
+  entityType ConversationEntity
+  entityId   String
+  label      String // Denormalized "RO-202606-0042" so chips render without a join
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+
+  @@unique([messageId, entityType, entityId])
+  @@index([entityType, entityId]) // "all chatter about this repair order"
+}
+
+enum ConversationType {
+  GENERAL
+  ENTITY
+  DIRECT // Reserved; not built yet
+}
+
+enum ConversationEntity {
+  REPAIR_ORDER
+  APPOINTMENT
+}
+
+enum MessageVisibility {
+  PUBLIC
+  MENTIONED_ONLY
 }

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -3,6 +3,8 @@ export default {
   displayName: 'server',
   preset: '../jest.preset.js',
   testEnvironment: 'node',
+  // DTOs in libs/data carry class-validator decorators, which run on import.
+  setupFiles: ['reflect-metadata'],
   transform: {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },

--- a/server/src/app/app.module.ts
+++ b/server/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { PayStubsModule } from '../pay-stubs/pay-stubs.module';
 import { InspectionsModule } from '../inspections/inspections.module';
 import { RepairOrdersModule } from '../repair-orders/repair-orders.module';
 import { CarfaxModule } from '../carfax/carfax.module';
+import { MessagingModule } from '../messaging/messaging.module';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleGuard } from '../auth/guards/role.guard';
 
@@ -79,6 +80,7 @@ import { RoleGuard } from '../auth/guards/role.guard';
     InspectionsModule,
     RepairOrdersModule,
     CarfaxModule,
+    MessagingModule,
   ],
   controllers: [AppController],
   providers: [

--- a/server/src/messaging/mention-parser.spec.ts
+++ b/server/src/messaging/mention-parser.spec.ts
@@ -1,0 +1,125 @@
+import {
+  buildMentionToken,
+  buildReferenceToken,
+  parseMentionUserIds,
+  parseReferences,
+} from './mention-parser';
+
+describe('parseMentionUserIds', () => {
+  it('returns nothing for a plain message', () => {
+    expect(parseMentionUserIds('please order 4 Michelins')).toEqual([]);
+  });
+
+  it('returns nothing for empty input', () => {
+    expect(parseMentionUserIds('')).toEqual([]);
+  });
+
+  it('pulls the id out of a mention token', () => {
+    expect(
+      parseMentionUserIds('@[Sarah Chen](user:clx123abc) please order')
+    ).toEqual(['clx123abc']);
+  });
+
+  it('keeps several distinct mentions in order', () => {
+    const body = '@[Sarah](user:aaa) and @[Mike](user:bbb) please sort this';
+
+    expect(parseMentionUserIds(body)).toEqual(['aaa', 'bbb']);
+  });
+
+  it('counts a repeated mention once', () => {
+    const body = '@[Sarah](user:aaa) ping @[Sarah](user:aaa) again';
+
+    expect(parseMentionUserIds(body)).toEqual(['aaa']);
+  });
+
+  // A bare "@sarah" is how people type when they mean nothing formal. Treating
+  // it as a mention would silently hide the message from the shop.
+  it('ignores a bare @name that is not a token', () => {
+    expect(parseMentionUserIds('@sarah can you order these')).toEqual([]);
+  });
+
+  it('ignores an email address', () => {
+    expect(parseMentionUserIds('mail sarah@example.com about it')).toEqual([]);
+  });
+
+  it.each([
+    ['no user: prefix', '@[Sarah](clx123)'],
+    ['wrong prefix', '@[Sarah](customer:clx123)'],
+    ['unclosed label', '@[Sarah(user:clx123)'],
+    ['empty id', '@[Sarah](user:)'],
+    ['empty label', '@[](user:clx123)'],
+  ])('ignores a malformed token: %s', (_case, body) => {
+    expect(parseMentionUserIds(body)).toEqual([]);
+  });
+
+  it('does not let a label span lines', () => {
+    expect(parseMentionUserIds('@[Sarah\nChen](user:clx123)')).toEqual([]);
+  });
+
+  it('reads a mention mid-sentence', () => {
+    expect(parseMentionUserIds('ask @[Mike](user:bbb) tomorrow')).toEqual([
+      'bbb',
+    ]);
+  });
+});
+
+describe('parseReferences', () => {
+  it('returns nothing for a plain message', () => {
+    expect(parseReferences('the alignment is done')).toEqual([]);
+  });
+
+  it('pulls out a repair order reference', () => {
+    expect(parseReferences('see #[RO-202606-0042](ro:clx789)')).toEqual([
+      {
+        entityType: 'REPAIR_ORDER',
+        entityId: 'clx789',
+        label: 'RO-202606-0042',
+      },
+    ]);
+  });
+
+  it('deduplicates by id and keeps the first label', () => {
+    const body = '#[RO-1](ro:aaa) and again #[RO-1-renamed](ro:aaa)';
+
+    expect(parseReferences(body)).toEqual([
+      { entityType: 'REPAIR_ORDER', entityId: 'aaa', label: 'RO-1' },
+    ]);
+  });
+
+  it('ignores a hashtag that is not a token', () => {
+    expect(parseReferences('#urgent get this done')).toEqual([]);
+  });
+
+  it('reads mentions and references from the same message', () => {
+    const body = '@[Sarah](user:aaa) parts for #[RO-202606-0042](ro:bbb)';
+
+    expect(parseMentionUserIds(body)).toEqual(['aaa']);
+    expect(parseReferences(body)).toEqual([
+      {
+        entityType: 'REPAIR_ORDER',
+        entityId: 'bbb',
+        label: 'RO-202606-0042',
+      },
+    ]);
+  });
+});
+
+describe('token builders round-trip', () => {
+  it('builds a mention the parser reads back', () => {
+    const token = buildMentionToken('clx123abc', 'Sarah Chen');
+
+    expect(parseMentionUserIds(token)).toEqual(['clx123abc']);
+  });
+
+  it('builds a reference the parser reads back', () => {
+    const token = buildReferenceToken('clx789', 'RO-202606-0042');
+
+    expect(parseReferences(token)).toEqual([
+      {
+        entityType: 'REPAIR_ORDER',
+        entityId: 'clx789',
+        label: 'RO-202606-0042',
+      },
+    ]);
+  });
+});

--- a/server/src/messaging/mention-parser.ts
+++ b/server/src/messaging/mention-parser.ts
@@ -1,0 +1,73 @@
+import type { ConversationEntity } from '@gt-automotive/data';
+
+/**
+ * Mentions and repair-order references are stored inline in the message body
+ * as tokens carrying an id, not a display name:
+ *
+ *   @[Sarah Chen](user:clx123abc)
+ *   #[RO-202606-0042](ro:clx456def)
+ *
+ * Names are for rendering only. Re-resolving a name at read time would break
+ * the moment somebody is renamed, and is ambiguous with two Sarahs.
+ *
+ * Everything here is pure. The server re-runs it on write and ignores whatever
+ * the client claims the mentions were — a token typed by hand grants nothing
+ * on its own, because access is decided by the MessageMention rows these
+ * functions produce.
+ */
+
+const MENTION_TOKEN = /@\[[^\]\n]{1,100}\]\(user:([A-Za-z0-9_-]{1,50})\)/g;
+const REFERENCE_TOKEN = /#\[([^\]\n]{1,50})\]\(ro:([A-Za-z0-9_-]{1,50})\)/g;
+
+export interface ParsedReference {
+  entityType: ConversationEntity;
+  entityId: string;
+  label: string;
+}
+
+/**
+ * User ids tagged in a message, deduplicated, in the order they appear.
+ *
+ * The presence of any id here is what makes a message private, so this is the
+ * single place that decides the audience.
+ */
+export function parseMentionUserIds(body: string): string[] {
+  if (!body) return [];
+
+  const seen = new Set<string>();
+  for (const match of body.matchAll(MENTION_TOKEN)) {
+    seen.add(match[1]);
+  }
+  return [...seen];
+}
+
+/**
+ * Repair orders referenced in a message, deduplicated by id. The label is kept
+ * so a chip can render without joining back to the repair order.
+ */
+export function parseReferences(body: string): ParsedReference[] {
+  if (!body) return [];
+
+  const byId = new Map<string, ParsedReference>();
+  for (const match of body.matchAll(REFERENCE_TOKEN)) {
+    const [, label, entityId] = match;
+    if (!byId.has(entityId)) {
+      byId.set(entityId, {
+        entityType: 'REPAIR_ORDER' as ConversationEntity,
+        entityId,
+        label,
+      });
+    }
+  }
+  return [...byId.values()];
+}
+
+/** Builds the canonical mention token for a user. */
+export function buildMentionToken(userId: string, displayName: string): string {
+  return `@[${displayName}](user:${userId})`;
+}
+
+/** Builds the canonical reference token for a repair order. */
+export function buildReferenceToken(roId: string, roNumber: string): string {
+  return `#[${roNumber}](ro:${roId})`;
+}

--- a/server/src/messaging/messaging.controller.ts
+++ b/server/src/messaging/messaging.controller.ts
@@ -1,0 +1,112 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  CreateMessageDto,
+  MentionSearchDto,
+  PollQueryDto,
+  UpdateMessageDto,
+} from '@gt-automotive/data';
+// Type-only: these appear in decorated signatures, which emitDecoratorMetadata
+// cannot resolve from a value import under isolatedModules.
+import type { ConversationEntity } from '@gt-automotive/data';
+import { MessagingService } from './messaging.service';
+import type { MessagingUser } from './repositories/message.repository';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RoleGuard } from '../auth/guards/role.guard';
+
+/**
+ * Internal messaging. Customers are not on this controller by design — they
+ * have no Clerk login in this system, and nothing here is ever shown on a
+ * document that reaches them.
+ */
+@Controller('messaging')
+@UseGuards(JwtAuthGuard, RoleGuard)
+@Roles('ADMIN', 'SUPERVISOR', 'FOREMAN', 'ACCOUNTANT', 'STAFF')
+export class MessagingController {
+  constructor(private readonly messaging: MessagingService) {}
+
+  /** The single poll: new messages for the open thread, plus every badge. */
+  @Get('poll')
+  poll(@CurrentUser() user: MessagingUser, @Query() query: PollQueryDto) {
+    return this.messaging.poll(user, query.conversationId, query.since);
+  }
+
+  @Get('conversations/general')
+  general(@CurrentUser() user: MessagingUser) {
+    return this.messaging.getGeneralConversation(user.id);
+  }
+
+  @Get('entity/:entityType/:entityId')
+  entityThread(
+    @CurrentUser() user: MessagingUser,
+    @Param('entityType') entityType: ConversationEntity,
+    @Param('entityId') entityId: string
+  ) {
+    return this.messaging.getEntityConversation(entityType, entityId, user.id);
+  }
+
+  @Post('conversations/:id/messages')
+  send(
+    @CurrentUser() user: MessagingUser,
+    @Param('id') conversationId: string,
+    @Body() dto: CreateMessageDto
+  ) {
+    return this.messaging.createMessage(conversationId, user, dto);
+  }
+
+  @Post('conversations/:id/read')
+  markRead(
+    @CurrentUser() user: MessagingUser,
+    @Param('id') conversationId: string
+  ) {
+    return this.messaging.markConversationRead(conversationId, user.id);
+  }
+
+  @Patch('messages/:id')
+  edit(
+    @CurrentUser() user: MessagingUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateMessageDto
+  ) {
+    return this.messaging.updateMessage(id, user, dto.body);
+  }
+
+  @Delete('messages/:id')
+  remove(@CurrentUser() user: MessagingUser, @Param('id') id: string) {
+    return this.messaging.deleteMessage(id, user);
+  }
+
+  @Get('mentions')
+  mentions(
+    @CurrentUser() user: MessagingUser,
+    @Query('unread') unread?: string
+  ) {
+    return this.messaging.getMentionInbox(user, unread === 'true');
+  }
+
+  @Post('mentions/:id/read')
+  markMentionRead(@CurrentUser() user: MessagingUser, @Param('id') id: string) {
+    return this.messaging.markMentionRead(id, user.id);
+  }
+
+  @Get('mentionable-users')
+  mentionableUsers(@Query() query: MentionSearchDto) {
+    return this.messaging.findMentionableUsers(query.q);
+  }
+
+  @Get('referenceable-ros')
+  referenceableRepairOrders(@Query() query: MentionSearchDto) {
+    return this.messaging.findReferenceableRepairOrders(query.q);
+  }
+}

--- a/server/src/messaging/messaging.module.ts
+++ b/server/src/messaging/messaging.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@gt-automotive/database';
+import { MessagingController } from './messaging.controller';
+import { MessagingService } from './messaging.service';
+import { MessageRepository } from './repositories/message.repository';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [MessagingController],
+  providers: [MessagingService, MessageRepository],
+  exports: [MessagingService],
+})
+export class MessagingModule {}

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -1,0 +1,344 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { MessagingService } from './messaging.service';
+import { MessageRepository } from './repositories/message.repository';
+
+/**
+ * The thing worth guarding here is who can read a message.
+ *
+ * Tagging somebody makes a message private, so the derivation of that flag is
+ * a security decision, not a formatting one. Every test below is a way of
+ * getting it wrong: trusting the client, trusting the token, or letting a
+ * reply escape the privacy of what it replies to.
+ */
+describe('MessagingService', () => {
+  let service: MessagingService;
+  let prisma: any;
+  let messages: jest.Mocked<Partial<MessageRepository>>;
+
+  const author = { id: 'author-1', role: { name: 'STAFF' } };
+
+  const internalUsers = [
+    { id: 'sarah-1' },
+    { id: 'mike-1' },
+    { id: 'author-1' },
+  ];
+
+  /** Captures what actually reached the database. */
+  let createdMessage: any;
+
+  const messageRow = (overrides: any = {}) => ({
+    id: 'msg-1',
+    conversationId: 'conv-1',
+    parentMessageId: null,
+    authorId: author.id,
+    body: 'hello',
+    visibility: 'PUBLIC',
+    author: { id: author.id, firstName: 'Vishal', lastName: 'T' },
+    mentions: [],
+    references: [],
+    createdAt: new Date('2026-08-20T17:00:00.000Z'),
+    editedAt: null,
+    deletedAt: null,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    createdMessage = undefined;
+
+    const tx = {
+      message: {
+        create: jest.fn().mockImplementation(({ data }) => {
+          createdMessage = data;
+          return Promise.resolve(
+            messageRow({ body: data.body, visibility: data.visibility })
+          );
+        }),
+        update: jest.fn().mockImplementation(({ data }) => {
+          createdMessage = data;
+          return Promise.resolve(
+            messageRow({ body: data.body, visibility: data.visibility })
+          );
+        }),
+      },
+      messageMention: { deleteMany: jest.fn().mockResolvedValue({ count: 0 }) },
+      messageReference: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      conversation: { update: jest.fn().mockResolvedValue({}) },
+    };
+
+    prisma = {
+      $transaction: jest.fn((fn: any) => fn(tx)),
+      conversation: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'conv-1' }),
+        findFirst: jest.fn().mockResolvedValue({ id: 'conv-1' }),
+        create: jest.fn(),
+      },
+      conversationMember: {
+        upsert: jest.fn().mockResolvedValue({}),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      user: {
+        findMany: jest.fn().mockImplementation(({ where }) => {
+          const ids: string[] = where?.id?.in ?? [];
+          return Promise.resolve(
+            internalUsers.filter((u) => ids.includes(u.id))
+          );
+        }),
+      },
+      message: { update: jest.fn().mockResolvedValue({}) },
+      messageMention: {
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        findFirst: jest.fn().mockResolvedValue({ id: 'mention-1' }),
+      },
+      repairOrder: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    messages = {
+      findByIdForUser: jest.fn(),
+      findForConversation: jest.fn().mockResolvedValue([]),
+      countUnreadMentions: jest.fn().mockResolvedValue(0),
+      unreadCountsByConversation: jest.fn().mockResolvedValue({}),
+    };
+
+    service = new MessagingService(prisma, messages as never);
+  });
+
+  const send = (body: string, parentMessageId?: string) =>
+    service.createMessage('conv-1', author, { body, parentMessageId });
+
+  describe('deriving visibility from the body', () => {
+    it('leaves an untagged message public', async () => {
+      await send('rear brakes are done');
+
+      expect(createdMessage.visibility).toBe('PUBLIC');
+      expect(createdMessage.mentions.create).toEqual([]);
+    });
+
+    it('makes a tagged message private to that person', async () => {
+      await send('@[Sarah](user:sarah-1) please order 4 Michelins');
+
+      expect(createdMessage.visibility).toBe('MENTIONED_ONLY');
+      expect(createdMessage.mentions.create).toEqual([{ userId: 'sarah-1' }]);
+    });
+
+    it('makes two tags an audience of both', async () => {
+      await send('@[Sarah](user:sarah-1) @[Mike](user:mike-1) sort this out');
+
+      expect(createdMessage.visibility).toBe('MENTIONED_ONLY');
+      expect(createdMessage.mentions.create).toEqual([
+        { userId: 'sarah-1' },
+        { userId: 'mike-1' },
+      ]);
+    });
+
+    it('does not create a mention row for the author tagging themselves', async () => {
+      await send('@[Me](user:author-1) note to self');
+
+      expect(createdMessage.mentions.create).toEqual([]);
+    });
+  });
+
+  describe('what the client is not allowed to decide', () => {
+    // The DTO has no visibility field, but a client can always send extra keys.
+    it('ignores a visibility sent by the client', async () => {
+      await service.createMessage('conv-1', author, {
+        body: '@[Sarah](user:sarah-1) parts please',
+        visibility: 'PUBLIC',
+      } as never);
+
+      expect(createdMessage.visibility).toBe('MENTIONED_ONLY');
+    });
+
+    it('ignores a mention list sent by the client', async () => {
+      await service.createMessage('conv-1', author, {
+        body: 'nothing tagged here',
+        mentions: [{ userId: 'mike-1' }],
+      } as never);
+
+      expect(createdMessage.visibility).toBe('PUBLIC');
+      expect(createdMessage.mentions.create).toEqual([]);
+    });
+
+    // Otherwise anyone could paste a token for an id that is not a colleague
+    // and hand themselves — or a customer — sight of the thread.
+    it('drops a token for someone who is not an active internal user', async () => {
+      await send('@[Ghost](user:not-a-user) hello');
+
+      expect(createdMessage.visibility).toBe('PUBLIC');
+      expect(createdMessage.mentions.create).toEqual([]);
+    });
+
+    it('keeps the real tags when a forged one rides alongside', async () => {
+      await send('@[Sarah](user:sarah-1) @[Ghost](user:not-a-user) hi');
+
+      expect(createdMessage.mentions.create).toEqual([{ userId: 'sarah-1' }]);
+    });
+  });
+
+  describe('replies inherit privacy', () => {
+    it('keeps an untagged reply to a private message private', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({
+          id: 'parent-1',
+          authorId: 'mike-1',
+          visibility: 'MENTIONED_ONLY',
+          mentions: [{ userId: 'sarah-1', user: {} }],
+        })
+      );
+
+      await send('on it', 'parent-1');
+
+      expect(createdMessage.visibility).toBe('MENTIONED_ONLY');
+    });
+
+    it('carries the parent audience so the thread stays readable to them', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({
+          id: 'parent-1',
+          authorId: 'mike-1',
+          visibility: 'MENTIONED_ONLY',
+          mentions: [{ userId: 'sarah-1', user: {} }],
+        })
+      );
+
+      await send('on it', 'parent-1');
+
+      expect(createdMessage.mentions.create).toEqual(
+        expect.arrayContaining([{ userId: 'sarah-1' }, { userId: 'mike-1' }])
+      );
+    });
+
+    it('leaves a reply to a public message public', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({ id: 'parent-1', visibility: 'PUBLIC' })
+      );
+
+      await send('agreed', 'parent-1');
+
+      expect(createdMessage.visibility).toBe('PUBLIC');
+    });
+
+    it('refuses to reply to a message the user cannot see', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(null);
+
+      await expect(send('sneaky', 'parent-1')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+
+    it('refuses to reply across conversations', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({ id: 'parent-1', conversationId: 'other-conv' })
+      );
+
+      await expect(send('wrong thread', 'parent-1')).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe('editing', () => {
+    it('re-derives visibility, so removing the tag makes it public', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({ visibility: 'MENTIONED_ONLY', authorId: author.id })
+      );
+
+      await service.updateMessage('msg-1', author, 'never mind, all done');
+
+      expect(createdMessage.visibility).toBe('PUBLIC');
+    });
+
+    it('refuses to edit somebody else’s message', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({ authorId: 'mike-1' })
+      );
+
+      await expect(
+        service.updateMessage('msg-1', author, 'edited')
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('deleting', () => {
+    it('soft deletes rather than removing the row', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({ authorId: author.id })
+      );
+
+      await service.deleteMessage('msg-1', author);
+
+      expect(prisma.message.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+        })
+      );
+    });
+
+    it('refuses to delete somebody else’s message', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({ authorId: 'mike-1' })
+      );
+
+      await expect(service.deleteMessage('msg-1', author)).rejects.toThrow(
+        ForbiddenException
+      );
+    });
+
+    it('lets an admin delete anyone’s message', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({ authorId: 'mike-1' })
+      );
+
+      await expect(
+        service.deleteMessage('msg-1', {
+          id: 'admin-1',
+          role: { name: 'ADMIN' },
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('mentionable users', () => {
+    it('asks only for active internal users, never customers', async () => {
+      prisma.user.findMany.mockResolvedValue([]);
+
+      await service.findMentionableUsers('sa');
+
+      const where = prisma.user.findMany.mock.calls.at(-1)[0].where;
+      expect(where.isActive).toBe(true);
+      expect(where.role.name.in).not.toContain('CUSTOMER');
+      expect(where.role.name.in).toEqual(
+        expect.arrayContaining(['ADMIN', 'STAFF', 'FOREMAN'])
+      );
+    });
+  });
+
+  describe('poll', () => {
+    it('returns a serverTime for the client to send back as the cursor', async () => {
+      const result = await service.poll(author, 'conv-1');
+
+      expect(result.serverTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(result.messages).toEqual([]);
+    });
+
+    it('reports counts even with no thread open', async () => {
+      (messages.countUnreadMentions as jest.Mock).mockResolvedValue(3);
+
+      const result = await service.poll(author);
+
+      expect(result.unreadMentions).toBe(3);
+      expect(messages.findForConversation).not.toHaveBeenCalled();
+    });
+
+    it('emits createdAt as a real instant, not a business date', async () => {
+      (messages.findForConversation as jest.Mock).mockResolvedValue([
+        messageRow(),
+      ]);
+
+      const result = await service.poll(author, 'conv-1');
+
+      expect(result.messages[0].createdAt).toBe('2026-08-20T17:00:00.000Z');
+    });
+  });
+});

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -1,0 +1,478 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '@gt-automotive/database';
+import {
+  ConversationEntity,
+  CreateMessageDto,
+  MessageDto,
+  MessageVisibility,
+  PollResponseDto,
+} from '@gt-automotive/data';
+import {
+  MessageRepository,
+  MessageWithRelations,
+  MESSAGE_INCLUDE,
+  MessagingUser,
+} from './repositories/message.repository';
+import { parseMentionUserIds, parseReferences } from './mention-parser';
+
+/** Roles that may use messaging. Customers are deliberately absent. */
+const INTERNAL_ROLES = [
+  'ADMIN',
+  'SUPERVISOR',
+  'FOREMAN',
+  'ACCOUNTANT',
+  'STAFF',
+];
+
+/** The one shop-wide channel. */
+const GENERAL_TITLE = 'Shop Chat';
+
+@Injectable()
+export class MessagingService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly messages: MessageRepository
+  ) {}
+
+  // ---- Reading ----
+
+  /**
+   * One request serves the open thread and every unread badge.
+   *
+   * `since` comes back from the previous response's serverTime rather than a
+   * client clock: a browser running a few seconds fast would ask for messages
+   * newer than a moment that has not happened yet, and silently miss them.
+   */
+  async poll(
+    user: MessagingUser,
+    conversationId?: string,
+    since?: string
+  ): Promise<PollResponseDto> {
+    const serverTime = new Date();
+    const sinceDate = since ? new Date(since) : undefined;
+
+    const messages = conversationId
+      ? await this.messages.findForConversation(conversationId, user, sinceDate)
+      : [];
+
+    if (conversationId) {
+      await this.ensureMembership(conversationId, user.id);
+    }
+
+    const [unreadMentions, conversationUnreads] = await Promise.all([
+      this.messages.countUnreadMentions(user.id),
+      this.messages.unreadCountsByConversation(user),
+    ]);
+
+    return {
+      messages: messages.map((m) => this.toDto(m)),
+      unreadMentions,
+      conversationUnreads,
+      serverTime: serverTime.toISOString(),
+    };
+  }
+
+  async getMentionInbox(user: MessagingUser, unreadOnly: boolean) {
+    const rows = await this.messages.findMentionInbox(user.id, unreadOnly);
+
+    return rows.map((row) => ({
+      mentionId: row.id,
+      readAt: row.readAt?.toISOString() ?? null,
+      message: this.toDto(row.message as unknown as MessageWithRelations),
+      conversation: {
+        id: row.message.conversation.id,
+        entityType: row.message.conversation.entityType,
+        entityId: row.message.conversation.entityId,
+      },
+    }));
+  }
+
+  // ---- Writing ----
+
+  /**
+   * Post a message.
+   *
+   * Visibility is worked out here and never taken from the request. A client
+   * that could set it — or hand us a mention list — could tag itself into
+   * somebody else's private message, so the body is the only input trusted and
+   * the mentions are re-derived from it on every write.
+   */
+  async createMessage(
+    conversationId: string,
+    user: MessagingUser,
+    dto: CreateMessageDto
+  ): Promise<MessageDto> {
+    await this.assertConversationExists(conversationId);
+    await this.ensureMembership(conversationId, user.id);
+
+    const mentionedIds = await this.resolveMentionableIds(
+      parseMentionUserIds(dto.body)
+    );
+    const references = parseReferences(dto.body);
+
+    let visibility: MessageVisibility =
+      mentionedIds.length > 0 ? 'MENTIONED_ONLY' : 'PUBLIC';
+    const audience = new Set(mentionedIds);
+
+    if (dto.parentMessageId) {
+      const parent = await this.messages.findByIdForUser(
+        dto.parentMessageId,
+        user
+      );
+      if (!parent || parent.conversationId !== conversationId) {
+        throw new NotFoundException('Message being replied to was not found');
+      }
+
+      // A reply can never be more visible than what it replies to. Without
+      // this, answering a private message without tagging anybody would post
+      // publicly into a thread nobody else can see — which leaks the original
+      // by implication and reads as a non-sequitur to everyone else.
+      if (parent.visibility === 'MENTIONED_ONLY') {
+        visibility = 'MENTIONED_ONLY';
+        parent.mentions.forEach((m) => audience.add(m.userId));
+        audience.add(parent.authorId);
+      }
+    }
+
+    // The author reaching themselves is implicit — they can always see their
+    // own message — so a self-mention row would only add noise.
+    audience.delete(user.id);
+
+    const created = await this.prisma.$transaction(async (tx) => {
+      const message = await tx.message.create({
+        data: {
+          conversationId,
+          authorId: user.id,
+          parentMessageId: dto.parentMessageId ?? null,
+          body: dto.body,
+          visibility,
+          mentions: {
+            create: [...audience].map((userId) => ({ userId })),
+          },
+          references: {
+            create: references.map((ref) => ({
+              entityType: ref.entityType,
+              entityId: ref.entityId,
+              label: ref.label,
+            })),
+          },
+        },
+        include: MESSAGE_INCLUDE,
+      });
+
+      await tx.conversation.update({
+        where: { id: conversationId },
+        data: { updatedAt: new Date() },
+      });
+
+      return message;
+    });
+
+    return this.toDto(created);
+  }
+
+  async updateMessage(
+    id: string,
+    user: MessagingUser,
+    body: string
+  ): Promise<MessageDto> {
+    const existing = await this.messages.findByIdForUser(id, user);
+    if (!existing) {
+      throw new NotFoundException('Message not found');
+    }
+    if (existing.authorId !== user.id) {
+      throw new ForbiddenException('You can only edit your own messages');
+    }
+
+    const mentionedIds = await this.resolveMentionableIds(
+      parseMentionUserIds(body)
+    );
+    const references = parseReferences(body);
+    const audience = new Set(mentionedIds);
+    audience.delete(user.id);
+
+    // An edit re-derives visibility from the new body, so removing the last
+    // mention makes a message public. Editing a reply cannot widen it, though:
+    // the inherited floor is recomputed from the parent, same as on create.
+    let visibility: MessageVisibility =
+      audience.size > 0 ? 'MENTIONED_ONLY' : 'PUBLIC';
+
+    if (existing.parentMessageId) {
+      const parent = await this.messages.findByIdForUser(
+        existing.parentMessageId,
+        user
+      );
+      if (parent?.visibility === 'MENTIONED_ONLY') {
+        visibility = 'MENTIONED_ONLY';
+        parent.mentions.forEach((m) => audience.add(m.userId));
+        audience.add(parent.authorId);
+        audience.delete(user.id);
+      }
+    }
+
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await tx.messageMention.deleteMany({ where: { messageId: id } });
+      await tx.messageReference.deleteMany({ where: { messageId: id } });
+
+      return tx.message.update({
+        where: { id },
+        data: {
+          body,
+          visibility,
+          editedAt: new Date(),
+          mentions: { create: [...audience].map((userId) => ({ userId })) },
+          references: {
+            create: references.map((ref) => ({
+              entityType: ref.entityType,
+              entityId: ref.entityId,
+              label: ref.label,
+            })),
+          },
+        },
+        include: MESSAGE_INCLUDE,
+      });
+    });
+
+    return this.toDto(updated);
+  }
+
+  /**
+   * Soft delete. The row stays so replies keep their parent and the thread
+   * still reads in order; the body is simply no longer returned.
+   */
+  async deleteMessage(id: string, user: MessagingUser): Promise<void> {
+    const existing = await this.messages.findByIdForUser(id, user);
+    if (!existing) {
+      throw new NotFoundException('Message not found');
+    }
+    if (existing.authorId !== user.id && user.role.name !== 'ADMIN') {
+      throw new ForbiddenException('You can only delete your own messages');
+    }
+
+    await this.prisma.message.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  async markConversationRead(
+    conversationId: string,
+    userId: string
+  ): Promise<void> {
+    await this.ensureMembership(conversationId, userId);
+    await this.prisma.conversationMember.updateMany({
+      where: { conversationId, userId },
+      data: { lastReadAt: new Date() },
+    });
+  }
+
+  async markMentionRead(mentionId: string, userId: string): Promise<void> {
+    const result = await this.prisma.messageMention.updateMany({
+      where: { id: mentionId, userId, readAt: null },
+      data: { readAt: new Date() },
+    });
+    if (result.count === 0) {
+      // Either it is not theirs or it was already read. Both are no-ops from
+      // the caller's point of view, but a missing mention should still 404
+      // rather than quietly succeed.
+      const exists = await this.prisma.messageMention.findFirst({
+        where: { id: mentionId, userId },
+        select: { id: true },
+      });
+      if (!exists) {
+        throw new NotFoundException('Mention not found');
+      }
+    }
+  }
+
+  // ---- Conversations ----
+
+  /** The shop-wide channel, created on first use. */
+  async getGeneralConversation(userId: string) {
+    const existing = await this.prisma.conversation.findFirst({
+      where: { type: 'GENERAL' },
+    });
+
+    const conversation =
+      existing ??
+      (await this.prisma.conversation.create({
+        data: { type: 'GENERAL', title: GENERAL_TITLE },
+      }));
+
+    await this.ensureMembership(conversation.id, userId);
+    return conversation;
+  }
+
+  /**
+   * The thread for a repair order, created on first use. The unique constraint
+   * on (entityType, entityId) is what guarantees one thread per repair order
+   * even if two people open it at the same moment.
+   */
+  async getEntityConversation(
+    entityType: ConversationEntity,
+    entityId: string,
+    userId: string
+  ) {
+    const existing = await this.prisma.conversation.findUnique({
+      where: { entityType_entityId: { entityType, entityId } },
+    });
+
+    let conversation = existing;
+    if (!conversation) {
+      try {
+        conversation = await this.prisma.conversation.create({
+          data: { type: 'ENTITY', entityType, entityId },
+        });
+      } catch {
+        // Lost a race with another request; theirs is just as good as ours.
+        conversation = await this.prisma.conversation.findUnique({
+          where: { entityType_entityId: { entityType, entityId } },
+        });
+      }
+    }
+
+    if (!conversation) {
+      throw new NotFoundException('Could not open a thread for this record');
+    }
+
+    await this.ensureMembership(conversation.id, userId);
+    return conversation;
+  }
+
+  // ---- Lookups for the composer ----
+
+  /** Who can be tagged. Customers are excluded — they have no login. */
+  async findMentionableUsers(query?: string) {
+    const users = await this.prisma.user.findMany({
+      where: {
+        isActive: true,
+        role: { name: { in: INTERNAL_ROLES as never[] } },
+        ...(query
+          ? {
+              OR: [
+                {
+                  firstName: { contains: query, mode: 'insensitive' as const },
+                },
+                { lastName: { contains: query, mode: 'insensitive' as const } },
+              ],
+            }
+          : {}),
+      },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        role: { select: { name: true } },
+      },
+      orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+      take: 25,
+    });
+
+    return users.map((u) => ({
+      id: u.id,
+      firstName: u.firstName,
+      lastName: u.lastName,
+      roleName: u.role.name,
+    }));
+  }
+
+  async findReferenceableRepairOrders(query?: string) {
+    const ros = await this.prisma.repairOrder.findMany({
+      where: query
+        ? { roNumber: { contains: query, mode: 'insensitive' } }
+        : {},
+      select: { id: true, roNumber: true, status: true },
+      orderBy: { openedAt: 'desc' },
+      take: 25,
+    });
+
+    return ros.map((ro) => ({
+      id: ro.id,
+      roNumber: ro.roNumber,
+      status: ro.status,
+    }));
+  }
+
+  // ---- Internals ----
+
+  /**
+   * Drops any id that is not an active internal user.
+   *
+   * A body can carry any token somebody cares to type, including a customer id
+   * or a deactivated employee. Only ids that survive this become mentions, and
+   * therefore only they can widen who sees the message.
+   */
+  private async resolveMentionableIds(ids: string[]): Promise<string[]> {
+    if (ids.length === 0) return [];
+
+    const users = await this.prisma.user.findMany({
+      where: {
+        id: { in: ids },
+        isActive: true,
+        role: { name: { in: INTERNAL_ROLES as never[] } },
+      },
+      select: { id: true },
+    });
+
+    const allowed = new Set(users.map((u) => u.id));
+    return ids.filter((id) => allowed.has(id));
+  }
+
+  private async assertConversationExists(id: string): Promise<void> {
+    const found = await this.prisma.conversation.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!found) {
+      throw new NotFoundException('Conversation not found');
+    }
+  }
+
+  private async ensureMembership(
+    conversationId: string,
+    userId: string
+  ): Promise<void> {
+    await this.prisma.conversationMember.upsert({
+      where: { conversationId_userId: { conversationId, userId } },
+      create: { conversationId, userId },
+      update: {},
+    });
+  }
+
+  /**
+   * `createdAt` goes out as a real instant. It is a point in time, not a
+   * business calendar date, so it must not pass through the business-day
+   * helpers — the client formats it for America/Vancouver.
+   */
+  private toDto(message: MessageWithRelations): MessageDto {
+    return {
+      id: message.id,
+      conversationId: message.conversationId,
+      parentMessageId: message.parentMessageId,
+      body: message.body,
+      visibility: message.visibility,
+      author: {
+        id: message.author.id,
+        firstName: message.author.firstName,
+        lastName: message.author.lastName,
+      },
+      mentions: message.mentions.map((m) => ({
+        userId: m.userId,
+        firstName: m.user.firstName,
+        lastName: m.user.lastName,
+      })),
+      references: message.references.map((r) => ({
+        entityType: r.entityType,
+        entityId: r.entityId,
+        label: r.label,
+      })),
+      createdAt: message.createdAt.toISOString(),
+      editedAt: message.editedAt?.toISOString() ?? null,
+      deletedAt: message.deletedAt?.toISOString() ?? null,
+    };
+  }
+}

--- a/server/src/messaging/repositories/message.repository.spec.ts
+++ b/server/src/messaging/repositories/message.repository.spec.ts
@@ -1,0 +1,51 @@
+import { MessageRepository, MessagingUser } from './message.repository';
+
+/**
+ * The visibility filter decides who can read what, so it is tested as a value
+ * rather than through a query. What matters is the shape of the clause handed
+ * to Prisma — if it is ever `{}` for a non-admin, every private message in the
+ * shop becomes readable.
+ */
+describe('MessageRepository.visibilityFilter', () => {
+  const repo = new MessageRepository({} as never);
+
+  const asUser = (id: string, roleName: string): MessagingUser => ({
+    id,
+    role: { name: roleName },
+  });
+
+  it('lets an admin see everything', () => {
+    expect(repo.visibilityFilter(asUser('admin1', 'ADMIN'))).toEqual({});
+  });
+
+  it.each(['STAFF', 'SUPERVISOR', 'FOREMAN', 'ACCOUNTANT'])(
+    'constrains %s to public, own, and mentioned',
+    (roleName) => {
+      const filter = repo.visibilityFilter(asUser('u1', roleName));
+
+      expect(filter).toEqual({
+        OR: [
+          { visibility: 'PUBLIC' },
+          { authorId: 'u1' },
+          { mentions: { some: { userId: 'u1' } } },
+        ],
+      });
+    }
+  );
+
+  it('never returns an unrestricted filter for a non-admin', () => {
+    for (const roleName of ['STAFF', 'SUPERVISOR', 'FOREMAN', 'ACCOUNTANT']) {
+      const filter = repo.visibilityFilter(asUser('u1', roleName));
+
+      expect(filter).not.toEqual({});
+      expect(filter.OR).toHaveLength(3);
+    }
+  });
+
+  it('scopes the filter to the asking user, not a shared one', () => {
+    const mine = repo.visibilityFilter(asUser('u1', 'STAFF'));
+    const theirs = repo.visibilityFilter(asUser('u2', 'STAFF'));
+
+    expect(mine).not.toEqual(theirs);
+  });
+});

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -1,0 +1,165 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '@gt-automotive/database';
+
+/** The slice of the authenticated user this repository needs. */
+export interface MessagingUser {
+  id: string;
+  role: { name: string };
+}
+
+/**
+ * Everything needed to render a message. Kept in one place so no read path
+ * can accidentally return a message without its mentions — the mentions are
+ * what the UI uses to draw the private badge, and their absence would make a
+ * private message look public.
+ */
+export const MESSAGE_INCLUDE = {
+  author: { select: { id: true, firstName: true, lastName: true } },
+  mentions: {
+    select: {
+      userId: true,
+      user: { select: { firstName: true, lastName: true } },
+    },
+  },
+  references: {
+    select: { entityType: true, entityId: true, label: true },
+  },
+} satisfies Prisma.MessageInclude;
+
+export type MessageWithRelations = Prisma.MessageGetPayload<{
+  include: typeof MESSAGE_INCLUDE;
+}>;
+
+@Injectable()
+export class MessageRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Who is allowed to see what.
+   *
+   * This is the security boundary for the whole feature, and it is deliberately
+   * the only place the rule is written. Every read composes it. Nothing filters
+   * on the client — a hidden message must never reach the browser at all, so
+   * hiding one with CSS would be a leak, not a fix.
+   *
+   * A message is visible when it is public, or you wrote it, or you were tagged
+   * in it. Admins see everything, which the composer tells people up front.
+   */
+  visibilityFilter(user: MessagingUser): Prisma.MessageWhereInput {
+    if (user.role.name === 'ADMIN') {
+      return {};
+    }
+
+    return {
+      OR: [
+        { visibility: 'PUBLIC' },
+        { authorId: user.id },
+        { mentions: { some: { userId: user.id } } },
+      ],
+    };
+  }
+
+  /** Messages in a thread that this user may see, oldest first. */
+  async findForConversation(
+    conversationId: string,
+    user: MessagingUser,
+    since?: Date
+  ): Promise<MessageWithRelations[]> {
+    return this.prisma.message.findMany({
+      where: {
+        conversationId,
+        deletedAt: null,
+        ...(since ? { createdAt: { gt: since } } : {}),
+        AND: [this.visibilityFilter(user)],
+      },
+      include: MESSAGE_INCLUDE,
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  /** A single message, or null when this user may not see it. */
+  async findByIdForUser(
+    id: string,
+    user: MessagingUser
+  ): Promise<MessageWithRelations | null> {
+    return this.prisma.message.findFirst({
+      where: {
+        id,
+        deletedAt: null,
+        AND: [this.visibilityFilter(user)],
+      },
+      include: MESSAGE_INCLUDE,
+    });
+  }
+
+  /**
+   * Unread mentions for the badge and the inbox.
+   *
+   * No visibility filter needed: being mentioned is itself the grant, so every
+   * row here is one this user is allowed to read by definition.
+   */
+  async countUnreadMentions(userId: string): Promise<number> {
+    return this.prisma.messageMention.count({
+      where: { userId, readAt: null, message: { deletedAt: null } },
+    });
+  }
+
+  async findMentionInbox(userId: string, unreadOnly: boolean) {
+    return this.prisma.messageMention.findMany({
+      where: {
+        userId,
+        message: { deletedAt: null },
+        ...(unreadOnly ? { readAt: null } : {}),
+      },
+      select: {
+        id: true,
+        readAt: true,
+        message: {
+          include: {
+            ...MESSAGE_INCLUDE,
+            conversation: {
+              select: { id: true, entityType: true, entityId: true },
+            },
+          },
+        },
+      },
+      orderBy: { message: { createdAt: 'desc' } },
+      take: 100,
+    });
+  }
+
+  /**
+   * Unread counts per conversation, for the sidebar dots.
+   *
+   * Counts only messages this user may see, so a private message they are not
+   * part of cannot betray its existence through a badge that never clears.
+   */
+  async unreadCountsByConversation(
+    user: MessagingUser
+  ): Promise<Record<string, number>> {
+    const memberships = await this.prisma.conversationMember.findMany({
+      where: { userId: user.id },
+      select: { conversationId: true, lastReadAt: true },
+    });
+
+    const counts: Record<string, number> = {};
+    for (const membership of memberships) {
+      const count = await this.prisma.message.count({
+        where: {
+          conversationId: membership.conversationId,
+          deletedAt: null,
+          authorId: { not: user.id },
+          ...(membership.lastReadAt
+            ? { createdAt: { gt: membership.lastReadAt } }
+            : {}),
+          AND: [this.visibilityFilter(user)],
+        },
+      });
+      if (count > 0) {
+        counts[membership.conversationId] = count;
+      }
+    }
+    return counts;
+  }
+}


### PR DESCRIPTION
Backend foundation for in-app messaging. No UI yet — that is GA-70.

Jira: [GA-69](https://gt-automotives.atlassian.net/browse/GA-69) · Epic: [GA-67](https://gt-automotives.atlassian.net/browse/GA-67) · Plan: `.claude/docs/messaging-integration-plan.md`

## The rule this implements

**Tagging somebody makes a message private to them. An untagged message is visible to everyone.** Admins can read everything, which the composer will say out loud in GA-70.

## Schema

Five tables. `Conversation` hangs off a repair order through `(entityType, entityId)`, made unique so a repair order can only ever have one thread — that constraint is also what makes the get-or-create safe when two people open the same RO at once.

`MessageMention` is the authoritative ACL, indexed on `(userId, readAt)` since that pair serves both the visibility check and the mentions inbox. `MessageReference` holds the clickable RO chip with the number denormalized, so chips render without a join.

## Deriving the audience is a security decision, so it happens in one place

`CreateMessageDto` carries **no `visibility` field and no mention list**. Both are re-derived from the body on every write — a client able to set either could tag itself into a colleague's private message.

A token is only a rendering hint. The ids it yields are checked against active internal users, so a hand-typed token for a customer, a former employee, or a stranger yields nothing. Access is decided by the `MessageMention` rows, never by the text.

Reading composes a single filter in the repository: public, or yours, or you were tagged. Nothing filters on the client — a hidden message that reaches the browser has already leaked, so hiding one with CSS would be the bug, not the fix.

## Replies inherit privacy

Worth review attention, since it is the non-obvious part.

Without inheritance, replying to a private message **without tagging anybody** would post publicly into a thread nobody else can see. That leaks the original by implication and reads as a non-sequitur to everyone else. So a reply can never be more visible than what it replies to, and it carries the parent's audience so the thread stays coherent for them.

Editing re-derives the same way — dropping the last tag makes a message public — but a reply cannot climb out of the privacy it inherited.

## Timestamps

`createdAt` goes out as a real instant, formatted for America/Vancouver on the client. It deliberately does **not** pass through `toBusinessCalendarDate()` or `businessDayUtcRange()`: a chat time is a point in time, not a business calendar date. Conflating those is the bug class that hit this repo in Nov 2025 and Jul 2026, so there is a test pinning it.

## Migration note

Generated by diffing schemas rather than `migrate dev`. At the time, the local database had GA-64's migration applied while that branch was unmerged, so `migrate dev` read it as drift and wanted a reset. The SQL is identical to what `migrate dev` produces and touches messaging objects only — verified by grepping the output for any non-messaging `ALTER`/`DROP`. Since rebasing onto merged `main`, `migrate status` reports no drift.

## Jest change

`setupFiles: ['reflect-metadata']` was needed: no server spec had ever imported a DTO from `libs/data`, so nobody had hit the class-validator decorators running on import. Any future spec touching a DTO would have failed the same way.

## Verification

- `tsc --noEmit -p server/tsconfig.app.json` clean
- `nx lint server` — 0 errors
- `nx test server` — 621 tests, 36 suites, all passing
- 50 new tests: 21 parser, 7 visibility filter, 22 service

Covering, among others: an untagged message stays public · a tagged one goes private · a self-tag creates no row · client-sent `visibility` is ignored · client-sent mention list is ignored · a forged token for a non-user grants nothing · real tags survive alongside a forged one · an untagged reply to a private message stays private · a reply cannot cross conversations · edits re-derive · admin can delete anyone's · `mentionable-users` never returns customers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)