### PR TITLE
Messaging UI: the conversation inside the repair order (GA-70)

### DIFF
--- a/apps/webApp/src/app/components/messaging/MessageComposer.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageComposer.tsx
@@ -1,0 +1,324 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  ClickAwayListener,
+  IconButton,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Popper,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import LockIcon from '@mui/icons-material/Lock';
+import GroupIcon from '@mui/icons-material/Group';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import {
+  buildMentionToken,
+  buildReferenceToken,
+  parseMentionUserIds,
+} from '@gt-automotive/data';
+import {
+  searchMentionableUsers,
+  searchReferenceableROs,
+} from '../../requests/messaging.requests';
+import { colors } from '../../theme/colors';
+
+interface Picked {
+  id: string;
+  label: string;
+  kind: 'user' | 'ro';
+}
+
+interface Suggestion {
+  id: string;
+  label: string;
+  secondary?: string;
+}
+
+interface Props {
+  onSend: (body: string) => Promise<void>;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Turns what is on screen into what gets sent.
+ *
+ * The field shows "@Sarah Chen" because nobody should have to look at a raw
+ * token while typing. Each picked name is converted back to its token here,
+ * matched by the exact text that was inserted — so if somebody edits a name
+ * after picking it, that mention quietly stops being one. The audience strip
+ * is computed from this same output rather than from the picked list, which
+ * is what makes it honest: it shows the audience of the message that will
+ * actually be sent, not the one we hoped for.
+ */
+function buildBody(text: string, picked: Picked[]): string {
+  let body = text;
+  for (const item of picked) {
+    const shown = item.kind === 'user' ? `@${item.label}` : `#${item.label}`;
+    const token =
+      item.kind === 'user'
+        ? buildMentionToken(item.id, item.label)
+        : buildReferenceToken(item.id, item.label);
+
+    body = body.replace(new RegExp(escapeRegExp(shown)), token);
+  }
+  return body;
+}
+
+/** The trigger being typed at the caret, if any. */
+function activeTrigger(text: string, caret: number) {
+  const upToCaret = text.slice(0, caret);
+  const match = /(^|\s)([@#])([^\s@#]{0,30})$/.exec(upToCaret);
+  if (!match) return null;
+
+  const [, lead, sigil, query] = match;
+  return {
+    sigil: sigil as '@' | '#',
+    query,
+    start: upToCaret.length - query.length - 1,
+    leadLength: lead.length,
+  };
+}
+
+export function MessageComposer({ onSend, disabled, placeholder }: Props) {
+  const [text, setText] = useState('');
+  const [picked, setPicked] = useState<Picked[]>([]);
+  const [sending, setSending] = useState(false);
+
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [trigger, setTrigger] = useState<ReturnType<
+    typeof activeTrigger
+  > | null>(null);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  const body = useMemo(() => buildBody(text, picked), [text, picked]);
+  const mentionedIds = useMemo(() => parseMentionUserIds(body), [body]);
+  const isPrivate = mentionedIds.length > 0;
+
+  const mentionedNames = useMemo(
+    () =>
+      picked
+        .filter((p) => p.kind === 'user' && mentionedIds.includes(p.id))
+        .map((p) => p.label),
+    [picked, mentionedIds]
+  );
+
+  // Debounced at 300ms to match the invoice and vendor search already in the app.
+  useEffect(() => {
+    if (!trigger) {
+      setSuggestions([]);
+      return;
+    }
+
+    let cancelled = false;
+    setSearching(true);
+    const handle = setTimeout(async () => {
+      try {
+        if (trigger.sigil === '@') {
+          const users = await searchMentionableUsers(trigger.query);
+          if (!cancelled) {
+            setSuggestions(
+              users.map((u) => ({
+                id: u.id,
+                label: [u.firstName, u.lastName].filter(Boolean).join(' '),
+                secondary: u.roleName,
+              }))
+            );
+          }
+        } else {
+          const ros = await searchReferenceableROs(trigger.query);
+          if (!cancelled) {
+            setSuggestions(
+              ros.map((ro) => ({
+                id: ro.id,
+                label: ro.roNumber,
+                secondary: ro.status,
+              }))
+            );
+          }
+        }
+      } catch {
+        if (!cancelled) setSuggestions([]);
+      } finally {
+        if (!cancelled) setSearching(false);
+      }
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [trigger]);
+
+  const handleChange = (value: string, caret: number) => {
+    setText(value);
+    setTrigger(activeTrigger(value, caret));
+  };
+
+  const choose = useCallback(
+    (suggestion: Suggestion) => {
+      if (!trigger) return;
+
+      const before = text.slice(0, trigger.start);
+      const after = text.slice(trigger.start + 1 + trigger.query.length);
+      const shown = `${trigger.sigil}${suggestion.label}`;
+
+      setText(`${before}${shown} ${after}`);
+      setPicked((prev) => [
+        ...prev,
+        {
+          id: suggestion.id,
+          label: suggestion.label,
+          kind: trigger.sigil === '@' ? 'user' : 'ro',
+        },
+      ]);
+      setTrigger(null);
+      inputRef.current?.focus();
+    },
+    [text, trigger]
+  );
+
+  const handleSend = async () => {
+    const trimmed = body.trim();
+    if (!trimmed || sending) return;
+
+    setSending(true);
+    try {
+      await onSend(trimmed);
+      setText('');
+      setPicked([]);
+      setTrigger(null);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const open = Boolean(trigger) && (suggestions.length > 0 || searching);
+
+  return (
+    <Box>
+      <Box ref={anchorRef}>
+        <TextField
+          inputRef={inputRef}
+          fullWidth
+          multiline
+          maxRows={6}
+          size="small"
+          value={text}
+          disabled={disabled || sending}
+          placeholder={placeholder ?? 'Write a message. Type @ to tag someone.'}
+          onChange={(e) =>
+            handleChange(e.target.value, e.target.selectionStart ?? 0)
+          }
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setTrigger(null);
+            // Enter sends; Shift+Enter is a newline. Never send while the
+            // suggestion list is open — Enter belongs to the list then.
+            if (e.key === 'Enter' && !e.shiftKey && !open) {
+              e.preventDefault();
+              void handleSend();
+            }
+          }}
+          InputProps={{
+            endAdornment: (
+              <IconButton
+                size="small"
+                color="primary"
+                disabled={!body.trim() || sending || disabled}
+                onClick={() => void handleSend()}
+                aria-label="Send message"
+              >
+                {sending ? <CircularProgress size={18} /> : <SendIcon />}
+              </IconButton>
+            ),
+          }}
+        />
+      </Box>
+
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        placement="top-start"
+        style={{ zIndex: 1300, width: anchorRef.current?.clientWidth }}
+      >
+        <ClickAwayListener onClickAway={() => setTrigger(null)}>
+          <Paper elevation={4} sx={{ maxHeight: 240, overflowY: 'auto' }}>
+            {searching && suggestions.length === 0 ? (
+              <Box sx={{ p: 1.5, display: 'flex', gap: 1 }}>
+                <CircularProgress size={16} />
+                <Typography variant="body2" color="text.secondary">
+                  Searching…
+                </Typography>
+              </Box>
+            ) : (
+              suggestions.map((s) => (
+                <ListItemButton key={s.id} onClick={() => choose(s)} dense>
+                  <ListItemText primary={s.label} secondary={s.secondary} />
+                </ListItemButton>
+              ))
+            )}
+          </Paper>
+        </ClickAwayListener>
+      </Popper>
+
+      {/*
+        Tagging someone silently changes who can read the message, so the
+        consequence is always on screen before it is sent. This is the only
+        guard against "I thought the shop would see that".
+      */}
+      <Box
+        sx={{
+          mt: 0.75,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          flexWrap: 'wrap',
+        }}
+      >
+        {isPrivate ? (
+          <>
+            <LockIcon sx={{ fontSize: 16, color: colors.semantic.warning }} />
+            <Typography variant="caption" sx={{ color: colors.text.secondary }}>
+              Only {mentionedNames.join(' and ') || 'the people tagged'} will
+              see this
+            </Typography>
+            {mentionedNames.map((name) => (
+              <Chip key={name} label={name} size="small" variant="outlined" />
+            ))}
+          </>
+        ) : (
+          <>
+            <GroupIcon sx={{ fontSize: 16, color: colors.text.secondary }} />
+            <Typography variant="caption" sx={{ color: colors.text.secondary }}>
+              Everyone can see this
+            </Typography>
+          </>
+        )}
+      </Box>
+
+      {isPrivate && (
+        <Box
+          sx={{ mt: 0.25, display: 'flex', alignItems: 'center', gap: 0.75 }}
+        >
+          <InfoOutlinedIcon
+            sx={{ fontSize: 14, color: colors.text.secondary }}
+          />
+          <Typography variant="caption" sx={{ color: colors.text.secondary }}>
+            Admins can also view this message
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -1,0 +1,142 @@
+import { useNavigate } from 'react-router-dom';
+import { Box, Chip, IconButton, Tooltip, Typography } from '@mui/material';
+import LockIcon from '@mui/icons-material/Lock';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { segmentMessageBody, type MessageDto } from '@gt-automotive/data';
+import { colors } from '../../theme/colors';
+
+interface Props {
+  message: MessageDto;
+  currentUserId: string;
+  canDelete: boolean;
+  onDelete: (id: string) => void;
+  /** Hidden inside a repair order, where every message is about that RO. */
+  showReferences?: boolean;
+}
+
+const displayName = (
+  first: string | null,
+  last: string | null,
+  fallback = 'Unknown'
+) => [first, last].filter(Boolean).join(' ') || fallback;
+
+/**
+ * Times are real instants formatted for the shop's timezone, not business
+ * calendar dates — a message sent at 6pm belongs at 6pm, whatever the server
+ * thinks the business day is.
+ */
+const formatTime = (iso: string) =>
+  new Date(iso).toLocaleString('en-CA', {
+    timeZone: 'America/Vancouver',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+export function MessageItem({
+  message,
+  currentUserId,
+  canDelete,
+  onDelete,
+  showReferences = true,
+}: Props) {
+  const navigate = useNavigate();
+  const isPrivate = message.visibility === 'MENTIONED_ONLY';
+  const isMine = message.author.id === currentUserId;
+  const segments = segmentMessageBody(message.body);
+
+  return (
+    <Box
+      sx={{
+        py: 1,
+        px: 1.5,
+        borderRadius: 1,
+        bgcolor: isPrivate
+          ? colors.semantic.warningLight + '22'
+          : 'transparent',
+        borderLeft: isPrivate
+          ? `3px solid ${colors.semantic.warning}`
+          : '3px solid transparent',
+        '&:hover .message-actions': { opacity: 1 },
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+          {displayName(message.author.firstName, message.author.lastName)}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {formatTime(message.createdAt)}
+        </Typography>
+        {message.editedAt && (
+          <Typography variant="caption" color="text.disabled">
+            edited
+          </Typography>
+        )}
+        {isPrivate && (
+          <Tooltip
+            title={`Private — visible to ${message.mentions
+              .map((m) => displayName(m.firstName, m.lastName))
+              .join(', ')} and admins`}
+          >
+            <LockIcon sx={{ fontSize: 15, color: colors.semantic.warning }} />
+          </Tooltip>
+        )}
+        <Box sx={{ flexGrow: 1 }} />
+        {(isMine || canDelete) && (
+          <IconButton
+            className="message-actions"
+            size="small"
+            sx={{ opacity: 0, transition: 'opacity 120ms' }}
+            onClick={() => onDelete(message.id)}
+            aria-label="Delete message"
+          >
+            <DeleteOutlineIcon fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
+
+      <Typography
+        variant="body2"
+        component="div"
+        sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}
+      >
+        {segments.map((segment, index) => {
+          if (segment.kind === 'text') {
+            return <span key={index}>{segment.text}</span>;
+          }
+          if (segment.kind === 'mention') {
+            return (
+              <Chip
+                key={index}
+                label={`@${segment.label}`}
+                size="small"
+                sx={{
+                  height: 20,
+                  mx: 0.25,
+                  bgcolor:
+                    segment.userId === currentUserId
+                      ? colors.semantic.warningLight
+                      : colors.neutral[200],
+                }}
+              />
+            );
+          }
+          if (!showReferences) return null;
+          return (
+            <Chip
+              key={index}
+              label={segment.label}
+              size="small"
+              clickable
+              onClick={() =>
+                navigate(`/admin/repair-orders/${segment.entityId}`)
+              }
+              sx={{ height: 20, mx: 0.25 }}
+            />
+          );
+        })}
+      </Typography>
+    </Box>
+  );
+}

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, Box, CircularProgress, Typography } from '@mui/material';
+import ChatIcon from '@mui/icons-material/Chat';
+import type { ConversationEntity } from '@gt-automotive/data';
+import { useMessagePolling } from './hooks/useMessagePolling';
+import { MessageComposer } from './MessageComposer';
+import { MessageItem } from './MessageItem';
+import {
+  deleteMessage,
+  getEntityThread,
+  getGeneralThread,
+  markConversationRead,
+  sendMessage,
+} from '../../requests/messaging.requests';
+import { useErrorHelpers } from '../../contexts/ErrorContext';
+import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
+
+interface Props {
+  /** Omit for the shop-wide channel. */
+  entityType?: ConversationEntity;
+  entityId?: string;
+  currentUserId: string;
+  isAdmin: boolean;
+  height?: number | string;
+}
+
+export function MessageThread({
+  entityType,
+  entityId,
+  currentUserId,
+  isAdmin,
+  height = 480,
+}: Props) {
+  const { showApiError } = useErrorHelpers();
+  const { confirmDelete } = useConfirmationHelpers();
+
+  const [conversationId, setConversationId] = useState<string | undefined>();
+  const [opening, setOpening] = useState(true);
+  const [openError, setOpenError] = useState<string | null>(null);
+
+  const { messages, loading, appendLocal, removeLocal } =
+    useMessagePolling(conversationId);
+
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setOpening(true);
+    setOpenError(null);
+
+    (async () => {
+      try {
+        const conversation =
+          entityType && entityId
+            ? await getEntityThread(entityType, entityId)
+            : await getGeneralThread();
+        if (!cancelled) setConversationId(conversation.id);
+      } catch (error) {
+        if (!cancelled) {
+          setOpenError('This conversation could not be opened.');
+          showApiError(error);
+        }
+      } finally {
+        if (!cancelled) setOpening(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [entityType, entityId, showApiError]);
+
+  // Reading the thread is what marks it read, so the badge clears on the way
+  // out rather than on every render.
+  useEffect(() => {
+    if (!conversationId) return;
+    return () => {
+      void markConversationRead(conversationId).catch(() => undefined);
+    };
+  }, [conversationId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  const handleSend = useCallback(
+    async (body: string) => {
+      if (!conversationId) return;
+      try {
+        const created = await sendMessage(conversationId, body);
+        appendLocal(created);
+      } catch (error) {
+        showApiError(error);
+      }
+    },
+    [conversationId, appendLocal, showApiError]
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      const confirmed = await confirmDelete('this message');
+      if (!confirmed) return;
+
+      try {
+        await deleteMessage(id);
+        removeLocal(id);
+      } catch (error) {
+        showApiError(error);
+      }
+    },
+    [confirmDelete, removeLocal, showApiError]
+  );
+
+  if (opening) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (openError) {
+    return <Alert severity="error">{openError}</Alert>;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height }}>
+      <Box sx={{ flexGrow: 1, overflowY: 'auto', mb: 1.5 }}>
+        {loading && messages.length === 0 ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : messages.length === 0 ? (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 1,
+              py: 6,
+            }}
+          >
+            <ChatIcon sx={{ fontSize: 40, color: 'text.disabled' }} />
+            <Typography variant="body2" color="text.secondary">
+              No messages yet
+            </Typography>
+            <Typography variant="caption" color="text.disabled">
+              Type @ to tag someone — only they will see it.
+            </Typography>
+          </Box>
+        ) : (
+          messages.map((message) => (
+            <MessageItem
+              key={message.id}
+              message={message}
+              currentUserId={currentUserId}
+              canDelete={isAdmin}
+              onDelete={handleDelete}
+              showReferences={!entityId}
+            />
+          ))
+        )}
+        <div ref={bottomRef} />
+      </Box>
+
+      <MessageComposer onSend={handleSend} disabled={!conversationId} />
+    </Box>
+  );
+}

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MessageDto } from '@gt-automotive/data';
+import { pollMessages } from '../../../requests/messaging.requests';
+
+/** Cadence while somebody is actually reading the thread. */
+const ACTIVE_INTERVAL_MS = 10_000;
+/** Cadence once the thread has been quiet for a while. */
+const IDLE_INTERVAL_MS = 60_000;
+/** How long without a new message before we consider the thread idle. */
+const IDLE_AFTER_MS = 2 * 60_000;
+
+interface PollingState {
+  messages: MessageDto[];
+  unreadMentions: number;
+  conversationUnreads: Record<string, number>;
+  loading: boolean;
+}
+
+/**
+ * Every bit of transport for messaging lives here.
+ *
+ * Components only ever see the accumulated message list, which is what makes
+ * the eventual switch to long polling a change to this file alone.
+ *
+ * Two things keep the request count honest. Polling stops entirely while the
+ * tab is hidden — a tab left open overnight is what turns a reasonable number
+ * of requests into a silly one — and the interval backs off once the thread
+ * goes quiet, which for a shop doing a couple of hundred messages a day is
+ * most of the time.
+ */
+export function useMessagePolling(conversationId?: string) {
+  const [state, setState] = useState<PollingState>({
+    messages: [],
+    unreadMentions: 0,
+    conversationUnreads: {},
+    loading: Boolean(conversationId),
+  });
+
+  // The server's clock, echoed back verbatim. Never Date.now(): a browser
+  // running fast would ask for messages newer than a moment that has not
+  // happened yet and never see them.
+  const cursorRef = useRef<string | undefined>(undefined);
+  const lastActivityRef = useRef<number>(Date.now());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const abortRef = useRef<AbortController | undefined>(undefined);
+
+  const runPoll = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const result = await pollMessages({
+        conversationId,
+        since: cursorRef.current,
+        signal: controller.signal,
+      });
+
+      cursorRef.current = result.serverTime;
+
+      setState((prev) => {
+        if (result.messages.length > 0) {
+          lastActivityRef.current = Date.now();
+        }
+
+        // Merge rather than replace: the cursor only ever returns what is new,
+        // and a re-send of an id we already hold must not duplicate it.
+        const seen = new Set(prev.messages.map((m) => m.id));
+        const added = result.messages.filter((m) => !seen.has(m.id));
+
+        return {
+          messages: added.length ? [...prev.messages, ...added] : prev.messages,
+          unreadMentions: result.unreadMentions,
+          conversationUnreads: result.conversationUnreads,
+          loading: false,
+        };
+      });
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        // A failed poll is not worth interrupting anyone over — the next one
+        // is seconds away and will catch up from the same cursor.
+        setState((prev) => ({ ...prev, loading: false }));
+      }
+    }
+  }, [conversationId]);
+
+  const scheduleNext = useCallback(() => {
+    const quietFor = Date.now() - lastActivityRef.current;
+    const delay =
+      quietFor > IDLE_AFTER_MS ? IDLE_INTERVAL_MS : ACTIVE_INTERVAL_MS;
+
+    timerRef.current = setTimeout(async () => {
+      if (!document.hidden) {
+        await runPoll();
+      }
+      scheduleNext();
+    }, delay);
+  }, [runPoll]);
+
+  useEffect(() => {
+    // A new thread starts from scratch: its cursor and history belong to it.
+    cursorRef.current = undefined;
+    lastActivityRef.current = Date.now();
+    setState({
+      messages: [],
+      unreadMentions: 0,
+      conversationUnreads: {},
+      loading: Boolean(conversationId),
+    });
+
+    void runPoll();
+    scheduleNext();
+
+    const onVisibilityChange = () => {
+      // Catch up immediately on return rather than making someone wait out
+      // the remainder of an interval that elapsed while they were away.
+      if (!document.hidden) void runPoll();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      abortRef.current?.abort();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [conversationId, runPoll, scheduleNext]);
+
+  /** Push a just-sent message in without waiting for the next poll. */
+  const appendLocal = useCallback((message: MessageDto) => {
+    lastActivityRef.current = Date.now();
+    setState((prev) =>
+      prev.messages.some((m) => m.id === message.id)
+        ? prev
+        : { ...prev, messages: [...prev.messages, message] }
+    );
+  }, []);
+
+  const replaceLocal = useCallback((message: MessageDto) => {
+    setState((prev) => ({
+      ...prev,
+      messages: prev.messages.map((m) => (m.id === message.id ? message : m)),
+    }));
+  }, []);
+
+  const removeLocal = useCallback((id: string) => {
+    setState((prev) => ({
+      ...prev,
+      messages: prev.messages.filter((m) => m.id !== id),
+    }));
+  }, []);
+
+  return { ...state, refresh: runPoll, appendLocal, replaceLocal, removeLocal };
+}

--- a/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
+++ b/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { MessageThread } from '../../components/messaging/MessageThread';
 import {
   Alert,
   Autocomplete,
@@ -2061,27 +2062,22 @@ function HistoryTab({ ro, baseRoute }: { ro: RepairOrder; baseRoute: string }) {
 
 // ---- Chat tab (placeholder) ----
 
-function ChatTab() {
+function ChatTab({
+  roId,
+  currentUserId,
+  isAdmin,
+}: {
+  roId: string;
+  currentUserId: string;
+  isAdmin: boolean;
+}) {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        py: 8,
-        gap: 2,
-      }}
-    >
-      <ChatIcon sx={{ fontSize: 56, color: 'text.disabled' }} />
-      <Typography variant="h6" color="text.secondary">
-        Chat coming soon
-      </Typography>
-      <Typography variant="body2" color="text.disabled" textAlign="center">
-        Internal messaging between service advisors and technicians will appear
-        here.
-      </Typography>
-    </Box>
+    <MessageThread
+      entityType="REPAIR_ORDER"
+      entityId={roId}
+      currentUserId={currentUserId}
+      isAdmin={isAdmin}
+    />
   );
 }
 
@@ -2272,7 +2268,13 @@ export function RODetail() {
         />
       )}
       {tab === 1 && <HistoryTab ro={ro} baseRoute={baseRoute} />}
-      {tab === 2 && <ChatTab />}
+      {tab === 2 && (
+        <ChatTab
+          roId={ro.id}
+          currentUserId={user?.id ?? ''}
+          isAdmin={isAdmin}
+        />
+      )}
     </Box>
   );
 }

--- a/apps/webApp/src/app/requests/messaging.requests.ts
+++ b/apps/webApp/src/app/requests/messaging.requests.ts
@@ -1,0 +1,137 @@
+import axios from 'axios';
+import type {
+  ConversationDto,
+  MentionInboxItemDto,
+  MentionableUserDto,
+  MessageDto,
+  PollResponseDto,
+  ReferenceableRODto,
+} from '@gt-automotive/data';
+
+// @ts-ignore
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+const apiClient = axios.create({
+  baseURL: `${API_URL}/api`,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+apiClient.interceptors.request.use(async (config) => {
+  if (window.Clerk?.session) {
+    const token = await window.Clerk.session.getToken({});
+    if (token) {
+      localStorage.setItem('authToken', token);
+      config.headers.Authorization = `Bearer ${token}`;
+      return config;
+    }
+  }
+  const token = localStorage.getItem('authToken');
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
+});
+
+export type { MessageDto, PollResponseDto, MentionableUserDto };
+
+/**
+ * One request serves the open thread and every unread badge.
+ *
+ * `since` must be the previous response's `serverTime`, echoed back untouched.
+ * Deriving it from the browser clock would ask for messages newer than a
+ * moment that has not happened yet on a fast machine, and lose them.
+ */
+export async function pollMessages(params: {
+  conversationId?: string;
+  since?: string;
+  signal?: AbortSignal;
+}): Promise<PollResponseDto> {
+  const { data } = await apiClient.get<PollResponseDto>('/messaging/poll', {
+    params: {
+      conversationId: params.conversationId,
+      since: params.since,
+    },
+    signal: params.signal,
+  });
+  return data;
+}
+
+export async function getEntityThread(
+  entityType: 'REPAIR_ORDER' | 'APPOINTMENT',
+  entityId: string
+): Promise<ConversationDto> {
+  const { data } = await apiClient.get<ConversationDto>(
+    `/messaging/entity/${entityType}/${entityId}`
+  );
+  return data;
+}
+
+export async function getGeneralThread(): Promise<ConversationDto> {
+  const { data } = await apiClient.get<ConversationDto>(
+    '/messaging/conversations/general'
+  );
+  return data;
+}
+
+export async function sendMessage(
+  conversationId: string,
+  body: string,
+  parentMessageId?: string
+): Promise<MessageDto> {
+  const { data } = await apiClient.post<MessageDto>(
+    `/messaging/conversations/${conversationId}/messages`,
+    { body, parentMessageId }
+  );
+  return data;
+}
+
+export async function editMessage(
+  id: string,
+  body: string
+): Promise<MessageDto> {
+  const { data } = await apiClient.patch<MessageDto>(
+    `/messaging/messages/${id}`,
+    { body }
+  );
+  return data;
+}
+
+export async function deleteMessage(id: string): Promise<void> {
+  await apiClient.delete(`/messaging/messages/${id}`);
+}
+
+export async function markConversationRead(id: string): Promise<void> {
+  await apiClient.post(`/messaging/conversations/${id}/read`);
+}
+
+export async function getMentionInbox(
+  unreadOnly = false
+): Promise<MentionInboxItemDto[]> {
+  const { data } = await apiClient.get<MentionInboxItemDto[]>(
+    '/messaging/mentions',
+    { params: { unread: unreadOnly ? 'true' : undefined } }
+  );
+  return data;
+}
+
+export async function markMentionRead(id: string): Promise<void> {
+  await apiClient.post(`/messaging/mentions/${id}/read`);
+}
+
+export async function searchMentionableUsers(
+  q: string
+): Promise<MentionableUserDto[]> {
+  const { data } = await apiClient.get<MentionableUserDto[]>(
+    '/messaging/mentionable-users',
+    { params: { q: q || undefined } }
+  );
+  return data;
+}
+
+export async function searchReferenceableROs(
+  q: string
+): Promise<ReferenceableRODto[]> {
+  const { data } = await apiClient.get<ReferenceableRODto[]>(
+    '/messaging/referenceable-ros',
+    { params: { q: q || undefined } }
+  );
+  return data;
+}

--- a/libs/data/src/index.ts
+++ b/libs/data/src/index.ts
@@ -31,6 +31,7 @@ export * from './lib/tax-report.dto';
 export * from './lib/tire-sale.dto';
 export * from './lib/repair-order.dto';
 export * from './lib/message.dto';
+export * from './lib/message-tokens';
 export * from './lib/pay-stub.dto';
 
 // Export utility functions

--- a/libs/data/src/lib/message-tokens.spec.ts
+++ b/libs/data/src/lib/message-tokens.spec.ts
@@ -1,0 +1,89 @@
+import {
+  buildMentionToken,
+  buildReferenceToken,
+  parseMentionUserIds,
+  segmentMessageBody,
+} from './message-tokens';
+
+/**
+ * Segmenting is what keeps a raw token off the screen. A token that fails to
+ * segment is rendered as literal "@[Sarah Chen](user:clx1)" text, which looks
+ * broken and quietly tells everyone an id they had no reason to see.
+ */
+describe('segmentMessageBody', () => {
+  it('returns plain text as a single segment', () => {
+    expect(segmentMessageBody('rear brakes done')).toEqual([
+      { kind: 'text', text: 'rear brakes done' },
+    ]);
+  });
+
+  it('returns nothing for an empty body', () => {
+    expect(segmentMessageBody('')).toEqual([]);
+  });
+
+  it('splits a mention out of the surrounding text', () => {
+    expect(segmentMessageBody('@[Sarah Chen](user:clx1) please order')).toEqual(
+      [
+        { kind: 'mention', label: 'Sarah Chen', userId: 'clx1' },
+        { kind: 'text', text: ' please order' },
+      ]
+    );
+  });
+
+  it('keeps text on both sides of a mention', () => {
+    expect(segmentMessageBody('ask @[Mike](user:clx2) about it')).toEqual([
+      { kind: 'text', text: 'ask ' },
+      { kind: 'mention', label: 'Mike', userId: 'clx2' },
+      { kind: 'text', text: ' about it' },
+    ]);
+  });
+
+  it('handles a mention and a repair order reference together', () => {
+    expect(
+      segmentMessageBody(
+        '@[Sarah](user:clx1) parts for #[RO-202606-0042](ro:clx9)'
+      )
+    ).toEqual([
+      { kind: 'mention', label: 'Sarah', userId: 'clx1' },
+      { kind: 'text', text: ' parts for ' },
+      { kind: 'reference', label: 'RO-202606-0042', entityId: 'clx9' },
+    ]);
+  });
+
+  it('leaves a malformed token as plain text rather than dropping it', () => {
+    const body = '@[Sarah](clx1) hello';
+
+    expect(segmentMessageBody(body)).toEqual([{ kind: 'text', text: body }]);
+  });
+
+  it('does not treat a bare @name as a mention', () => {
+    expect(segmentMessageBody('@sarah look at this')).toEqual([
+      { kind: 'text', text: '@sarah look at this' },
+    ]);
+  });
+
+  it('round-trips what the builders produce', () => {
+    const body = `${buildMentionToken(
+      'clx1',
+      'Sarah Chen'
+    )} see ${buildReferenceToken('clx9', 'RO-1')}`;
+
+    expect(segmentMessageBody(body)).toEqual([
+      { kind: 'mention', label: 'Sarah Chen', userId: 'clx1' },
+      { kind: 'text', text: ' see ' },
+      { kind: 'reference', label: 'RO-1', entityId: 'clx9' },
+    ]);
+  });
+
+  // The composer decides what to show from the same body it will send, so
+  // these two must agree about what counts as a mention.
+  it('agrees with parseMentionUserIds about which ids are mentions', () => {
+    const body = '@[Sarah](user:clx1) and @[Ghost](broken:clx2)';
+
+    const fromSegments = segmentMessageBody(body)
+      .filter((s) => s.kind === 'mention')
+      .map((s) => (s as { userId: string }).userId);
+
+    expect(fromSegments).toEqual(parseMentionUserIds(body));
+  });
+});

--- a/libs/data/src/lib/message-tokens.ts
+++ b/libs/data/src/lib/message-tokens.ts
@@ -1,0 +1,105 @@
+/**
+ * The wire format for mentions and repair-order references inside a message
+ * body. Shared by the server, which derives who may read a message from it,
+ * and by the composer, which shows the resulting audience before you send.
+ *
+ * One definition on purpose. If the two sides ever disagreed about what counts
+ * as a mention, the composer would promise an audience the server does not
+ * deliver — the worst possible bug for a feature whose whole job is deciding
+ * who can read something.
+ *
+ *   @[Sarah Chen](user:clx123abc)
+ *   #[RO-202606-0042](ro:clx456def)
+ *
+ * Names are for rendering only. Resolving a name at read time would break the
+ * moment somebody is renamed, and is ambiguous with two Sarahs.
+ */
+
+export const MENTION_TOKEN_PATTERN =
+  /@\[[^\]\n]{1,100}\]\(user:([A-Za-z0-9_-]{1,50})\)/g;
+
+export const REFERENCE_TOKEN_PATTERN =
+  /#\[([^\]\n]{1,50})\]\(ro:([A-Za-z0-9_-]{1,50})\)/g;
+
+/** Matches any token, capturing the kind, label and id, for rendering. */
+export const ANY_TOKEN_PATTERN =
+  /([@#])\[([^\]\n]{1,100})\]\((user|ro):([A-Za-z0-9_-]{1,50})\)/g;
+
+export interface ParsedReference {
+  entityType: 'REPAIR_ORDER';
+  entityId: string;
+  label: string;
+}
+
+/**
+ * User ids tagged in a message, deduplicated, in the order they appear.
+ * The presence of any id here is what makes a message private.
+ */
+export function parseMentionUserIds(body: string): string[] {
+  if (!body) return [];
+
+  const seen = new Set<string>();
+  for (const match of body.matchAll(MENTION_TOKEN_PATTERN)) {
+    seen.add(match[1]);
+  }
+  return [...seen];
+}
+
+/** Repair orders referenced in a message, deduplicated by id. */
+export function parseReferences(body: string): ParsedReference[] {
+  if (!body) return [];
+
+  const byId = new Map<string, ParsedReference>();
+  for (const match of body.matchAll(REFERENCE_TOKEN_PATTERN)) {
+    const [, label, entityId] = match;
+    if (!byId.has(entityId)) {
+      byId.set(entityId, { entityType: 'REPAIR_ORDER', entityId, label });
+    }
+  }
+  return [...byId.values()];
+}
+
+export function buildMentionToken(userId: string, displayName: string): string {
+  return `@[${displayName}](user:${userId})`;
+}
+
+export function buildReferenceToken(roId: string, roNumber: string): string {
+  return `#[${roNumber}](ro:${roId})`;
+}
+
+export type MessageSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'mention'; label: string; userId: string }
+  | { kind: 'reference'; label: string; entityId: string };
+
+/**
+ * Splits a body into renderable pieces so chips can be drawn without the raw
+ * token ever reaching the screen.
+ */
+export function segmentMessageBody(body: string): MessageSegment[] {
+  const segments: MessageSegment[] = [];
+  let cursor = 0;
+
+  for (const match of body.matchAll(ANY_TOKEN_PATTERN)) {
+    const [full, sigil, label, kind, id] = match;
+    const start = match.index ?? 0;
+
+    if (start > cursor) {
+      segments.push({ kind: 'text', text: body.slice(cursor, start) });
+    }
+
+    segments.push(
+      kind === 'user'
+        ? { kind: 'mention', label, userId: id }
+        : { kind: 'reference', label, entityId: id }
+    );
+
+    cursor = start + full.length;
+    void sigil;
+  }
+
+  if (cursor < body.length) {
+    segments.push({ kind: 'text', text: body.slice(cursor) });
+  }
+  return segments;
+}

--- a/server/src/messaging/mention-parser.ts
+++ b/server/src/messaging/mention-parser.ts
@@ -1,73 +1,12 @@
-import type { ConversationEntity } from '@gt-automotive/data';
-
 /**
- * Mentions and repair-order references are stored inline in the message body
- * as tokens carrying an id, not a display name:
- *
- *   @[Sarah Chen](user:clx123abc)
- *   #[RO-202606-0042](ro:clx456def)
- *
- * Names are for rendering only. Re-resolving a name at read time would break
- * the moment somebody is renamed, and is ambiguous with two Sarahs.
- *
- * Everything here is pure. The server re-runs it on write and ignores whatever
- * the client claims the mentions were — a token typed by hand grants nothing
- * on its own, because access is decided by the MessageMention rows these
- * functions produce.
+ * The token format lives in libs/data so the composer and the server cannot
+ * drift apart about what counts as a mention — the composer promises an
+ * audience, and this is what decides it.
  */
-
-const MENTION_TOKEN = /@\[[^\]\n]{1,100}\]\(user:([A-Za-z0-9_-]{1,50})\)/g;
-const REFERENCE_TOKEN = /#\[([^\]\n]{1,50})\]\(ro:([A-Za-z0-9_-]{1,50})\)/g;
-
-export interface ParsedReference {
-  entityType: ConversationEntity;
-  entityId: string;
-  label: string;
-}
-
-/**
- * User ids tagged in a message, deduplicated, in the order they appear.
- *
- * The presence of any id here is what makes a message private, so this is the
- * single place that decides the audience.
- */
-export function parseMentionUserIds(body: string): string[] {
-  if (!body) return [];
-
-  const seen = new Set<string>();
-  for (const match of body.matchAll(MENTION_TOKEN)) {
-    seen.add(match[1]);
-  }
-  return [...seen];
-}
-
-/**
- * Repair orders referenced in a message, deduplicated by id. The label is kept
- * so a chip can render without joining back to the repair order.
- */
-export function parseReferences(body: string): ParsedReference[] {
-  if (!body) return [];
-
-  const byId = new Map<string, ParsedReference>();
-  for (const match of body.matchAll(REFERENCE_TOKEN)) {
-    const [, label, entityId] = match;
-    if (!byId.has(entityId)) {
-      byId.set(entityId, {
-        entityType: 'REPAIR_ORDER' as ConversationEntity,
-        entityId,
-        label,
-      });
-    }
-  }
-  return [...byId.values()];
-}
-
-/** Builds the canonical mention token for a user. */
-export function buildMentionToken(userId: string, displayName: string): string {
-  return `@[${displayName}](user:${userId})`;
-}
-
-/** Builds the canonical reference token for a repair order. */
-export function buildReferenceToken(roId: string, roNumber: string): string {
-  return `#[${roNumber}](ro:${roId})`;
-}
+export {
+  parseMentionUserIds,
+  parseReferences,
+  buildMentionToken,
+  buildReferenceToken,
+  type ParsedReference,
+} from '@gt-automotive/data';


### PR DESCRIPTION
Replaces the "chat coming soon" placeholder on the repair order with a working thread, on top of the backend from #117.

Jira: [GA-70](https://gt-automotives.atlassian.net/browse/GA-70) · Epic: [GA-67](https://gt-automotives.atlassian.net/browse/GA-67)

## The part worth reviewing

Tagging somebody silently changes who can read a message. So the composer says what will happen **before** it happens — `🔒 Only Sarah Chen will see this` or `👥 Everyone can see this`, updating as you type, with the admin notice on private ones.

Without it this feature has a quiet failure mode: somebody tags a colleague expecting the shop to see it, nobody does, and the parts never get ordered.

**The strip is computed from the body that will actually be sent, not from the names that were picked.** That distinction is the whole point. The field shows `@Sarah Chen` because nobody should stare at a raw token while typing, and each picked name converts back to its token on send. If somebody edits a name after picking it, that mention stops being one — and because the strip reads the converted body, it flips to "Everyone can see this" and says so. The failure mode announces itself rather than hiding.

## Shared token format

The token definition moved to `libs/data`, used by both the composer and the server (`server/src/messaging/mention-parser.ts` now re-exports it).

Two copies could disagree about what counts as a mention, and then the composer would promise an audience the server does not deliver — the worst available bug for a feature whose entire job is deciding who can read something. One definition, one regex, tested for agreement between `segmentMessageBody` and `parseMentionUserIds`.

## Deviation from the ticket: no Tiptap

The ticket recommended Tiptap + `@tiptap/extension-mention`. I used MUI `TextField` + `Popper` instead.

Tiptap means four runtime dependencies for a plain-text box in an app with no rich text anywhere. What it buys is caret handling, which is small when there is a single input to reason about. Happy to revisit if the picker turns out to be fiddly in practice.

## Polling

Stops entirely while the tab is hidden — a tab left open overnight is what turns a reasonable request count into a silly one — and backs off from 10s to 60s once a thread goes quiet, which at a couple of hundred messages a day is most of the time. Returning to the tab triggers an immediate catch-up rather than waiting out the interval.

All of it lives in `useMessagePolling`, so the long-polling switch in GA-71 is a change to that one file.

The cursor is the server's `serverTime` echoed back verbatim, never `Date.now()` — a browser running fast would ask for messages newer than a moment that has not happened yet and never see them.

## Verified

- `tsc --noEmit` clean on `server` and `webApp`
- `nx lint server webApp` — 0 errors
- **1,021 tests passing**: 629 server · 221 data · 171 webApp
- 8 new tests on `segmentMessageBody`, which is what keeps a raw token off the screen
- `process.env.VITE_*` — none
- Browser dialogs — none; uses the existing `confirmDelete` helper
- **D2 holds**: no print path, PDF template, or email module imports anything under `messaging/`

## Not yet done

I have not run the app and clicked through this. The logic is unit-tested and it compiles, but the picker, the strip, and an actual private message should be confirmed in a browser before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)