### PR TITLE
Messaging UI: mentions inbox, floating button, threaded replies (GA-71)

### DIFF
--- a/apps/webApp/index.html
+++ b/apps/webApp/index.html
@@ -2,10 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>GT Automotives - Professional Tire & Auto Services</title>
+    <title>GT Automotives</title>
     <base href="/" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <link rel="icon" type="image/svg+xml" href="/gt-favicon.svg" />
     <link rel="alternate icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/gt-favicon.svg" />

--- a/apps/webApp/src/app/components/messaging/MentionsList.tsx
+++ b/apps/webApp/src/app/components/messaging/MentionsList.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../requests/messaging.requests';
 import { colors } from '../../theme/colors';
 import { useRoleBaseRoute } from './hooks/useRoleBaseRoute';
+import { announceRead } from './messaging-read-signal';
 
 interface Props {
   /** Bumped by the caller when the unread count changes, to refetch. */
@@ -110,7 +111,10 @@ export function MentionsList({
       )
     );
     markMentionRead(item.mentionId)
-      .then(() => callbacksRef.current.onRead?.())
+      .then(() => {
+        callbacksRef.current.onRead?.();
+        announceRead();
+      })
       .catch(() => undefined);
   }, []);
 

--- a/apps/webApp/src/app/components/messaging/MentionsList.tsx
+++ b/apps/webApp/src/app/components/messaging/MentionsList.tsx
@@ -10,6 +10,8 @@ import {
 } from '@mui/material';
 import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
 import LockIcon from '@mui/icons-material/Lock';
+import ReplyIcon from '@mui/icons-material/Reply';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {
   segmentMessageBody,
   type MentionInboxItemDto,
@@ -17,8 +19,11 @@ import {
 import {
   getMentionInbox,
   markMentionRead,
+  sendMessage,
 } from '../../requests/messaging.requests';
+import { MessageComposer } from './MessageComposer';
 import { colors } from '../../theme/colors';
+import { useRoleBaseRoute } from './hooks/useRoleBaseRoute';
 
 interface Props {
   /** Bumped by the caller when the unread count changes, to refetch. */
@@ -57,7 +62,10 @@ const previewOf = (body: string) =>
  */
 export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
   const navigate = useNavigate();
+  const baseRoute = useRoleBaseRoute();
   const [items, setItems] = useState<MentionInboxItemDto[]>([]);
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replied, setReplied] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
 
   // Callbacks from the caller are not memoised, so they are held in a ref
@@ -86,29 +94,47 @@ export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
     };
   }, [refreshKey]);
 
-  const open = useCallback(
-    async (item: MentionInboxItemDto) => {
-      if (!item.readAt) {
-        // Optimistic: the badge should drop the moment it is opened, not after
-        // a round trip.
-        setItems((prev) =>
-          prev.map((row) =>
-            row.mentionId === item.mentionId
-              ? { ...row, readAt: new Date().toISOString() }
-              : row
-          )
-        );
-        markMentionRead(item.mentionId)
-          .then(() => callbacksRef.current.onRead?.())
-          .catch(() => undefined);
-      }
+  const markRead = useCallback((item: MentionInboxItemDto) => {
+    if (item.readAt) return;
 
-      if (item.conversation.entityId) {
+    // Optimistic: the badge should drop the moment it is dealt with, not after
+    // a round trip that only records what the user already did.
+    setItems((prev) =>
+      prev.map((row) =>
+        row.mentionId === item.mentionId
+          ? { ...row, readAt: new Date().toISOString() }
+          : row
+      )
+    );
+    markMentionRead(item.mentionId)
+      .then(() => callbacksRef.current.onRead?.())
+      .catch(() => undefined);
+  }, []);
+
+  const goToRepairOrder = useCallback(
+    (item: MentionInboxItemDto) => {
+      markRead(item);
+      if (
+        item.conversation.entityType === 'REPAIR_ORDER' &&
+        item.conversation.entityId
+      ) {
         callbacksRef.current.onNavigate?.();
-        navigate(`/admin/repair-orders/${item.conversation.entityId}`);
+        navigate(`${baseRoute}/repair-orders/${item.conversation.entityId}`);
       }
     },
-    [navigate]
+    [navigate, baseRoute, markRead]
+  );
+
+  const reply = useCallback(
+    async (item: MentionInboxItemDto, body: string) => {
+      // Threaded on the message that tagged them, which is what makes the
+      // server keep the reply inside the same private audience.
+      await sendMessage(item.conversation.id, body, item.message.id);
+      markRead(item);
+      setReplyingTo(null);
+      setReplied((prev) => ({ ...prev, [item.mentionId]: true }));
+    },
+    [markRead]
   );
 
   if (loading) {
@@ -147,12 +173,19 @@ export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
     <Box>
       {items.map((item) => {
         const unread = !item.readAt;
-        const roLabel = item.message.references[0]?.label;
+        // The conversation is the source of truth for which job this is
+        // about; a typed #reference only matters for mentions from shop chat.
+        const roLabel =
+          item.conversation.roNumber ?? item.message.references[0]?.label;
 
         return (
           <Box key={item.mentionId}>
             <ListItemButton
-              onClick={() => void open(item)}
+              onClick={() =>
+                setReplyingTo((current) =>
+                  current === item.mentionId ? null : item.mentionId
+                )
+              }
               sx={{
                 display: 'block',
                 py: 1.25,
@@ -190,7 +223,17 @@ export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
                   {formatTime(item.message.createdAt)}
                 </Typography>
                 {roLabel && (
-                  <Chip label={roLabel} size="small" sx={{ height: 18 }} />
+                  <Chip
+                    label={roLabel}
+                    size="small"
+                    clickable
+                    icon={<OpenInNewIcon sx={{ fontSize: 13 }} />}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      goToRepairOrder(item);
+                    }}
+                    sx={{ height: 20 }}
+                  />
                 )}
               </Box>
               <Typography
@@ -205,7 +248,53 @@ export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
               >
                 {previewOf(item.message.body)}
               </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.5,
+                  mt: 0.5,
+                }}
+              >
+                <ReplyIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+                <Typography variant="caption" color="text.disabled">
+                  {replied[item.mentionId]
+                    ? 'Replied'
+                    : replyingTo === item.mentionId
+                    ? 'Cancel'
+                    : 'Reply'}
+                </Typography>
+              </Box>
             </ListItemButton>
+
+            {replyingTo === item.mentionId && (
+              <Box sx={{ px: 2, pb: 1.5 }}>
+                <MessageComposer
+                  autoFocus
+                  placeholder={`Reply to ${displayName(
+                    item.message.author.firstName,
+                    item.message.author.lastName
+                  )}…`}
+                  // A reply cannot be more visible than what it answers, so
+                  // the strip must show the audience it will actually reach
+                  // rather than claiming the whole shop can see it.
+                  inheritedAudience={
+                    item.message.visibility === 'MENTIONED_ONLY'
+                      ? [
+                          displayName(
+                            item.message.author.firstName,
+                            item.message.author.lastName
+                          ),
+                          ...item.message.mentions.map((m) =>
+                            displayName(m.firstName, m.lastName)
+                          ),
+                        ]
+                      : undefined
+                  }
+                  onSend={(body) => reply(item, body)}
+                />
+              </Box>
+            )}
             <Divider />
           </Box>
         );

--- a/apps/webApp/src/app/components/messaging/MentionsList.tsx
+++ b/apps/webApp/src/app/components/messaging/MentionsList.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Divider,
+  ListItemButton,
+  Typography,
+} from '@mui/material';
+import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
+import LockIcon from '@mui/icons-material/Lock';
+import {
+  segmentMessageBody,
+  type MentionInboxItemDto,
+} from '@gt-automotive/data';
+import {
+  getMentionInbox,
+  markMentionRead,
+} from '../../requests/messaging.requests';
+import { colors } from '../../theme/colors';
+
+interface Props {
+  /** Bumped by the caller when the unread count changes, to refetch. */
+  refreshKey?: number;
+  onRead?: () => void;
+  onNavigate?: () => void;
+}
+
+const displayName = (first: string | null, last: string | null) =>
+  [first, last].filter(Boolean).join(' ') || 'Unknown';
+
+const formatTime = (iso: string) =>
+  new Date(iso).toLocaleString('en-CA', {
+    timeZone: 'America/Vancouver',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+/** Strips tokens down to readable text for the one-line preview. */
+const previewOf = (body: string) =>
+  segmentMessageBody(body)
+    .map((segment) =>
+      segment.kind === 'text' ? segment.text : `@${segment.label}`
+    )
+    .join('')
+    .trim();
+
+/**
+ * Everything tagged at you, across every repair order, in one list.
+ *
+ * Without this a tagged job sits unread in a thread nobody happened to open,
+ * which is the whole failure this feature exists to prevent — the message was
+ * directed at someone precisely so they would act on it.
+ */
+export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<MentionInboxItemDto[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Callbacks from the caller are not memoised, so they are held in a ref
+  // rather than named as dependencies — see MessageThread for what happens
+  // when an unstable identity drives an effect.
+  const callbacksRef = useRef({ onRead, onNavigate });
+  callbacksRef.current = { onRead, onNavigate };
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    getMentionInbox(false)
+      .then((rows) => {
+        if (!cancelled) setItems(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  const open = useCallback(
+    async (item: MentionInboxItemDto) => {
+      if (!item.readAt) {
+        // Optimistic: the badge should drop the moment it is opened, not after
+        // a round trip.
+        setItems((prev) =>
+          prev.map((row) =>
+            row.mentionId === item.mentionId
+              ? { ...row, readAt: new Date().toISOString() }
+              : row
+          )
+        );
+        markMentionRead(item.mentionId)
+          .then(() => callbacksRef.current.onRead?.())
+          .catch(() => undefined);
+      }
+
+      if (item.conversation.entityId) {
+        callbacksRef.current.onNavigate?.();
+        navigate(`/admin/repair-orders/${item.conversation.entityId}`);
+      }
+    },
+    [navigate]
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 5 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 1,
+          py: 6,
+          px: 2,
+          textAlign: 'center',
+        }}
+      >
+        <AlternateEmailIcon sx={{ fontSize: 36, color: 'text.disabled' }} />
+        <Typography variant="body2" color="text.secondary">
+          Nothing tagged at you
+        </Typography>
+        <Typography variant="caption" color="text.disabled">
+          When somebody tags you with @, it shows up here.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {items.map((item) => {
+        const unread = !item.readAt;
+        const roLabel = item.message.references[0]?.label;
+
+        return (
+          <Box key={item.mentionId}>
+            <ListItemButton
+              onClick={() => void open(item)}
+              sx={{
+                display: 'block',
+                py: 1.25,
+                bgcolor: unread
+                  ? colors.semantic.warningLight + '18'
+                  : undefined,
+                borderLeft: unread
+                  ? `3px solid ${colors.semantic.warning}`
+                  : '3px solid transparent',
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  flexWrap: 'wrap',
+                }}
+              >
+                {item.message.visibility === 'MENTIONED_ONLY' && (
+                  <LockIcon
+                    sx={{ fontSize: 14, color: colors.semantic.warning }}
+                  />
+                )}
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontWeight: unread ? 700 : 500 }}
+                >
+                  {displayName(
+                    item.message.author.firstName,
+                    item.message.author.lastName
+                  )}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {formatTime(item.message.createdAt)}
+                </Typography>
+                {roLabel && (
+                  <Chip label={roLabel} size="small" sx={{ height: 18 }} />
+                )}
+              </Box>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{
+                  mt: 0.25,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {previewOf(item.message.body)}
+              </Typography>
+            </ListItemButton>
+            <Divider />
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/webApp/src/app/components/messaging/MentionsList.tsx
+++ b/apps/webApp/src/app/components/messaging/MentionsList.tsx
@@ -10,8 +10,8 @@ import {
 } from '@mui/material';
 import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
 import LockIcon from '@mui/icons-material/Lock';
-import ReplyIcon from '@mui/icons-material/Reply';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import ForumIcon from '@mui/icons-material/Forum';
 import {
   segmentMessageBody,
   type MentionInboxItemDto,
@@ -19,9 +19,7 @@ import {
 import {
   getMentionInbox,
   markMentionRead,
-  sendMessage,
 } from '../../requests/messaging.requests';
-import { MessageComposer } from './MessageComposer';
 import { colors } from '../../theme/colors';
 import { useRoleBaseRoute } from './hooks/useRoleBaseRoute';
 
@@ -30,6 +28,8 @@ interface Props {
   refreshKey?: number;
   onRead?: () => void;
   onNavigate?: () => void;
+  /** Open the thread a mention came from, so it is read in context. */
+  onOpenConversation?: (item: MentionInboxItemDto) => void;
 }
 
 const displayName = (first: string | null, last: string | null) =>
@@ -60,19 +60,22 @@ const previewOf = (body: string) =>
  * which is the whole failure this feature exists to prevent — the message was
  * directed at someone precisely so they would act on it.
  */
-export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
+export function MentionsList({
+  refreshKey,
+  onRead,
+  onNavigate,
+  onOpenConversation,
+}: Props) {
   const navigate = useNavigate();
   const baseRoute = useRoleBaseRoute();
   const [items, setItems] = useState<MentionInboxItemDto[]>([]);
-  const [replyingTo, setReplyingTo] = useState<string | null>(null);
-  const [replied, setReplied] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
 
   // Callbacks from the caller are not memoised, so they are held in a ref
   // rather than named as dependencies — see MessageThread for what happens
   // when an unstable identity drives an effect.
-  const callbacksRef = useRef({ onRead, onNavigate });
-  callbacksRef.current = { onRead, onNavigate };
+  const callbacksRef = useRef({ onRead, onNavigate, onOpenConversation });
+  callbacksRef.current = { onRead, onNavigate, onOpenConversation };
 
   useEffect(() => {
     let cancelled = false;
@@ -125,14 +128,10 @@ export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
     [navigate, baseRoute, markRead]
   );
 
-  const reply = useCallback(
-    async (item: MentionInboxItemDto, body: string) => {
-      // Threaded on the message that tagged them, which is what makes the
-      // server keep the reply inside the same private audience.
-      await sendMessage(item.conversation.id, body, item.message.id);
+  const openConversation = useCallback(
+    (item: MentionInboxItemDto) => {
       markRead(item);
-      setReplyingTo(null);
-      setReplied((prev) => ({ ...prev, [item.mentionId]: true }));
+      callbacksRef.current.onOpenConversation?.(item);
     },
     [markRead]
   );
@@ -181,11 +180,7 @@ export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
         return (
           <Box key={item.mentionId}>
             <ListItemButton
-              onClick={() =>
-                setReplyingTo((current) =>
-                  current === item.mentionId ? null : item.mentionId
-                )
-              }
+              onClick={() => openConversation(item)}
               sx={{
                 display: 'block',
                 py: 1.25,
@@ -256,45 +251,13 @@ export function MentionsList({ refreshKey, onRead, onNavigate }: Props) {
                   mt: 0.5,
                 }}
               >
-                <ReplyIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+                <ForumIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
                 <Typography variant="caption" color="text.disabled">
-                  {replied[item.mentionId]
-                    ? 'Replied'
-                    : replyingTo === item.mentionId
-                    ? 'Cancel'
-                    : 'Reply'}
+                  Open conversation
                 </Typography>
               </Box>
             </ListItemButton>
 
-            {replyingTo === item.mentionId && (
-              <Box sx={{ px: 2, pb: 1.5 }}>
-                <MessageComposer
-                  autoFocus
-                  placeholder={`Reply to ${displayName(
-                    item.message.author.firstName,
-                    item.message.author.lastName
-                  )}…`}
-                  // A reply cannot be more visible than what it answers, so
-                  // the strip must show the audience it will actually reach
-                  // rather than claiming the whole shop can see it.
-                  inheritedAudience={
-                    item.message.visibility === 'MENTIONED_ONLY'
-                      ? [
-                          displayName(
-                            item.message.author.firstName,
-                            item.message.author.lastName
-                          ),
-                          ...item.message.mentions.map((m) =>
-                            displayName(m.firstName, m.lastName)
-                          ),
-                        ]
-                      : undefined
-                  }
-                  onSend={(body) => reply(item, body)}
-                />
-              </Box>
-            )}
             <Divider />
           </Box>
         );

--- a/apps/webApp/src/app/components/messaging/MentionsList.tsx
+++ b/apps/webApp/src/app/components/messaging/MentionsList.tsx
@@ -23,6 +23,7 @@ import {
 import { colors } from '../../theme/colors';
 import { useRoleBaseRoute } from './hooks/useRoleBaseRoute';
 import { announceRead } from './messaging-read-signal';
+import { UserAvatar } from './UserAvatar';
 
 interface Props {
   /** Bumped by the caller when the unread count changes, to refetch. */
@@ -204,6 +205,14 @@ export function MentionsList({
                   flexWrap: 'wrap',
                 }}
               >
+                <UserAvatar
+                  name={displayName(
+                    item.message.author.firstName,
+                    item.message.author.lastName
+                  )}
+                  userId={item.message.author.id}
+                  size={24}
+                />
                 {item.message.visibility === 'MENTIONED_ONLY' && (
                   <LockIcon
                     sx={{ fontSize: 14, color: colors.semantic.warning }}

--- a/apps/webApp/src/app/components/messaging/MessageComposer.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageComposer.tsx
@@ -43,6 +43,14 @@ interface Props {
   onSend: (body: string) => Promise<void>;
   disabled?: boolean;
   placeholder?: string;
+  /**
+   * Names this message will reach regardless of what is typed, because it is a
+   * reply to a private message and inherits that audience. The strip has to
+   * know: without it a reply with no tag would claim everyone can see it, when
+   * the server is about to keep it private.
+   */
+  inheritedAudience?: string[];
+  autoFocus?: boolean;
 }
 
 const escapeRegExp = (value: string) =>
@@ -88,7 +96,13 @@ function activeTrigger(text: string, caret: number) {
   };
 }
 
-export function MessageComposer({ onSend, disabled, placeholder }: Props) {
+export function MessageComposer({
+  onSend,
+  disabled,
+  placeholder,
+  inheritedAudience,
+  autoFocus,
+}: Props) {
   const [text, setText] = useState('');
   const [picked, setPicked] = useState<Picked[]>([]);
   const [sending, setSending] = useState(false);
@@ -104,15 +118,20 @@ export function MessageComposer({ onSend, disabled, placeholder }: Props) {
 
   const body = useMemo(() => buildBody(text, picked), [text, picked]);
   const mentionedIds = useMemo(() => parseMentionUserIds(body), [body]);
-  const isPrivate = mentionedIds.length > 0;
+  // Compared by value, not identity: the caller builds this array inline, so
+  // depending on the array itself would recompute on every render.
+  const inheritedKey = (inheritedAudience ?? []).join('\u0000');
+  const isPrivate = mentionedIds.length > 0 || inheritedKey.length > 0;
 
-  const mentionedNames = useMemo(
-    () =>
-      picked
-        .filter((p) => p.kind === 'user' && mentionedIds.includes(p.id))
-        .map((p) => p.label),
-    [picked, mentionedIds]
-  );
+  const mentionedNames = useMemo(() => {
+    const typed = picked
+      .filter((p) => p.kind === 'user' && mentionedIds.includes(p.id))
+      .map((p) => p.label);
+    const inherited = inheritedKey ? inheritedKey.split('\u0000') : [];
+    // Both sets see it: whoever the parent was private to, plus anyone newly
+    // tagged in the reply.
+    return [...new Set([...inherited, ...typed])];
+  }, [picked, mentionedIds, inheritedKey]);
 
   // Debounced at 300ms to match the invoice and vendor search already in the app.
   useEffect(() => {
@@ -217,6 +236,7 @@ export function MessageComposer({ onSend, disabled, placeholder }: Props) {
           size="small"
           value={text}
           disabled={disabled || sending}
+          autoFocus={autoFocus}
           placeholder={placeholder ?? 'Write a message. Type @ to tag someone.'}
           onChange={(e) =>
             handleChange(e.target.value, e.target.selectionStart ?? 0)

--- a/apps/webApp/src/app/components/messaging/MessageComposer.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageComposer.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   ClickAwayListener,
   IconButton,
+  ListItemAvatar,
   ListItemButton,
   ListItemText,
   Paper,
@@ -26,6 +27,7 @@ import {
   searchReferenceableROs,
 } from '../../requests/messaging.requests';
 import { colors } from '../../theme/colors';
+import { UserAvatar } from './UserAvatar';
 
 interface Picked {
   id: string;
@@ -286,6 +288,11 @@ export function MessageComposer({
             ) : (
               suggestions.map((s) => (
                 <ListItemButton key={s.id} onClick={() => choose(s)} dense>
+                  {trigger?.sigil === '@' && (
+                    <ListItemAvatar sx={{ minWidth: 40 }}>
+                      <UserAvatar name={s.label} userId={s.id} size={28} />
+                    </ListItemAvatar>
+                  )}
                   <ListItemText primary={s.label} secondary={s.secondary} />
                 </ListItemButton>
               ))

--- a/apps/webApp/src/app/components/messaging/MessageComposer.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageComposer.tsx
@@ -147,11 +147,13 @@ export function MessageComposer({
         if (trigger.sigil === '@') {
           const users = await searchMentionableUsers(trigger.query);
           if (!cancelled) {
+            // Name only. Everyone here works at the same shop and knows who
+            // does what, so the role was a second line of noise under every
+            // entry in a list people scan quickly.
             setSuggestions(
               users.map((u) => ({
                 id: u.id,
                 label: [u.firstName, u.lastName].filter(Boolean).join(' '),
-                secondary: u.roleName,
               }))
             );
           }

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { Box, Chip, IconButton, Tooltip, Typography } from '@mui/material';
 import LockIcon from '@mui/icons-material/Lock';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import ReplyIcon from '@mui/icons-material/Reply';
 import { segmentMessageBody, type MessageDto } from '@gt-automotive/data';
 import { colors } from '../../theme/colors';
 import { useRoleBaseRoute } from './hooks/useRoleBaseRoute';
@@ -13,6 +14,11 @@ interface Props {
   onDelete: (id: string) => void;
   /** Hidden inside a repair order, where every message is about that RO. */
   showReferences?: boolean;
+  onReply?: (target: {
+    messageId: string;
+    authorName: string;
+    audience: string[];
+  }) => void;
 }
 
 const displayName = (
@@ -41,6 +47,7 @@ export function MessageItem({
   canDelete,
   onDelete,
   showReferences = true,
+  onReply,
 }: Props) {
   const navigate = useNavigate();
   const baseRoute = useRoleBaseRoute();
@@ -85,6 +92,31 @@ export function MessageItem({
           </Tooltip>
         )}
         <Box sx={{ flexGrow: 1 }} />
+        {onReply && (
+          <IconButton
+            className="message-actions"
+            size="small"
+            sx={{ opacity: 0, transition: 'opacity 120ms' }}
+            onClick={() =>
+              onReply({
+                messageId: message.id,
+                authorName: displayName(
+                  message.author.firstName,
+                  message.author.lastName
+                ),
+                // Carried through so the composer can say who a reply reaches.
+                audience: isPrivate
+                  ? message.mentions.map((m) =>
+                      displayName(m.firstName, m.lastName)
+                    )
+                  : [],
+              })
+            }
+            aria-label="Reply to message"
+          >
+            <ReplyIcon fontSize="small" />
+          </IconButton>
+        )}
         {(isMine || canDelete) && (
           <IconButton
             className="message-actions"

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -58,131 +58,178 @@ export function MessageItem({
 }: Props) {
   const navigate = useNavigate();
   const baseRoute = useRoleBaseRoute();
+
   const isPrivate = message.visibility === 'MENTIONED_ONLY';
   const isMine = message.author.id === currentUserId;
+  const author = displayName(message.author.firstName, message.author.lastName);
   const segments = segmentMessageBody(message.body);
 
+  const accent = isPrivate
+    ? colors.semantic.warning
+    : unread
+    ? colors.primary.main
+    : null;
+
+  const background = isPrivate
+    ? `${colors.semantic.warningLight}22`
+    : isMine
+    ? `${colors.primary.main}12`
+    : unread
+    ? `${colors.primary.light}14`
+    : colors.neutral[50];
+
   return (
+    // Own messages sit on the right, the way every chat does it: the side says
+    // who is talking before any of the text is read.
     <Box
       sx={{
-        py: 1,
-        px: 1.5,
-        borderRadius: 1,
-        bgcolor: isPrivate
-          ? colors.semantic.warningLight + '22'
-          : 'transparent',
-        borderLeft: isPrivate
-          ? `3px solid ${colors.semantic.warning}`
-          : '3px solid transparent',
-        '&:hover .message-actions': { opacity: 1 },
+        display: 'flex',
+        justifyContent: isMine ? 'flex-end' : 'flex-start',
+        mb: 0.5,
       }}
+      onClick={() => onSeen?.()}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <UserAvatar
-          name={displayName(message.author.firstName, message.author.lastName)}
-          userId={message.author.id}
-          size={24}
-        />
-        <Typography variant="subtitle2" sx={{ fontWeight: unread ? 800 : 600 }}>
-          {displayName(message.author.firstName, message.author.lastName)}
-        </Typography>
-        <Typography variant="caption" color="text.secondary">
-          {formatTime(message.createdAt)}
-        </Typography>
-        {message.editedAt && (
-          <Typography variant="caption" color="text.disabled">
-            edited
-          </Typography>
-        )}
-        {isPrivate && (
-          <Tooltip
-            title={`Private — visible to ${message.mentions
-              .map((m) => displayName(m.firstName, m.lastName))
-              .join(', ')} and admins`}
-          >
-            <LockIcon sx={{ fontSize: 15, color: colors.semantic.warning }} />
-          </Tooltip>
-        )}
-        <Box sx={{ flexGrow: 1 }} />
-        {onReply && (
-          <IconButton
-            className="message-actions"
-            size="small"
-            sx={{ opacity: 0, transition: 'opacity 120ms' }}
-            onClick={() =>
-              onReply({
-                messageId: message.id,
-                authorName: displayName(
-                  message.author.firstName,
-                  message.author.lastName
-                ),
-                // Carried through so the composer can say who a reply reaches.
-                audience: isPrivate
-                  ? message.mentions.map((m) =>
-                      displayName(m.firstName, m.lastName)
-                    )
-                  : [],
-              })
-            }
-            aria-label="Reply to message"
-          >
-            <ReplyIcon fontSize="small" />
-          </IconButton>
-        )}
-        {(isMine || canDelete) && (
-          <IconButton
-            className="message-actions"
-            size="small"
-            sx={{ opacity: 0, transition: 'opacity 120ms' }}
-            onClick={() => onDelete(message.id)}
-            aria-label="Delete message"
-          >
-            <DeleteOutlineIcon fontSize="small" />
-          </IconButton>
-        )}
-      </Box>
-
-      <Typography
-        variant="body2"
-        component="div"
-        sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', mt: 0.25 }}
+      <Box
+        sx={{
+          maxWidth: '88%',
+          minWidth: 0,
+          py: 1,
+          px: 1.5,
+          borderRadius: 1.5,
+          cursor: onSeen ? 'pointer' : 'default',
+          bgcolor: background,
+          // The accent follows the bubble so it stays on the outer edge rather
+          // than floating in the middle of the row.
+          ...(accent
+            ? isMine
+              ? { borderRight: `3px solid ${accent}` }
+              : { borderLeft: `3px solid ${accent}` }
+            : {}),
+          '&:hover .message-actions': { opacity: 1 },
+        }}
       >
-        {segments.map((segment, index) => {
-          if (segment.kind === 'text') {
-            return <span key={index}>{segment.text}</span>;
-          }
-          if (segment.kind === 'mention') {
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flexDirection: isMine ? 'row-reverse' : 'row',
+          }}
+        >
+          <UserAvatar name={author} userId={message.author.id} size={24} />
+          <Typography
+            variant="subtitle2"
+            sx={{ fontWeight: unread ? 800 : 600 }}
+          >
+            {author}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatTime(message.createdAt)}
+          </Typography>
+          {message.editedAt && (
+            <Typography variant="caption" color="text.disabled">
+              edited
+            </Typography>
+          )}
+          {isPrivate && (
+            <Tooltip
+              title={`Private — visible to ${message.mentions
+                .map((m) => displayName(m.firstName, m.lastName))
+                .join(', ')} and admins`}
+            >
+              <LockIcon sx={{ fontSize: 15, color: colors.semantic.warning }} />
+            </Tooltip>
+          )}
+
+          <Box sx={{ flexGrow: 1 }} />
+
+          {onReply && (
+            <IconButton
+              className="message-actions"
+              size="small"
+              sx={{ opacity: 0, transition: 'opacity 120ms' }}
+              onClick={(event) => {
+                event.stopPropagation();
+                onReply({
+                  messageId: message.id,
+                  authorName: author,
+                  // Carried through so the composer can say who a reply reaches.
+                  audience: isPrivate
+                    ? message.mentions.map((m) =>
+                        displayName(m.firstName, m.lastName)
+                      )
+                    : [],
+                });
+              }}
+              aria-label="Reply to message"
+            >
+              <ReplyIcon fontSize="small" />
+            </IconButton>
+          )}
+          {(isMine || canDelete) && (
+            <IconButton
+              className="message-actions"
+              size="small"
+              sx={{ opacity: 0, transition: 'opacity 120ms' }}
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete(message.id);
+              }}
+              aria-label="Delete message"
+            >
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          )}
+        </Box>
+
+        <Typography
+          variant="body2"
+          component="div"
+          sx={{
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            mt: 0.25,
+            textAlign: isMine ? 'right' : 'left',
+          }}
+        >
+          {segments.map((segment, index) => {
+            if (segment.kind === 'text') {
+              return <span key={index}>{segment.text}</span>;
+            }
+            if (segment.kind === 'mention') {
+              return (
+                <Chip
+                  key={index}
+                  label={`@${segment.label}`}
+                  size="small"
+                  sx={{
+                    height: 20,
+                    mx: 0.25,
+                    bgcolor:
+                      segment.userId === currentUserId
+                        ? colors.semantic.warningLight
+                        : colors.neutral[200],
+                  }}
+                />
+              );
+            }
+            if (!showReferences) return null;
             return (
               <Chip
                 key={index}
-                label={`@${segment.label}`}
+                label={segment.label}
                 size="small"
-                sx={{
-                  height: 20,
-                  mx: 0.25,
-                  bgcolor:
-                    segment.userId === currentUserId
-                      ? colors.semantic.warningLight
-                      : colors.neutral[200],
+                clickable
+                onClick={(event) => {
+                  event.stopPropagation();
+                  navigate(`${baseRoute}/repair-orders/${segment.entityId}`);
                 }}
+                sx={{ height: 20, mx: 0.25 }}
               />
             );
-          }
-          if (!showReferences) return null;
-          return (
-            <Chip
-              key={index}
-              label={segment.label}
-              size="small"
-              clickable
-              onClick={() =>
-                navigate(`${baseRoute}/repair-orders/${segment.entityId}`)
-              }
-              sx={{ height: 20, mx: 0.25 }}
-            />
-          );
-        })}
-      </Typography>
+          })}
+        </Typography>
+      </Box>
     </Box>
   );
 }

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -5,6 +5,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ReplyIcon from '@mui/icons-material/Reply';
 import { segmentMessageBody, type MessageDto } from '@gt-automotive/data';
 import { colors } from '../../theme/colors';
+import { UserAvatar } from './UserAvatar';
 import { useRoleBaseRoute } from './hooks/useRoleBaseRoute';
 
 interface Props {
@@ -77,6 +78,11 @@ export function MessageItem({
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <UserAvatar
+          name={displayName(message.author.firstName, message.author.lastName)}
+          userId={message.author.id}
+          size={24}
+        />
         <Typography variant="subtitle2" sx={{ fontWeight: unread ? 800 : 600 }}>
           {displayName(message.author.firstName, message.author.lastName)}
         </Typography>

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -4,6 +4,7 @@ import LockIcon from '@mui/icons-material/Lock';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { segmentMessageBody, type MessageDto } from '@gt-automotive/data';
 import { colors } from '../../theme/colors';
+import { useRoleBaseRoute } from './hooks/useRoleBaseRoute';
 
 interface Props {
   message: MessageDto;
@@ -42,6 +43,7 @@ export function MessageItem({
   showReferences = true,
 }: Props) {
   const navigate = useNavigate();
+  const baseRoute = useRoleBaseRoute();
   const isPrivate = message.visibility === 'MENTIONED_ONLY';
   const isMine = message.author.id === currentUserId;
   const segments = segmentMessageBody(message.body);
@@ -130,7 +132,7 @@ export function MessageItem({
               size="small"
               clickable
               onClick={() =>
-                navigate(`/admin/repair-orders/${segment.entityId}`)
+                navigate(`${baseRoute}/repair-orders/${segment.entityId}`)
               }
               sx={{ height: 20, mx: 0.25 }}
             />

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -70,21 +70,27 @@ export function MessageItem({
     ? colors.primary.main
     : null;
 
+  // Identical either way. Which side it sits on is the only thing that says
+  // who wrote it — tinting your own as well made the same conversation look
+  // like two different kinds of message.
   const background = isPrivate
     ? `${colors.semantic.warningLight}22`
-    : isMine
-    ? `${colors.primary.main}12`
     : unread
     ? `${colors.primary.light}14`
     : colors.neutral[50];
 
   return (
-    // Own messages sit on the right, the way every chat does it: the side says
-    // who is talking before any of the text is read.
+    /*
+     * Your own messages are pushed to the right, and that is the whole
+     * difference — the box and everything in it is laid out identically either
+     * way. Mirroring the contents as well made the same conversation look like
+     * two kinds of message.
+     */
     <Box
       sx={{
         display: 'flex',
         justifyContent: isMine ? 'flex-end' : 'flex-start',
+        pl: isMine ? 4 : 0,
         mb: 0.5,
       }}
       onClick={() => onSeen?.()}
@@ -98,32 +104,25 @@ export function MessageItem({
           borderRadius: 1.5,
           cursor: onSeen ? 'pointer' : 'default',
           bgcolor: background,
-          // The accent follows the bubble so it stays on the outer edge rather
-          // than floating in the middle of the row.
-          ...(accent
-            ? isMine
-              ? { borderRight: `3px solid ${accent}` }
-              : { borderLeft: `3px solid ${accent}` }
-            : {}),
+          ...(accent ? { borderLeft: `3px solid ${accent}` } : {}),
           '&:hover .message-actions': { opacity: 1 },
         }}
       >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            flexDirection: isMine ? 'row-reverse' : 'row',
-          }}
-        >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <UserAvatar name={author} userId={message.author.id} size={24} />
           <Typography
             variant="subtitle2"
-            sx={{ fontWeight: unread ? 800 : 600 }}
+            noWrap
+            sx={{ fontWeight: unread ? 800 : 600, flexShrink: 0 }}
           >
             {author}
           </Typography>
-          <Typography variant="caption" color="text.secondary">
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            noWrap
+            sx={{ flexShrink: 0 }}
+          >
             {formatTime(message.createdAt)}
           </Typography>
           {message.editedAt && (
@@ -189,7 +188,6 @@ export function MessageItem({
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-word',
             mt: 0.25,
-            textAlign: isMine ? 'right' : 'left',
           }}
         >
           {segments.map((segment, index) => {

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -19,6 +19,10 @@ interface Props {
     authorName: string;
     audience: string[];
   }) => void;
+  /** Arrived since this reader last looked. */
+  unread?: boolean;
+  /** Clicking a message is a deliberate "I have read this". */
+  onSeen?: () => void;
 }
 
 const displayName = (
@@ -48,6 +52,8 @@ export function MessageItem({
   onDelete,
   showReferences = true,
   onReply,
+  unread = false,
+  onSeen,
 }: Props) {
   const navigate = useNavigate();
   const baseRoute = useRoleBaseRoute();
@@ -71,7 +77,7 @@ export function MessageItem({
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: unread ? 800 : 600 }}>
           {displayName(message.author.firstName, message.author.lastName)}
         </Typography>
         <Typography variant="caption" color="text.secondary">

--- a/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MessageThread } from './MessageThread';
+
+const mockGetEntityThread = jest.fn();
+const mockPollMessages = jest.fn();
+
+jest.mock('../../requests/messaging.requests', () => ({
+  getEntityThread: (...args: unknown[]) => mockGetEntityThread(...args),
+  getGeneralThread: jest.fn(),
+  pollMessages: (...args: unknown[]) => mockPollMessages(...args),
+  sendMessage: jest.fn(),
+  deleteMessage: jest.fn(),
+  markConversationRead: jest.fn().mockResolvedValue(undefined),
+  searchMentionableUsers: jest.fn().mockResolvedValue([]),
+  searchReferenceableROs: jest.fn().mockResolvedValue([]),
+}));
+
+/*
+ * Mirrors the real contexts, which build a fresh object of fresh arrow
+ * functions on every render rather than memoising. That unstable identity is
+ * the thing these tests exist to survive.
+ */
+jest.mock('../../contexts/ErrorContext', () => ({
+  useErrorHelpers: () => ({
+    showApiError: (error: unknown) => void error,
+  }),
+}));
+
+jest.mock('../../contexts/ConfirmationContext', () => ({
+  useConfirmationHelpers: () => ({
+    confirmDelete: () => Promise.resolve(false),
+  }),
+}));
+
+const renderThread = () =>
+  render(
+    <MemoryRouter>
+      <MessageThread
+        entityType="REPAIR_ORDER"
+        entityId="ro-1"
+        currentUserId="user-1"
+        isAdmin={false}
+      />
+    </MemoryRouter>
+  );
+
+describe('MessageThread', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEntityThread.mockResolvedValue({ id: 'conv-1' });
+    mockPollMessages.mockResolvedValue({
+      messages: [],
+      unreadMentions: 0,
+      conversationUnreads: {},
+      serverTime: '2026-08-20T17:00:00.000Z',
+    });
+  });
+
+  /*
+   * The bug this guards against: naming a context helper in a dependency array
+   * made the effect re-run on every render, so opening the thread set state,
+   * which re-rendered, which opened it again. On screen it looked like the tab
+   * refreshing forever; in the network tab it was an unbounded request loop.
+   *
+   * Nothing in typecheck or lint can see this, which is how it reached a
+   * browser in the first place.
+   */
+  it('opens the conversation once, not on every render', async () => {
+    renderThread();
+
+    await waitFor(() => expect(mockGetEntityThread).toHaveBeenCalled());
+    // Long enough for a runaway loop to show itself.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(mockGetEntityThread).toHaveBeenCalledTimes(1);
+    expect(mockGetEntityThread).toHaveBeenCalledWith('REPAIR_ORDER', 'ro-1');
+  });
+
+  it('settles instead of re-rendering forever', async () => {
+    renderThread();
+
+    await waitFor(() =>
+      expect(screen.getByText('No messages yet')).toBeTruthy()
+    );
+
+    const pollsAfterSettling = mockPollMessages.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    // A held poll plus the initial catch-up is fine; a loop is not.
+    expect(
+      mockPollMessages.mock.calls.length - pollsAfterSettling
+    ).toBeLessThan(3);
+  });
+
+  it('shows an error rather than an empty thread when opening fails', async () => {
+    mockGetEntityThread.mockRejectedValue(new Error('nope'));
+
+    renderThread();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('This conversation could not be opened.')
+      ).toBeTruthy()
+    );
+    expect(mockGetEntityThread).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -43,6 +43,17 @@ export function MessageThread({
 
   const bottomRef = useRef<HTMLDivElement>(null);
 
+  /*
+   * useErrorHelpers and useConfirmationHelpers build a fresh object of fresh
+   * arrow functions on every render, so their identity changes constantly.
+   * Naming one in a dependency array makes that effect re-run on every render —
+   * which here meant opening the thread, setting state, re-rendering, and
+   * opening it again, forever. Held in a ref so identity cannot drive effects,
+   * while calls still reach the current context.
+   */
+  const helpersRef = useRef({ showApiError, confirmDelete });
+  helpersRef.current = { showApiError, confirmDelete };
+
   useEffect(() => {
     let cancelled = false;
     setOpening(true);
@@ -58,7 +69,7 @@ export function MessageThread({
       } catch (error) {
         if (!cancelled) {
           setOpenError('This conversation could not be opened.');
-          showApiError(error);
+          helpersRef.current.showApiError(error);
         }
       } finally {
         if (!cancelled) setOpening(false);
@@ -68,7 +79,7 @@ export function MessageThread({
     return () => {
       cancelled = true;
     };
-  }, [entityType, entityId, showApiError]);
+  }, [entityType, entityId]);
 
   // Reading the thread is what marks it read, so the badge clears on the way
   // out rather than on every render.
@@ -90,25 +101,25 @@ export function MessageThread({
         const created = await sendMessage(conversationId, body);
         appendLocal(created);
       } catch (error) {
-        showApiError(error);
+        helpersRef.current.showApiError(error);
       }
     },
-    [conversationId, appendLocal, showApiError]
+    [conversationId, appendLocal]
   );
 
   const handleDelete = useCallback(
     async (id: string) => {
-      const confirmed = await confirmDelete('this message');
+      const confirmed = await helpersRef.current.confirmDelete('this message');
       if (!confirmed) return;
 
       try {
         await deleteMessage(id);
         removeLocal(id);
       } catch (error) {
-        showApiError(error);
+        helpersRef.current.showApiError(error);
       }
     },
-    [confirmDelete, removeLocal, showApiError]
+    [removeLocal]
   );
 
   if (opening) {

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Box,
   CircularProgress,
+  Divider,
   IconButton,
   Typography,
 } from '@mui/material';
@@ -23,6 +24,7 @@ import {
 } from '../../requests/messaging.requests';
 import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
+import { announceRead } from './messaging-read-signal';
 
 export interface ReplyTarget {
   messageId: string;
@@ -63,6 +65,7 @@ export function MessageThread({
   const [replyTo, setReplyTo] = useState<ReplyTarget | undefined>(
     initialReplyTo
   );
+  const [readMark, setReadMark] = useState<string | null>(null);
   const [openError, setOpenError] = useState<string | null>(null);
 
   const { messages, loading, appendLocal, removeLocal } =
@@ -98,7 +101,10 @@ export function MessageThread({
           entityType && entityId
             ? await getEntityThread(entityType, entityId)
             : await getGeneralThread();
-        if (!cancelled) setConversationId(conversation.id);
+        if (!cancelled) {
+          setConversationId(conversation.id);
+          setReadMark(conversation.lastReadAt ?? null);
+        }
       } catch (error) {
         if (!cancelled) {
           setOpenError('This conversation could not be opened.');
@@ -114,14 +120,25 @@ export function MessageThread({
     };
   }, [entityType, entityId, knownConversationId]);
 
-  // Reading the thread is what marks it read, so the badge clears on the way
-  // out rather than on every render.
-  useEffect(() => {
+  /*
+   * Mark read while the thread is on screen, not on the way out.
+   *
+   * Marking only on unmount meant the badge still showed a count for messages
+   * being looked at, and stayed wrong for as long as the thread stayed open.
+   * Re-runs when new messages land, so a thread left open keeps clearing.
+   */
+  const markRead = useCallback(() => {
     if (!conversationId) return;
-    return () => {
-      void markConversationRead(conversationId).catch(() => undefined);
-    };
+    markConversationRead(conversationId)
+      .then(announceRead)
+      .catch(() => undefined);
   }, [conversationId]);
+
+  useEffect(() => {
+    if (!conversationId || document.hidden) return;
+    const handle = setTimeout(markRead, 400);
+    return () => clearTimeout(handle);
+  }, [conversationId, markRead, messages.length]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -198,17 +215,54 @@ export function MessageThread({
             </Typography>
           </Box>
         ) : (
-          messages.map((message) => (
-            <MessageItem
-              key={message.id}
-              message={message}
-              currentUserId={currentUserId}
-              canDelete={isAdmin}
-              onDelete={handleDelete}
-              showReferences={!entityId}
-              onReply={setReplyTo}
-            />
-          ))
+          messages.map((message, index) => {
+            const isUnread =
+              message.author.id !== currentUserId &&
+              (!readMark || message.createdAt > readMark);
+            const firstUnread =
+              isUnread &&
+              !messages
+                .slice(0, index)
+                .some(
+                  (earlier) =>
+                    earlier.author.id !== currentUserId &&
+                    (!readMark || earlier.createdAt > readMark)
+                );
+
+            return (
+              <Box key={message.id}>
+                {firstUnread && (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      my: 1,
+                    }}
+                  >
+                    <Divider sx={{ flexGrow: 1 }} />
+                    <Typography
+                      variant="caption"
+                      sx={{ color: colors.semantic.error, fontWeight: 700 }}
+                    >
+                      New
+                    </Typography>
+                    <Divider sx={{ flexGrow: 1 }} />
+                  </Box>
+                )}
+                <MessageItem
+                  message={message}
+                  currentUserId={currentUserId}
+                  canDelete={isAdmin}
+                  onDelete={handleDelete}
+                  showReferences={!entityId}
+                  onReply={setReplyTo}
+                  unread={isUnread}
+                  onSeen={markRead}
+                />
+              </Box>
+            );
+          })
         )}
         <div ref={bottomRef} />
       </Box>

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, Box, CircularProgress, Typography } from '@mui/material';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  IconButton,
+  Typography,
+} from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
+import ReplyIcon from '@mui/icons-material/Reply';
+import CloseIcon from '@mui/icons-material/Close';
+import { colors } from '../../theme/colors';
 import type { ConversationEntity } from '@gt-automotive/data';
 import { useMessagePolling } from './hooks/useMessagePolling';
 import { MessageComposer } from './MessageComposer';
@@ -15,27 +24,45 @@ import {
 import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
 
+export interface ReplyTarget {
+  messageId: string;
+  authorName: string;
+  /** Names the parent is private to, if it is. Empty for a public parent. */
+  audience: string[];
+}
+
 interface Props {
-  /** Omit for the shop-wide channel. */
+  /** A conversation already known by id — skips the get-or-create. */
+  conversationId?: string;
+  /** Or the record it hangs off. Omit both for the shop-wide channel. */
   entityType?: ConversationEntity;
   entityId?: string;
   currentUserId: string;
   isAdmin: boolean;
   height?: number | string;
+  /** Opens with a reply already aimed at this message. */
+  initialReplyTo?: ReplyTarget;
 }
 
 export function MessageThread({
+  conversationId: knownConversationId,
   entityType,
   entityId,
   currentUserId,
   isAdmin,
   height = 480,
+  initialReplyTo,
 }: Props) {
   const { showApiError } = useErrorHelpers();
   const { confirmDelete } = useConfirmationHelpers();
 
-  const [conversationId, setConversationId] = useState<string | undefined>();
-  const [opening, setOpening] = useState(true);
+  const [conversationId, setConversationId] = useState<string | undefined>(
+    knownConversationId
+  );
+  const [opening, setOpening] = useState(!knownConversationId);
+  const [replyTo, setReplyTo] = useState<ReplyTarget | undefined>(
+    initialReplyTo
+  );
   const [openError, setOpenError] = useState<string | null>(null);
 
   const { messages, loading, appendLocal, removeLocal } =
@@ -55,6 +82,12 @@ export function MessageThread({
   helpersRef.current = { showApiError, confirmDelete };
 
   useEffect(() => {
+    if (knownConversationId) {
+      setConversationId(knownConversationId);
+      setOpening(false);
+      return;
+    }
+
     let cancelled = false;
     setOpening(true);
     setOpenError(null);
@@ -79,7 +112,7 @@ export function MessageThread({
     return () => {
       cancelled = true;
     };
-  }, [entityType, entityId]);
+  }, [entityType, entityId, knownConversationId]);
 
   // Reading the thread is what marks it read, so the badge clears on the way
   // out rather than on every render.
@@ -98,13 +131,18 @@ export function MessageThread({
     async (body: string) => {
       if (!conversationId) return;
       try {
-        const created = await sendMessage(conversationId, body);
+        const created = await sendMessage(
+          conversationId,
+          body,
+          replyTo?.messageId
+        );
         appendLocal(created);
+        setReplyTo(undefined);
       } catch (error) {
         helpersRef.current.showApiError(error);
       }
     },
-    [conversationId, appendLocal]
+    [conversationId, appendLocal, replyTo]
   );
 
   const handleDelete = useCallback(
@@ -168,13 +206,53 @@ export function MessageThread({
               canDelete={isAdmin}
               onDelete={handleDelete}
               showReferences={!entityId}
+              onReply={setReplyTo}
             />
           ))
         )}
         <div ref={bottomRef} />
       </Box>
 
-      <MessageComposer onSend={handleSend} disabled={!conversationId} />
+      {replyTo && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 1,
+            py: 0.5,
+            mb: 0.5,
+            borderLeft: `3px solid ${colors.primary.main}`,
+            bgcolor: 'action.hover',
+          }}
+        >
+          <ReplyIcon sx={{ fontSize: 15, color: 'text.secondary' }} />
+          <Typography variant="caption" sx={{ flexGrow: 1 }}>
+            Replying to {replyTo.authorName}
+          </Typography>
+          <IconButton
+            size="small"
+            onClick={() => setReplyTo(undefined)}
+            aria-label="Cancel reply"
+          >
+            <CloseIcon sx={{ fontSize: 15 }} />
+          </IconButton>
+        </Box>
+      )}
+
+      <MessageComposer
+        onSend={handleSend}
+        disabled={!conversationId}
+        autoFocus={Boolean(initialReplyTo)}
+        // A reply cannot be more visible than what it answers, so the strip
+        // must name who it will actually reach rather than claiming the shop
+        // can see it.
+        inheritedAudience={
+          replyTo && replyTo.audience.length > 0
+            ? [replyTo.authorName, ...replyTo.audience]
+            : undefined
+        }
+      />
     </Box>
   );
 }

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -14,7 +14,10 @@ import {
 import ChatIcon from '@mui/icons-material/Chat';
 import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import VolumeUpIcon from '@mui/icons-material/VolumeUp';
+import VolumeOffIcon from '@mui/icons-material/VolumeOff';
 import { useMessagePolling } from './hooks/useMessagePolling';
+import { useNotificationSound } from './hooks/useNotificationSound';
 import { MessageThread } from './MessageThread';
 import { MentionsList } from './MentionsList';
 import type { ReplyTarget } from './MessageThread';
@@ -81,7 +84,17 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
 
   // No conversation id: this poll exists for the counts alone. The server
   // returns them whether or not a thread is open.
-  const { unreadMentions, refresh } = useMessagePolling(undefined);
+  const { unreadMentions, conversationUnreads, refresh } =
+    useMessagePolling(undefined);
+
+  // Everything unread, not only mentions: an untagged message in the shop
+  // channel is still something somebody has not seen.
+  const unreadTotal =
+    unreadMentions +
+    Object.values(conversationUnreads).reduce((sum, n) => sum + n, 0);
+
+  const { enabled: soundEnabled, setEnabled: setSoundEnabled } =
+    useNotificationSound(unreadTotal);
 
   return (
     <>
@@ -147,12 +160,23 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
               {openedThread ? openedThread.title : 'Messages'}
             </Typography>
           </Box>
-          <IconButton
-            onClick={() => setOpen(false)}
-            aria-label="Close messages"
-          >
-            <CloseIcon />
-          </IconButton>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Tooltip title={soundEnabled ? 'Mute new-message sound' : 'Unmute'}>
+              <IconButton
+                onClick={() => setSoundEnabled(!soundEnabled)}
+                aria-label={
+                  soundEnabled
+                    ? 'Mute new-message sound'
+                    : 'Unmute new-message sound'
+                }
+              >
+                {soundEnabled ? <VolumeUpIcon /> : <VolumeOffIcon />}
+              </IconButton>
+            </Tooltip>
+            <IconButton onClick={closeDrawer} aria-label="Close messages">
+              <CloseIcon />
+            </IconButton>
+          </Box>
         </Box>
 
         {!openedThread && (

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Badge,
   Box,
@@ -20,6 +20,7 @@ import { useMessagePolling } from './hooks/useMessagePolling';
 import { useNotificationSound } from './hooks/useNotificationSound';
 import { MessageThread } from './MessageThread';
 import { MentionsList } from './MentionsList';
+import { onReadAnnounced } from './messaging-read-signal';
 import type { ReplyTarget } from './MessageThread';
 import type { MentionInboxItemDto } from '@gt-automotive/data';
 
@@ -95,6 +96,10 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
 
   const { enabled: soundEnabled, setEnabled: setSoundEnabled } =
     useNotificationSound(unreadTotal);
+
+  // The count is held open in a long poll, so it would otherwise stay wrong
+  // for up to twenty-five seconds after something was read.
+  useEffect(() => onReadAnnounced(() => void refresh()), [refresh]);
 
   return (
     <>
@@ -233,7 +238,6 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
           {open && !openedThread && tab === 1 && (
             <MentionsList
               refreshKey={unreadMentions}
-              onRead={() => void refresh()}
               onNavigate={closeDrawer}
               onOpenConversation={openThreadFor}
             />

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import {
+  Badge,
+  Box,
+  Divider,
+  Drawer,
+  Fab,
+  IconButton,
+  Tab,
+  Tabs,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ChatIcon from '@mui/icons-material/Chat';
+import CloseIcon from '@mui/icons-material/Close';
+import { useMessagePolling } from './hooks/useMessagePolling';
+import { MessageThread } from './MessageThread';
+import { MentionsList } from './MentionsList';
+
+interface Props {
+  currentUserId: string;
+  isAdmin: boolean;
+}
+
+/**
+ * Always-present entry point to messaging, with the count of things tagged at
+ * you.
+ *
+ * Notification for this feature is in-app only, so the badge is the whole
+ * mechanism — nothing else tells somebody they were tagged. It therefore polls
+ * with no conversation open, which is what keeps the count live wherever the
+ * user happens to be in the app.
+ */
+export function MessagingFab({ currentUserId, isAdmin }: Props) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState(0);
+
+  // No conversation id: this poll exists for the counts alone. The server
+  // returns them whether or not a thread is open.
+  const { unreadMentions, refresh } = useMessagePolling(undefined);
+
+  return (
+    <>
+      <Tooltip title="Messages" placement="left">
+        <Fab
+          color="primary"
+          aria-label={
+            unreadMentions > 0
+              ? `Messages, ${unreadMentions} unread`
+              : 'Messages'
+          }
+          onClick={() => setOpen(true)}
+          sx={{
+            position: 'fixed',
+            bottom: { xs: 16, sm: 24 },
+            right: { xs: 16, sm: 24 },
+            zIndex: (theme) => theme.zIndex.drawer - 1,
+          }}
+        >
+          <Badge badgeContent={unreadMentions} color="error" max={99}>
+            <ChatIcon />
+          </Badge>
+        </Fab>
+      </Tooltip>
+
+      <Drawer
+        anchor="right"
+        open={open}
+        onClose={() => setOpen(false)}
+        slotProps={{
+          paper: {
+            sx: { width: { xs: '100%', sm: 420 }, display: 'flex' },
+          },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: 2,
+            py: 1.5,
+          }}
+        >
+          <Typography variant="h6">Messages</Typography>
+          <IconButton
+            onClick={() => setOpen(false)}
+            aria-label="Close messages"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        <Tabs
+          value={tab}
+          onChange={(_, value) => setTab(value)}
+          variant="fullWidth"
+        >
+          <Tab label="Shop Chat" />
+          <Tab
+            label={
+              <Badge
+                badgeContent={unreadMentions}
+                color="error"
+                max={99}
+                sx={{ pr: unreadMentions > 0 ? 1.5 : 0 }}
+              >
+                Mentions
+              </Badge>
+            }
+          />
+        </Tabs>
+        <Divider />
+
+        <Box sx={{ flexGrow: 1, overflowY: 'auto', px: tab === 0 ? 1.5 : 0 }}>
+          {/*
+            Mounted only while its tab is showing. The thread holds a long poll
+            open, and leaving one running behind a hidden tab would keep a
+            connection busy for a conversation nobody is reading.
+          */}
+          {open && tab === 0 && (
+            <MessageThread
+              currentUserId={currentUserId}
+              isAdmin={isAdmin}
+              height="100%"
+            />
+          )}
+          {open && tab === 1 && (
+            <MentionsList
+              refreshKey={unreadMentions}
+              onRead={() => void refresh()}
+              onNavigate={() => setOpen(false)}
+            />
+          )}
+        </Box>
+      </Drawer>
+    </>
+  );
+}

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -13,9 +13,12 @@ import {
 } from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
 import CloseIcon from '@mui/icons-material/Close';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useMessagePolling } from './hooks/useMessagePolling';
 import { MessageThread } from './MessageThread';
 import { MentionsList } from './MentionsList';
+import type { ReplyTarget } from './MessageThread';
+import type { MentionInboxItemDto } from '@gt-automotive/data';
 
 interface Props {
   currentUserId: string;
@@ -34,6 +37,47 @@ interface Props {
 export function MessagingFab({ currentUserId, isAdmin }: Props) {
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState(0);
+
+  /*
+   * A mention on its own is one sentence with no surroundings, which is rarely
+   * enough to act on — the answer usually depends on what was said before it.
+   * Opening one swaps the panel for the conversation it came from, with the
+   * reply already aimed at the message that did the tagging.
+   */
+  const [openedThread, setOpenedThread] = useState<{
+    conversationId: string;
+    title: string;
+    replyTo: ReplyTarget;
+  } | null>(null);
+
+  const openThreadFor = (item: MentionInboxItemDto) => {
+    const authorName =
+      [item.message.author.firstName, item.message.author.lastName]
+        .filter(Boolean)
+        .join(' ') || 'Unknown';
+
+    setOpenedThread({
+      conversationId: item.conversation.id,
+      title: item.conversation.roNumber ?? 'Shop Chat',
+      replyTo: {
+        messageId: item.message.id,
+        authorName,
+        audience:
+          item.message.visibility === 'MENTIONED_ONLY'
+            ? item.message.mentions.map(
+                (m) =>
+                  [m.firstName, m.lastName].filter(Boolean).join(' ') ||
+                  'Unknown'
+              )
+            : [],
+      },
+    });
+  };
+
+  const closeDrawer = () => {
+    setOpen(false);
+    setOpenedThread(null);
+  };
 
   // No conversation id: this poll exists for the counts alone. The server
   // returns them whether or not a thread is open.
@@ -66,7 +110,7 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
       <Drawer
         anchor="right"
         open={open}
-        onClose={() => setOpen(false)}
+        onClose={closeDrawer}
         slotProps={{
           paper: {
             sx: { width: { xs: '100%', sm: 420 }, display: 'flex' },
@@ -82,7 +126,27 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
             py: 1.5,
           }}
         >
-          <Typography variant="h6">Messages</Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              minWidth: 0,
+            }}
+          >
+            {openedThread && (
+              <IconButton
+                size="small"
+                onClick={() => setOpenedThread(null)}
+                aria-label="Back to mentions"
+              >
+                <ArrowBackIcon />
+              </IconButton>
+            )}
+            <Typography variant="h6" noWrap>
+              {openedThread ? openedThread.title : 'Messages'}
+            </Typography>
+          </Box>
           <IconButton
             onClick={() => setOpen(false)}
             aria-label="Close messages"
@@ -91,45 +155,63 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
           </IconButton>
         </Box>
 
-        <Tabs
-          value={tab}
-          onChange={(_, value) => setTab(value)}
-          variant="fullWidth"
-        >
-          <Tab label="Shop Chat" />
-          <Tab
-            label={
-              <Badge
-                badgeContent={unreadMentions}
-                color="error"
-                max={99}
-                sx={{ pr: unreadMentions > 0 ? 1.5 : 0 }}
-              >
-                Mentions
-              </Badge>
-            }
-          />
-        </Tabs>
+        {!openedThread && (
+          <Tabs
+            value={tab}
+            onChange={(_, value) => setTab(value)}
+            variant="fullWidth"
+          >
+            <Tab label="Shop Chat" />
+            <Tab
+              label={
+                <Badge
+                  badgeContent={unreadMentions}
+                  color="error"
+                  max={99}
+                  sx={{ pr: unreadMentions > 0 ? 1.5 : 0 }}
+                >
+                  Mentions
+                </Badge>
+              }
+            />
+          </Tabs>
+        )}
         <Divider />
 
-        <Box sx={{ flexGrow: 1, overflowY: 'auto', px: tab === 0 ? 1.5 : 0 }}>
+        <Box
+          sx={{
+            flexGrow: 1,
+            overflowY: 'auto',
+            px: openedThread || tab === 0 ? 1.5 : 0,
+          }}
+        >
           {/*
             Mounted only while its tab is showing. The thread holds a long poll
             open, and leaving one running behind a hidden tab would keep a
             connection busy for a conversation nobody is reading.
           */}
-          {open && tab === 0 && (
+          {open && openedThread && (
+            <MessageThread
+              conversationId={openedThread.conversationId}
+              initialReplyTo={openedThread.replyTo}
+              currentUserId={currentUserId}
+              isAdmin={isAdmin}
+              height="100%"
+            />
+          )}
+          {open && !openedThread && tab === 0 && (
             <MessageThread
               currentUserId={currentUserId}
               isAdmin={isAdmin}
               height="100%"
             />
           )}
-          {open && tab === 1 && (
+          {open && !openedThread && tab === 1 && (
             <MentionsList
               refreshKey={unreadMentions}
               onRead={() => void refresh()}
-              onNavigate={() => setOpen(false)}
+              onNavigate={closeDrawer}
+              onOpenConversation={openThreadFor}
             />
           )}
         </Box>

--- a/apps/webApp/src/app/components/messaging/UserAvatar.tsx
+++ b/apps/webApp/src/app/components/messaging/UserAvatar.tsx
@@ -1,0 +1,63 @@
+import { Avatar } from '@mui/material';
+import { colors } from '../../theme/colors';
+
+/**
+ * Brand colours first, then enough distinct hues that a small shop rarely sees
+ * two people share one. Every entry is dark enough for white text to stay
+ * legible on it.
+ */
+const AVATAR_COLORS = [
+  colors.primary.main,
+  colors.secondary.main,
+  colors.semantic.info,
+  colors.semantic.success,
+  colors.semantic.error,
+  colors.primary.lighter,
+  colors.semantic.warningDark,
+  colors.primary.dark,
+];
+
+/**
+ * Same person, same colour, forever — and without storing anything.
+ *
+ * Keyed on the user id rather than the name so a colour survives somebody being
+ * renamed, and so two people who happen to share a first name never collide.
+ */
+function colorFor(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+interface Props {
+  name: string;
+  /** Colour is derived from this, so it survives a rename. */
+  userId?: string;
+  size?: number;
+}
+
+export function UserAvatar({ name, userId, size = 28 }: Props) {
+  return (
+    <Avatar
+      sx={{
+        width: size,
+        height: size,
+        bgcolor: colorFor(userId || name),
+        color: colors.primary.contrast,
+        fontSize: size * 0.4,
+        fontWeight: 600,
+      }}
+    >
+      {initialsOf(name)}
+    </Avatar>
+  );
+}

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
@@ -2,12 +2,21 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MessageDto } from '@gt-automotive/data';
 import { pollMessages } from '../../../requests/messaging.requests';
 
-/** Cadence while somebody is actually reading the thread. */
-const ACTIVE_INTERVAL_MS = 10_000;
-/** Cadence once the thread has been quiet for a while. */
-const IDLE_INTERVAL_MS = 60_000;
-/** How long without a new message before we consider the thread idle. */
-const IDLE_AFTER_MS = 2 * 60_000;
+/**
+ * How long the server may hold a request open waiting for something to happen.
+ *
+ * The hold is the interval. A message comes back the moment it is written
+ * rather than up to ten seconds later, and an idle thread costs one request
+ * every twenty-five seconds instead of one every ten. Capped server-side too,
+ * below the reverse proxy's thirty second timeout.
+ */
+const HOLD_MS = 25_000;
+
+/** Breather between holds, so a server answering instantly cannot spin. */
+const GAP_MS = 500;
+
+/** Backoff after a failure, so an outage is not hammered. */
+const ERROR_BACKOFF_MS = 5_000;
 
 interface PollingState {
   messages: MessageDto[];
@@ -17,16 +26,13 @@ interface PollingState {
 }
 
 /**
- * Every bit of transport for messaging lives here.
+ * Every bit of transport for messaging lives here, so components only ever see
+ * an accumulated message list.
  *
- * Components only ever see the accumulated message list, which is what makes
- * the eventual switch to long polling a change to this file alone.
- *
- * Two things keep the request count honest. Polling stops entirely while the
- * tab is hidden — a tab left open overnight is what turns a reasonable number
- * of requests into a silly one — and the interval backs off once the thread
- * goes quiet, which for a shop doing a couple of hundred messages a day is
- * most of the time.
+ * Polling stops entirely while the tab is hidden — a window left open
+ * overnight is what turns a reasonable number of requests into a silly one —
+ * and resumes with an immediate catch-up when someone comes back, rather than
+ * making them wait out a hold that started before they left.
  */
 export function useMessagePolling(conversationId?: string) {
   const [state, setState] = useState<PollingState>({
@@ -38,33 +44,18 @@ export function useMessagePolling(conversationId?: string) {
 
   // The server's clock, echoed back verbatim. Never Date.now(): a browser
   // running fast would ask for messages newer than a moment that has not
-  // happened yet and never see them.
+  // happened yet, and never see them.
   const cursorRef = useRef<string | undefined>(undefined);
-  const lastActivityRef = useRef<number>(Date.now());
-  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const abortRef = useRef<AbortController | undefined>(undefined);
+  const stoppedRef = useRef(false);
 
-  const runPoll = useCallback(async () => {
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    try {
-      const result = await pollMessages({
-        conversationId,
-        since: cursorRef.current,
-        signal: controller.signal,
-      });
-
+  const applyResult = useCallback(
+    (result: Awaited<ReturnType<typeof pollMessages>>) => {
       cursorRef.current = result.serverTime;
 
       setState((prev) => {
-        if (result.messages.length > 0) {
-          lastActivityRef.current = Date.now();
-        }
-
-        // Merge rather than replace: the cursor only ever returns what is new,
-        // and a re-send of an id we already hold must not duplicate it.
+        // Merge rather than replace: the cursor only returns what is new, and
+        // a message we already hold must not appear twice.
         const seen = new Set(prev.messages.map((m) => m.id));
         const added = result.messages.filter((m) => !seen.has(m.id));
 
@@ -75,32 +66,26 @@ export function useMessagePolling(conversationId?: string) {
           loading: false,
         };
       });
-    } catch (error) {
-      if (!controller.signal.aborted) {
-        // A failed poll is not worth interrupting anyone over — the next one
-        // is seconds away and will catch up from the same cursor.
-        setState((prev) => ({ ...prev, loading: false }));
-      }
+    },
+    []
+  );
+
+  /** One immediate round trip, for mount and for returning to the tab. */
+  const runPoll = useCallback(async () => {
+    try {
+      const result = await pollMessages({
+        conversationId,
+        since: cursorRef.current,
+      });
+      if (!stoppedRef.current) applyResult(result);
+    } catch {
+      setState((prev) => ({ ...prev, loading: false }));
     }
-  }, [conversationId]);
-
-  const scheduleNext = useCallback(() => {
-    const quietFor = Date.now() - lastActivityRef.current;
-    const delay =
-      quietFor > IDLE_AFTER_MS ? IDLE_INTERVAL_MS : ACTIVE_INTERVAL_MS;
-
-    timerRef.current = setTimeout(async () => {
-      if (!document.hidden) {
-        await runPoll();
-      }
-      scheduleNext();
-    }, delay);
-  }, [runPoll]);
+  }, [conversationId, applyResult]);
 
   useEffect(() => {
-    // A new thread starts from scratch: its cursor and history belong to it.
+    stoppedRef.current = false;
     cursorRef.current = undefined;
-    lastActivityRef.current = Date.now();
     setState({
       messages: [],
       unreadMentions: 0,
@@ -108,26 +93,55 @@ export function useMessagePolling(conversationId?: string) {
       loading: Boolean(conversationId),
     });
 
-    void runPoll();
-    scheduleNext();
+    const sleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+
+    const loop = async () => {
+      while (!stoppedRef.current) {
+        if (document.hidden) {
+          await sleep(GAP_MS);
+          continue;
+        }
+
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        try {
+          const result = await pollMessages({
+            conversationId,
+            since: cursorRef.current,
+            waitMs: HOLD_MS,
+            signal: controller.signal,
+          });
+          if (stoppedRef.current) return;
+          applyResult(result);
+          await sleep(GAP_MS);
+        } catch {
+          if (stoppedRef.current || controller.signal.aborted) return;
+          // A failed poll is not worth interrupting anyone over. Back off and
+          // pick up from the same cursor — nothing is lost.
+          setState((prev) => ({ ...prev, loading: false }));
+          await sleep(ERROR_BACKOFF_MS);
+        }
+      }
+    };
+
+    void loop();
 
     const onVisibilityChange = () => {
-      // Catch up immediately on return rather than making someone wait out
-      // the remainder of an interval that elapsed while they were away.
       if (!document.hidden) void runPoll();
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      stoppedRef.current = true;
       abortRef.current?.abort();
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
-  }, [conversationId, runPoll, scheduleNext]);
+  }, [conversationId, applyResult, runPoll]);
 
-  /** Push a just-sent message in without waiting for the next poll. */
+  /** Show a just-sent message without waiting for the next round trip. */
   const appendLocal = useCallback((message: MessageDto) => {
-    lastActivityRef.current = Date.now();
     setState((prev) =>
       prev.messages.some((m) => m.id === message.id)
         ? prev

--- a/apps/webApp/src/app/components/messaging/hooks/useNotificationSound.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useNotificationSound.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const PREFERENCE_KEY = 'gt.messaging.soundEnabled';
+
+/**
+ * Kept in localStorage rather than the sessionStorage that usePersistedState
+ * uses: filters are per-tab because two tabs are usually two pieces of work,
+ * but somebody who turned the ping off meant off, everywhere, until they turn
+ * it back on.
+ */
+function readPreference(): boolean {
+  try {
+    return localStorage.getItem(PREFERENCE_KEY) !== 'false';
+  } catch {
+    // Private browsing throws on access. Defaulting to on is the same as
+    // never having set it.
+    return true;
+  }
+}
+
+let audioContext: AudioContext | null = null;
+
+/**
+ * A short two-note ping, synthesised rather than loaded.
+ *
+ * No file to ship, no request to make, and nothing to go missing from the
+ * bundle. Two notes because a single beep is easy to mistake for the operating
+ * system.
+ */
+function playPing(): void {
+  try {
+    const Ctor =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!Ctor) return;
+
+    audioContext = audioContext ?? new Ctor();
+    // Browsers suspend the context until the page has been interacted with.
+    if (audioContext.state === 'suspended') void audioContext.resume();
+
+    const now = audioContext.currentTime;
+    [
+      { frequency: 880, at: 0 },
+      { frequency: 1174.7, at: 0.11 },
+    ].forEach(({ frequency, at }) => {
+      const oscillator = audioContext!.createOscillator();
+      const gain = audioContext!.createGain();
+
+      oscillator.type = 'sine';
+      oscillator.frequency.value = frequency;
+
+      // Eased in and out: a square-edged gain envelope clicks.
+      gain.gain.setValueAtTime(0, now + at);
+      gain.gain.linearRampToValueAtTime(0.12, now + at + 0.015);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + at + 0.16);
+
+      oscillator.connect(gain).connect(audioContext!.destination);
+      oscillator.start(now + at);
+      oscillator.stop(now + at + 0.18);
+    });
+  } catch {
+    // Audio is a courtesy. If the browser refuses, the badge still moved.
+  }
+}
+
+/**
+ * Pings when the unread total goes up.
+ *
+ * Notification here is in-app only, so the badge is the whole mechanism — and
+ * a badge only works on someone already looking at that corner of the screen.
+ * The sound is what makes it work for someone who is not.
+ *
+ * Only ever on an increase, and never on the first reading: otherwise opening
+ * the app would replay every unread message that arrived while it was closed.
+ */
+export function useNotificationSound(unreadTotal: number) {
+  const [enabled, setEnabledState] = useState(readPreference);
+  const previousTotal = useRef<number | null>(null);
+
+  const setEnabled = useCallback((next: boolean) => {
+    setEnabledState(next);
+    try {
+      localStorage.setItem(PREFERENCE_KEY, String(next));
+    } catch {
+      // Preference is lost on reload; the toggle still works for this session.
+    }
+    if (next) playPing(); // Confirms it is audible, and unlocks the context.
+  }, []);
+
+  useEffect(() => {
+    if (previousTotal.current === null) {
+      previousTotal.current = unreadTotal;
+      return;
+    }
+
+    if (unreadTotal > previousTotal.current && enabled) {
+      playPing();
+    }
+    // Reset on a drop too, so clearing then receiving pings again.
+    previousTotal.current = unreadTotal;
+  }, [unreadTotal, enabled]);
+
+  return { enabled, setEnabled };
+}

--- a/apps/webApp/src/app/components/messaging/hooks/useRoleBaseRoute.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useRoleBaseRoute.ts
@@ -1,0 +1,21 @@
+import { useLocation } from 'react-router-dom';
+
+/**
+ * The route prefix for whichever role's section the user is currently in.
+ *
+ * The same repair order lives at /admin/repair-orders/:id, /staff/... ,
+ * /supervisor/... and /foreman/..., each behind its own role guard. Linking to
+ * a fixed prefix sends everyone but an admin to a page they are not allowed to
+ * open, so a link built for one role cannot be reused for another.
+ *
+ * Mirrors how RODetail already derives its own links.
+ */
+export function useRoleBaseRoute(): string {
+  const { pathname } = useLocation();
+
+  if (pathname.startsWith('/staff')) return '/staff';
+  if (pathname.startsWith('/supervisor')) return '/supervisor';
+  if (pathname.startsWith('/foreman')) return '/foreman';
+  if (pathname.startsWith('/accountant')) return '/accountant';
+  return '/admin';
+}

--- a/apps/webApp/src/app/components/messaging/messaging-read-signal.ts
+++ b/apps/webApp/src/app/components/messaging/messaging-read-signal.ts
@@ -1,0 +1,21 @@
+/**
+ * Announces that something has been marked read.
+ *
+ * The badge and the thread are separate components with separate polls, and
+ * the poll may be held open for twenty-five seconds — so reading a thread left
+ * the count stale for up to that long. The repair order page has no path to
+ * the badge at all.
+ *
+ * A window event reaches all of them without threading a callback through
+ * every mount point, and costs nothing when nobody is listening.
+ */
+const EVENT = 'gt:messaging-read';
+
+export function announceRead(): void {
+  window.dispatchEvent(new CustomEvent(EVENT));
+}
+
+export function onReadAnnounced(listener: () => void): () => void {
+  window.addEventListener(EVENT, listener);
+  return () => window.removeEventListener(EVENT, listener);
+}

--- a/apps/webApp/src/app/layouts/AccountantLayout.tsx
+++ b/apps/webApp/src/app/layouts/AccountantLayout.tsx
@@ -41,6 +41,7 @@ import {
 import { useAuth } from '../hooks/useAuth';
 import { colors } from '../theme/colors';
 import gtLogo from '../images-and-logos/gt-automotive-logo.svg';
+import { MessagingFab } from '../components/messaging/MessagingFab';
 
 const drawerWidth = 280;
 const drawerCollapsedWidth = 72;
@@ -54,7 +55,7 @@ export function AccountantLayout() {
     financial: true,
     reports: true,
   });
-  const { user, logout } = useAuth();
+  const { user, logout, isAdmin } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -781,6 +782,7 @@ export function AccountantLayout() {
           </Container>
         </Box>
       </Box>
+      <MessagingFab currentUserId={user?.id ?? ''} isAdmin={isAdmin} />
     </Box>
   );
 }

--- a/apps/webApp/src/app/layouts/AdminLayout.tsx
+++ b/apps/webApp/src/app/layouts/AdminLayout.tsx
@@ -60,6 +60,7 @@ import { useAuth } from '../hooks/useAuth';
 import { colors } from '../theme/colors';
 import gtLogo from '../images-and-logos/gt-automotive-logo.svg';
 import companyService from '../requests/company.requests';
+import { MessagingFab } from '../components/messaging/MessagingFab';
 
 const drawerWidth = 280;
 const drawerCollapsedWidth = 72;
@@ -76,7 +77,7 @@ export function AdminLayout() {
     reports: true,
     system: true,
   });
-  const { user, logout } = useAuth();
+  const { user, logout, isAdmin } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -869,6 +870,7 @@ export function AdminLayout() {
           </Container>
         </Box>
       </Box>
+      <MessagingFab currentUserId={user?.id ?? ''} isAdmin={isAdmin} />
     </Box>
   );
 }

--- a/apps/webApp/src/app/layouts/ForemanLayout.tsx
+++ b/apps/webApp/src/app/layouts/ForemanLayout.tsx
@@ -55,6 +55,7 @@ import { useAuth } from '../hooks/useAuth';
 import { colors } from '../theme/colors';
 import gtLogo from '../images-and-logos/gt-automotive-logo.svg';
 import companyService from '../requests/company.requests';
+import { MessagingFab } from '../components/messaging/MessagingFab';
 
 const drawerWidth = 280;
 const drawerCollapsedWidth = 72;
@@ -70,7 +71,7 @@ export function ForemanLayout() {
     analytics: true,
     system: true,
   });
-  const { user, logout } = useAuth();
+  const { user, logout, isAdmin } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -844,6 +845,7 @@ export function ForemanLayout() {
           </Container>
         </Box>
       </Box>
+      <MessagingFab currentUserId={user?.id ?? ''} isAdmin={isAdmin} />
     </Box>
   );
 }

--- a/apps/webApp/src/app/layouts/StaffLayout.tsx
+++ b/apps/webApp/src/app/layouts/StaffLayout.tsx
@@ -51,6 +51,7 @@ import { useAuth } from '../hooks/useAuth';
 import { colors } from '../theme/colors';
 import gtLogo from '../images-and-logos/gt-automotive-logo.svg';
 import companyService from '../requests/company.requests';
+import { MessagingFab } from '../components/messaging/MessagingFab';
 
 const drawerWidth = 280;
 const drawerCollapsedWidth = 72;
@@ -65,7 +66,7 @@ export function StaffLayout() {
     business: true,
     scheduling: true,
   });
-  const { user, logout } = useAuth();
+  const { user, logout, isAdmin } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -795,6 +796,7 @@ export function StaffLayout() {
           </Container>
         </Box>
       </Box>
+      <MessagingFab currentUserId={user?.id ?? ''} isAdmin={isAdmin} />
     </Box>
   );
 }

--- a/apps/webApp/src/app/layouts/SupervisorLayout.tsx
+++ b/apps/webApp/src/app/layouts/SupervisorLayout.tsx
@@ -52,6 +52,7 @@ import {
 import { useAuth } from '../hooks/useAuth';
 import { colors } from '../theme/colors';
 import gtLogo from '../images-and-logos/gt-automotive-logo.svg';
+import { MessagingFab } from '../components/messaging/MessagingFab';
 
 const drawerWidth = 280;
 const drawerCollapsedWidth = 72;
@@ -66,7 +67,7 @@ export function SupervisorLayout() {
     business: true,
     scheduling: true,
   });
-  const { user, logout } = useAuth();
+  const { user, logout, isAdmin } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -838,6 +839,7 @@ export function SupervisorLayout() {
           </Container>
         </Box>
       </Box>
+      <MessagingFab currentUserId={user?.id ?? ''} isAdmin={isAdmin} />
     </Box>
   );
 }

--- a/apps/webApp/src/app/providers/QueryProvider.tsx
+++ b/apps/webApp/src/app/providers/QueryProvider.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 interface QueryProviderProps {
   children: React.ReactNode;
@@ -30,12 +29,7 @@ const queryClient = new QueryClient({
 
 export function QueryProvider({ children }: QueryProviderProps) {
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      {process.env.NODE_ENV === 'development' && (
-        <ReactQueryDevtools initialIsOpen={false} />
-      )}
-    </QueryClientProvider>
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 }
 

--- a/apps/webApp/src/app/requests/messaging.requests.ts
+++ b/apps/webApp/src/app/requests/messaging.requests.ts
@@ -42,13 +42,18 @@ export type { MessageDto, PollResponseDto, MentionableUserDto };
 export async function pollMessages(params: {
   conversationId?: string;
   since?: string;
+  /** Hold the request open this long if nothing is new. Omit to return at once. */
+  waitMs?: number;
   signal?: AbortSignal;
 }): Promise<PollResponseDto> {
   const { data } = await apiClient.get<PollResponseDto>('/messaging/poll', {
     params: {
       conversationId: params.conversationId,
       since: params.since,
+      waitMs: params.waitMs,
     },
+    // The server may hold this open, so the client has to outlast the hold.
+    timeout: 40_000,
     signal: params.signal,
   });
   return data;

--- a/libs/data/src/lib/message.dto.ts
+++ b/libs/data/src/lib/message.dto.ts
@@ -120,6 +120,8 @@ export interface MessageDto {
 
 export interface ConversationDto {
   id: string;
+  /** Where this reader had got to when the thread opened. */
+  lastReadAt?: string | null;
   type: ConversationType;
   title: string | null;
   entityType: ConversationEntity | null;

--- a/libs/data/src/lib/message.dto.ts
+++ b/libs/data/src/lib/message.dto.ts
@@ -136,6 +136,8 @@ export interface MentionInboxItemDto {
     id: string;
     entityType: ConversationEntity | null;
     entityId: string | null;
+    /** Repair order number, so a mention read outside its thread says which job. */
+    roNumber: string | null;
   };
 }
 

--- a/server/src/messaging/message-events.service.spec.ts
+++ b/server/src/messaging/message-events.service.spec.ts
@@ -26,9 +26,12 @@ describe('MessageEventsService', () => {
     await expect(waiting).resolves.toBe(true);
   });
 
-  it('does not wake for a different thread', async () => {
+  // A public message in another thread does wake you, deliberately: it moves
+  // your unread count, which is the badge's whole job. What must not wake you
+  // is a private message you are not part of.
+  it('does not wake for a private message in a different thread', async () => {
     const waiting = events.waitForMessage('sarah-1', 'conv-1', 60);
-    publish({ conversationId: 'conv-2' });
+    publish({ conversationId: 'conv-2', mentionedUserIds: ['mike-1'] });
 
     await expect(waiting).resolves.toBe(false);
   });
@@ -89,5 +92,47 @@ describe('MessageEventsService', () => {
 
     await expect(waiting).resolves.toBe(true);
     expect(events['emitter'].listenerCount('message')).toBe(0);
+  });
+
+  /*
+   * The badge poll runs with no conversation open, so before this an untagged
+   * message in shop chat woke nobody: the reader sat out the full hold and the
+   * count stayed wrong for up to twenty-five seconds, and the sound never
+   * fired because the count never moved.
+   */
+  describe('public messages', () => {
+    it('wakes a reader with no thread open', async () => {
+      const waiting = events.waitForMessage('sarah-1', undefined, 1000);
+      publish({ conversationId: 'general-1', mentionedUserIds: [] });
+
+      await expect(waiting).resolves.toBe(true);
+    });
+
+    it('wakes a reader sitting in a different thread', async () => {
+      const waiting = events.waitForMessage('sarah-1', 'conv-9', 1000);
+      publish({ conversationId: 'general-1', mentionedUserIds: [] });
+
+      await expect(waiting).resolves.toBe(true);
+    });
+
+    it('still does not wake the author of it', async () => {
+      const waiting = events.waitForMessage('sarah-1', undefined, 60);
+      publish({
+        conversationId: 'general-1',
+        mentionedUserIds: [],
+        authorId: 'sarah-1',
+      });
+
+      await expect(waiting).resolves.toBe(false);
+    });
+
+    // Waking is not reading: a private message must still only reach the
+    // people tagged in it, which the poll re-checks after any wake-up.
+    it('does not widen who a private message wakes', async () => {
+      const waiting = events.waitForMessage('mike-1', undefined, 60);
+      publish({ conversationId: 'conv-1', mentionedUserIds: ['sarah-1'] });
+
+      await expect(waiting).resolves.toBe(false);
+    });
   });
 });

--- a/server/src/messaging/message-events.service.ts
+++ b/server/src/messaging/message-events.service.ts
@@ -71,7 +71,14 @@ export class MessageEventsService implements OnModuleDestroy {
           event.conversationId === conversationId;
         const tagsMe = event.mentionedUserIds.includes(userId);
 
-        if (inOpenThread || tagsMe) finish(true);
+        // An untagged message is visible to everybody, so it moves everybody's
+        // unread count — including people with no thread open, which is the
+        // whole reason the badge exists. Waking on it is not a disclosure: the
+        // poll still re-queries through the visibility filter, and a reader who
+        // gained nothing simply gets the counts they already had.
+        const isPublic = event.mentionedUserIds.length === 0;
+
+        if (inOpenThread || tagsMe || isPublic) finish(true);
       };
 
       const timer = setTimeout(() => finish(false), timeoutMs);

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -429,4 +429,86 @@ describe('MessagingService', () => {
       );
     });
   });
+
+  describe('mention inbox', () => {
+    const inboxRow = (conversation: any) => ({
+      id: 'mention-1',
+      readAt: null,
+      message: {
+        ...messageRow(),
+        conversation,
+      },
+    });
+
+    /*
+     * A mention is read from the inbox, away from the thread it was written
+     * in, so it has to say which job it is about or it is just a sentence with
+     * no context.
+     */
+    it('carries the repair order number of the thread it came from', async () => {
+      (messages.findMentionInbox as jest.Mock) = jest.fn().mockResolvedValue([
+        inboxRow({
+          id: 'conv-1',
+          entityType: 'REPAIR_ORDER',
+          entityId: 'ro-1',
+        }),
+      ]);
+      prisma.repairOrder.findMany.mockResolvedValue([
+        { id: 'ro-1', roNumber: 'RO-202608-0002' },
+      ]);
+
+      const inbox = await service.getMentionInbox(author, false);
+
+      expect(inbox[0].conversation.roNumber).toBe('RO-202608-0002');
+      expect(inbox[0].conversation.entityId).toBe('ro-1');
+    });
+
+    it('leaves the number null for a mention from shop chat', async () => {
+      (messages.findMentionInbox as jest.Mock) = jest
+        .fn()
+        .mockResolvedValue([
+          inboxRow({ id: 'conv-2', entityType: null, entityId: null }),
+        ]);
+
+      const inbox = await service.getMentionInbox(author, false);
+
+      expect(inbox[0].conversation.roNumber).toBeNull();
+      expect(prisma.repairOrder.findMany).not.toHaveBeenCalled();
+    });
+
+    it('looks up each repair order once however many mentions it has', async () => {
+      (messages.findMentionInbox as jest.Mock) = jest
+        .fn()
+        .mockResolvedValue([
+          inboxRow({ id: 'c1', entityType: 'REPAIR_ORDER', entityId: 'ro-1' }),
+          inboxRow({ id: 'c1', entityType: 'REPAIR_ORDER', entityId: 'ro-1' }),
+          inboxRow({ id: 'c2', entityType: 'REPAIR_ORDER', entityId: 'ro-2' }),
+        ]);
+      prisma.repairOrder.findMany.mockResolvedValue([
+        { id: 'ro-1', roNumber: 'RO-1' },
+        { id: 'ro-2', roNumber: 'RO-2' },
+      ]);
+
+      await service.getMentionInbox(author, false);
+
+      expect(prisma.repairOrder.findMany).toHaveBeenCalledTimes(1);
+      const ids = prisma.repairOrder.findMany.mock.calls[0][0].where.id.in;
+      expect(ids.sort()).toEqual(['ro-1', 'ro-2']);
+    });
+
+    it('survives a repair order that has since been deleted', async () => {
+      (messages.findMentionInbox as jest.Mock) = jest.fn().mockResolvedValue([
+        inboxRow({
+          id: 'conv-1',
+          entityType: 'REPAIR_ORDER',
+          entityId: 'gone',
+        }),
+      ]);
+      prisma.repairOrder.findMany.mockResolvedValue([]);
+
+      const inbox = await service.getMentionInbox(author, false);
+
+      expect(inbox[0].conversation.roNumber).toBeNull();
+    });
+  });
 });

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -69,7 +69,9 @@ describe('MessagingService', () => {
     };
 
     prisma = {
-      $transaction: jest.fn((fn: any) => fn(tx)),
+      $transaction: jest.fn((arg: any) =>
+        typeof arg === 'function' ? arg(tx) : Promise.all(arg)
+      ),
       conversation: {
         findUnique: jest.fn().mockResolvedValue({ id: 'conv-1' }),
         findFirst: jest.fn().mockResolvedValue({ id: 'conv-1' }),
@@ -78,6 +80,7 @@ describe('MessagingService', () => {
       conversationMember: {
         upsert: jest.fn().mockResolvedValue({}),
         updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        findUnique: jest.fn().mockResolvedValue({ lastReadAt: null }),
       },
       user: {
         findMany: jest.fn().mockImplementation(({ where }) => {
@@ -509,6 +512,53 @@ describe('MessagingService', () => {
       const inbox = await service.getMentionInbox(author, false);
 
       expect(inbox[0].conversation.roNumber).toBeNull();
+    });
+  });
+
+  describe('marking a conversation read', () => {
+    /*
+     * The badge used to lie. Somebody tagged in a repair order would open that
+     * thread, read the message, and still be told they had an unread mention,
+     * because the only thing that cleared one was clicking it in the inbox.
+     */
+    it('clears the mentions in that conversation, not just the read mark', async () => {
+      await service.markConversationRead('conv-1', author.id);
+
+      expect(prisma.messageMention.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId: author.id,
+            readAt: null,
+            message: { conversationId: 'conv-1' },
+          },
+        })
+      );
+    });
+
+    it('moves the read mark forward', async () => {
+      await service.markConversationRead('conv-1', author.id);
+
+      expect(prisma.conversationMember.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { conversationId: 'conv-1', userId: author.id },
+          data: { lastReadAt: expect.any(Date) },
+        })
+      );
+    });
+
+    // Half of this applied would leave the two counts disagreeing.
+    it('does both in one transaction', async () => {
+      await service.markConversationRead('conv-1', author.id);
+
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves other conversations alone', async () => {
+      await service.markConversationRead('conv-1', author.id);
+
+      const where = prisma.messageMention.updateMany.mock.calls.at(-1)[0].where;
+      expect(where.message.conversationId).toBe('conv-1');
+      expect(where.userId).toBe(author.id);
     });
   });
 });

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -403,13 +403,21 @@ describe('MessagingService', () => {
       expect(result.messages).toHaveLength(1);
     });
 
-    it('returns the empty result on timeout', async () => {
+    /*
+     * Returning the pre-wait answer on a timeout handed back counts up to
+     * twenty-five seconds old, which is how a message in shop chat could sit
+     * unannounced on somebody else's screen.
+     */
+    it('re-queries on timeout rather than returning the pre-wait answer', async () => {
       events.waitForMessage.mockResolvedValue(false);
+      (messages.findForConversation as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([messageRow()]);
 
       const result = await service.poll(author, 'conv-1', undefined, 25_000);
 
-      expect(messages.findForConversation).toHaveBeenCalledTimes(1);
-      expect(result.messages).toEqual([]);
+      expect(messages.findForConversation).toHaveBeenCalledTimes(2);
+      expect(result.messages).toHaveLength(1);
     });
   });
 

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -66,6 +66,11 @@ export class MessagingService {
       await this.ensureMembership(conversationId, user.id);
     }
 
+    // Everyone belongs to the shop channel whether or not they have opened it.
+    // Unread counts are drawn from memberships, so without this a message in
+    // shop chat counted for nobody until each person happened to click the tab.
+    await this.ensureGeneralMembership(user.id);
+
     const first = await this.collect(user, conversationId, since);
     if (first.messages.length > 0 || waitMs <= 0) {
       return first;
@@ -80,10 +85,12 @@ export class MessagingService {
       Math.min(waitMs, MAX_HOLD_MS)
     );
 
-    // Re-query either way. The wake-up only says something happened; whether
-    // this user may read it is still the visibility filter's decision, and on
-    // a timeout the counts may have moved for other reasons.
-    return woke ? this.collect(user, conversationId, since) : first;
+    // Re-query either way, waking or timing out. A wake-up only says something
+    // happened — whether this user may read it is still the visibility
+    // filter's decision — and returning the pre-wait answer on a timeout would
+    // hand back counts up to twenty-five seconds old.
+    void woke;
+    return this.collect(user, conversationId, since);
   }
 
   private async collect(
@@ -538,6 +545,16 @@ export class MessagingService {
     });
     if (!found) {
       throw new NotFoundException('Conversation not found');
+    }
+  }
+
+  private async ensureGeneralMembership(userId: string): Promise<void> {
+    const general = await this.prisma.conversation.findFirst({
+      where: { type: 'GENERAL' },
+      select: { id: true },
+    });
+    if (general) {
+      await this.ensureMembership(general.id, userId);
     }
   }
 

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -114,6 +114,33 @@ export class MessagingService {
   async getMentionInbox(user: MessagingUser, unreadOnly: boolean) {
     const rows = await this.messages.findMentionInbox(user.id, unreadOnly);
 
+    // A mention is read away from the thread it was written in, so it has to
+    // carry its own context. The repair order number comes from the
+    // conversation rather than from a reference row on the message: a message
+    // posted inside a repair order is about that repair order by definition,
+    // and storing it twice would leave two things to keep in step.
+    const roIds = [
+      ...new Set(
+        rows
+          .filter(
+            (row) =>
+              row.message.conversation.entityType === 'REPAIR_ORDER' &&
+              row.message.conversation.entityId
+          )
+          .map((row) => row.message.conversation.entityId as string)
+      ),
+    ];
+
+    const repairOrders = roIds.length
+      ? await this.prisma.repairOrder.findMany({
+          where: { id: { in: roIds } },
+          select: { id: true, roNumber: true },
+        })
+      : [];
+    const roNumberById = new Map(
+      repairOrders.map((ro) => [ro.id, ro.roNumber])
+    );
+
     return rows.map((row) => ({
       mentionId: row.id,
       readAt: row.readAt?.toISOString() ?? null,
@@ -122,6 +149,9 @@ export class MessagingService {
         id: row.message.conversation.id,
         entityType: row.message.conversation.entityType,
         entityId: row.message.conversation.entityId,
+        roNumber: row.message.conversation.entityId
+          ? roNumberById.get(row.message.conversation.entityId) ?? null
+          : null,
       },
     }));
   }

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -330,15 +330,31 @@ export class MessagingService {
     });
   }
 
+  /**
+   * Reading a conversation clears its mentions too.
+   *
+   * Without this the badge lied: somebody tagged in a repair order would open
+   * that thread, read the message, and still be told they had an unread
+   * mention — because the only thing that cleared one was clicking it in the
+   * inbox. Being read is being read, wherever it happened.
+   */
   async markConversationRead(
     conversationId: string,
     userId: string
   ): Promise<void> {
     await this.ensureMembership(conversationId, userId);
-    await this.prisma.conversationMember.updateMany({
-      where: { conversationId, userId },
-      data: { lastReadAt: new Date() },
-    });
+    const now = new Date();
+
+    await this.prisma.$transaction([
+      this.prisma.conversationMember.updateMany({
+        where: { conversationId, userId },
+        data: { lastReadAt: now },
+      }),
+      this.prisma.messageMention.updateMany({
+        where: { userId, readAt: null, message: { conversationId } },
+        data: { readAt: now },
+      }),
+    ]);
   }
 
   async markMentionRead(mentionId: string, userId: string): Promise<void> {
@@ -375,7 +391,7 @@ export class MessagingService {
       }));
 
     await this.ensureMembership(conversation.id, userId);
-    return conversation;
+    return this.withReadState(conversation, userId);
   }
 
   /**
@@ -411,7 +427,29 @@ export class MessagingService {
     }
 
     await this.ensureMembership(conversation.id, userId);
-    return conversation;
+    return this.withReadState(conversation, userId);
+  }
+
+  /**
+   * Adds where this reader had got to. Everything after it is drawn as new, and
+   * the mark is taken once when the thread opens rather than followed live —
+   * otherwise the "new" line would erase itself as you looked at it.
+   */
+  private async withReadState<T extends { id: string }>(
+    conversation: T,
+    userId: string
+  ): Promise<T & { lastReadAt: string | null }> {
+    const membership = await this.prisma.conversationMember.findUnique({
+      where: {
+        conversationId_userId: { conversationId: conversation.id, userId },
+      },
+      select: { lastReadAt: true },
+    });
+
+    return {
+      ...conversation,
+      lastReadAt: membership?.lastReadAt?.toISOString() ?? null,
+    };
   }
 
   // ---- Lookups for the composer ----


### PR DESCRIPTION
The interface half of GA-71, plus everything that came out of actually using it. The backend (retention purge, long polling) went in with #120.

Jira: [GA-71](https://gt-automotives.atlassian.net/browse/GA-71) · Epic: [GA-67](https://gt-automotives.atlassian.net/browse/GA-67)

## What this adds

**A floating messages button** on every internal layout, carrying the unread count and opening a panel with the shop channel and everything tagged at you. Notification here is in-app only, so the badge is the entire mechanism — until now the only way to find a mention was to open the repair order it was written on and happen to look.

**Mentions open into their conversation.** A mention alone is one sentence with nothing around it; whether front desk should order the part usually depends on what was said before the tag. Opening one swaps the panel for the whole thread, with the repair order number as the heading and a back arrow to the list.

**Threaded replies.** The reply arrives already aimed at the message that tagged you. That threading is also what keeps it private — a reply inherits the audience of what it answers, so answering without tagging back still reaches only the people who could already see it. The composer is told that audience and names it: a reply box reading "Everyone can see this" while the server kept the message private would be the worst kind of wrong.

**A sound on new messages**, fired on any rise in the unread total. Synthesised rather than loaded, so there is no asset to ship. Mute toggle in the panel header, kept in localStorage — filters are per-tab, but "sound off" means off everywhere.

**Coloured initials avatars**, keyed on the user id so the same person is the same colour everywhere, and two accounts sharing a display name get different colours rather than being mistaken for each other.

**Long polling, browser side.** The hold is the interval: a message arrives when it is written rather than up to ten seconds later, *and* an idle thread costs one request every 25 seconds instead of one every 10. The loop still stops dead while the tab is hidden.

## Bugs found by using it

**The chat tab reopened itself forever.** Opening the thread named `showApiError` in its dependency array; `useErrorHelpers` builds fresh arrow functions every render, so the effect re-ran on every render, set state, re-rendered, and opened the thread again. `MessageThread.spec.tsx` counts calls — **with the dependency restored it fails at six, passes at one**, verified by reverting the fix rather than assumed.

**A shop chat message reached nobody else.** Three things wrong at once: an untagged message woke no waiting poll (the badge polls with no thread open, and the wake only matched an open thread or a tag); the timeout returned the pre-wait answer, so counts were up to 25 seconds stale; and the shop channel counted for nobody who had never opened it, because unread counts come from memberships. All three fixed. Waking is still not reading — the poll re-queries through the visibility filter, so a private message reaches no further than before.

**The count never cleared.** Reading a thread did not clear its mentions, marking happened only on unmount, and the badge and thread are separate components with separate polls. Marking a conversation read now clears its mentions in the same transaction, marking happens while the thread is on screen, and a window event announces a read so every badge refreshes.

**The repair order was never shown on a mention**, and its link went to `/admin/...` from everywhere — a page staff, supervisors and foremen are not allowed to open.

**The unread highlight and click-to-mark-read never applied.** That edit targeted a block prettier had since reformatted, so it silently matched nothing. Caught while rewriting the component; each behaviour verified in the file afterwards rather than trusted from a clean typecheck.

## Smaller changes

- Mention picker shows names only — everyone knows who does what, and the role was a second line of noise
- Own messages sit on the right. Laid out identically either way; pushing the box across is the whole difference
- React Query devtools overlay removed — its button sat where the messages button now lives. The dependency stays in `package.json` deliberately: removing it means regenerating `yarn.lock`, and CI installs with `--frozen-lockfile`
- Tab title is now "GT Automotives", without the tagline

## Verified

- `tsc --noEmit` clean on `server` and `webApp`
- `nx lint server webApp` — 0 errors
- **1,065 tests passing**: 670 server · 221 data · 174 webApp

## Not verified

The reply-inheritance display is asserted only by reading the code — no test proves the composer names the inherited audience instead of saying "Everyone". Given that this feature's whole job is being right about who can read something, that is the assertion worth adding next.

## Note for whoever merges

There are two active accounts both named "Vishal Toora" (`vishal.toora83@` and `vishal.alawalpuria@`). Messaging renders them as two different people with two different avatar colours, which is correct but will read as confusing in shop chat. Worth deciding whether the second account should exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)