### PR TITLE
Messaging: admins stop reading private messages, RO chat redesign, and notifications when you are away

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,254 @@
+---
+name: security-reviewer
+description: Security-only review of a branch before it becomes a pull request. Works the attack surface this application actually has — Clerk auth, the role guards, per-record ownership, the reverse proxy's internal key, generated PDFs and emails, Azure blob SAS URLs, raw SQL, and the messaging visibility ACL. Runs alongside code-reviewer as a pre-PR gate, or on its own when a change touches an endpoint, a guard, a query, or anything that leaves the system.
+tools: Bash, Read, Grep, Glob
+model: opus
+---
+
+# Security Reviewer — pre-PR gate
+
+You look for ways this branch lets somebody see, change or send something they
+should not. Nothing else. `code-reviewer` covers correctness, cleanliness and
+the mechanical gates; duplicating it wastes the pass.
+
+**You are read-only.** No Write, no Edit. Findings go to the author.
+
+---
+
+## 0. Ground rules
+
+1. **An attack, or it is not a finding.** Name the actor, what they send, and
+   what they get back. "This could be unsafe" is not a finding. If you cannot
+   write the request that exploits it, drop it or downgrade it.
+2. **The actor is usually an insider.** This system has no public write surface
+   worth attacking. The realistic threats are a STAFF account reading payroll,
+   one employee reading another's pay stub, a customer reaching another
+   customer's invoice, and a private message reaching somebody it was not for.
+   Weight the review accordingly.
+3. **Review the committed tree** (`git diff origin/main...HEAD`), not the
+   working tree.
+4. **Zero findings is a real outcome.** Say so plainly. A gate that always finds
+   something gets waved through, and then it protects nothing.
+5. **Read the guard, do not trust the decorator.** `@Roles('ADMIN')` on a
+   controller says nothing about what the service does when another caller
+   reaches the same method.
+
+---
+
+## 1. Establish scope
+
+```bash
+git fetch origin --quiet
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD                       # read it
+git diff origin/main...HEAD --name-only | grep -E 'controller|guard|service|repository|\.sql$|workflow'
+```
+
+Then decide which of §3–§9 the diff can actually reach. A branch that only
+touches a React component does not need the SQL pass; say which passes you
+skipped and why.
+
+---
+
+## 2. How a request is authorised here
+
+Know the chain before judging any link in it.
+
+```
+Browser
+  → https://gt-automotives.com/api/*          (Azure Web App, frontend)
+  → reverse proxy generated in .github/workflows/gt-build.yml
+      adds X-Internal-API-Key and X-Proxy-Signature
+  → backend Web App (also reachable directly at *.azurewebsites.net)
+      InternalApiGuard   — is this call from the proxy?
+      JwtAuthGuard       — Clerk token → server/src/auth/strategies/clerk-jwt.strategy.ts
+      RoleGuard          — @Roles(...) against the user's role name
+      the service        — per-record ownership, if anyone wrote it
+```
+
+Two things follow, and both have bitten this repo:
+
+- **The backend is reachable without the proxy.** Anything that treats a header
+  as proof of anything is trusting a value the caller controls. The internal key
+  is a shared secret, not an identity.
+- **The role guard is the coarsest check in the chain.** Every id-taking
+  endpoint needs an ownership check after it. See §4.
+
+Roles, narrowest first: `CUSTOMER`, `STAFF`, `SUPERVISOR`, `FOREMAN`,
+`ACCOUNTANT`, `ADMIN`. Seniority is not entitlement — Supervisor and Foreman are
+deliberately _not_ payroll roles.
+
+---
+
+## 3. Authorization
+
+For every new or changed controller method:
+
+- `@Roles(...)` present, and the **narrowest correct set**. No decorator means
+  every authenticated internal user reaches it — state which roles that is.
+- A guard added to the controller but not the service leaves every other caller
+  of that service method unguarded. Check the service.
+- A read-only feature must not hand over a write path. If a role gained a view
+  this branch, confirm it did not also inherit approve / process / delete.
+- **Payroll and pay data are the crown jewels.** Any widening of who reaches
+  `pay-stubs`, `payments`, `time-clock` totals or `reports` is a finding until
+  the branch shows it was asked for.
+
+---
+
+## 4. IDOR and ownership
+
+The question, asked literally, for every endpoint taking an id:
+
+> Can user A fetch, change or delete user B's record by changing the id?
+
+- **Customers see ONLY their own data.** Absolute rule in this project.
+- An employee sees only their own pay stubs, hours and payments.
+- A `findFirst`/`findUnique` by id alone, with the caller never compared to the
+  row, is the shape to grep for:
+
+```bash
+git diff origin/main...HEAD | grep -nE 'find(First|Unique)\(|findById|where: \{ id'
+```
+
+- Ownership belongs in the **service or repository**, not the component. A
+  filter applied in React means the data already reached the browser.
+- **Messaging has a per-message ACL**, which is stricter than anything else
+  here: `MessageRepository.visibilityFilter()` is the only place the rule is
+  written, and every read must compose it. A read path that does not is a
+  Blocker. There is no role bypass — admins included (D4, Aug 2026).
+
+---
+
+## 5. Injection
+
+- Raw SQL exists in `customer.repository.ts`, `invoice.repository.ts`,
+  `payments.service.ts`, `tire.repository.ts`. New raw SQL must use `$queryRaw`
+  **tagged templates**. `$queryRawUnsafe` with interpolation is a **Blocker**.
+
+```bash
+git diff origin/main...HEAD | grep -nE '\$queryRawUnsafe|\$executeRawUnsafe'
+```
+
+- A Prisma `where` assembled from unvalidated input, especially anything that
+  lets the caller choose a column or an operator.
+- `orderBy` or `select` taken from a query string.
+- Any child process or file path built from request data.
+
+---
+
+## 6. What leaves the system
+
+Everything below crosses a boundary, and once it has crossed there is no
+recalling it.
+
+- **Generated documents.** Invoice, quotation, inspection and pay stub HTML is
+  string-concatenated and rendered by Puppeteer. Every interpolated value that
+  can hold customer or user text goes through the template's `escapeHtml`. A
+  customer named with markup otherwise lands in a PDF and in an email.
+- **Emails.** Same escaping rule, plus: check the recipient list is derived
+  server-side. An emailed document is the fastest way to send the wrong person
+  the right data.
+- **SMS.** Telnyx is scoped to customer appointment confirmations and reminders.
+  A new message type, or customer data in an existing one, needs saying out
+  loud. No pay figures, no invoice totals.
+- **Azure Blob.** The storage account **forbids public blob access**. Anything
+  stored there is served through `generateSasUrl()`, never a raw blob URL, and a
+  SAS URL is a bearer credential — flag any path that logs one, emails one, or
+  puts one where it can be bookmarked. Prefer a short expiry.
+- **Notifications and toasts.** A browser notification is read by whoever walks
+  past the screen. Message bodies, customer names and pay figures do not belong
+  in one.
+- **Responses carrying pay or financial data** should not be cacheable —
+  `Cache-Control: private, no-store`.
+
+---
+
+## 7. Mass assignment and derived values
+
+`data: { ...dto }` spread into a Prisma `create`/`update` lets the caller set
+any column the DTO happens to carry.
+
+Totals, statuses, ids, role assignments, `visibility`, audit columns and
+timestamps are **computed server-side**. A client-supplied total is a finding
+even when the current UI never sends one.
+
+```bash
+git diff origin/main...HEAD | grep -nE 'data: \{ \.\.\.|Object\.assign\('
+```
+
+---
+
+## 8. Secrets, logging and dependencies
+
+- No credentials, connection strings, API keys or tokens in source, tests,
+  fixtures, committed config or workflow files. **Blocker.** A hardcoded
+  _fallback_ for a secret is still a committed secret.
+
+```bash
+git diff origin/main...HEAD | grep -inE 'password|secret|api[_-]?key|token|BEGIN (RSA|PRIVATE)'
+git diff origin/main...HEAD --name-only | grep -E '\.env(\.|$)|\.pem$|\.key$'
+```
+
+- **Nothing sensitive in logs.** This repo shipped a JWT payload dump on every
+  authenticated request (GA-68) that made the log stream useless and would have
+  written ~1.3 GB/month of token contents to disk. No tokens, no PII, no pay
+  figures, no full request bodies.
+- New runtime dependencies: name them, and say what they pull in. A dependency
+  is a supply chain, and this application handles pay data.
+- `yarn.lock` changed without a `package.json` change deserves a look.
+
+---
+
+## 9. Availability
+
+Cheap to overlook, and this backend is a single **B1** instance.
+
+- An endpoint that holds a connection open (messaging's long poll holds 25s)
+  must stay under the reverse proxy's 30s timeout and must not multiply per
+  browser tab without bound.
+- An unbounded `findMany` with no `take`, on a table that grows.
+- A query inside a loop — `unreadCountsByConversation` runs one count per
+  membership per poll, and that is the shape to catch before it ships.
+- Anything a caller can ask to be expensive: a report with an unbounded date
+  range, a PDF batch with no cap.
+
+---
+
+## 10. Severity
+
+| Severity    | Meaning                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| **Blocker** | Data reaches someone it must not, or the branch commits a secret. Do not open the PR.       |
+| **High**    | Exploitable by an authenticated insider with a plausible motive, or a real escalation path. |
+| **Medium**  | Needs an unlikely precondition, or narrows to information disclosure with limited value.    |
+| **Low**     | Defence in depth. Worth doing, not worth blocking.                                          |
+
+---
+
+## 11. Output
+
+```markdown
+## Security review — <branch>
+
+**Scope:** <what the diff touches> · **Passes run:** <§ numbers> · **Skipped:** <§ and why>
+
+**Verdict:** Clear | N findings (highest: <severity>)
+
+### Findings
+
+#### 1. [Severity] <what an attacker gets, in one line>
+
+`path/to/file.ts:LINE`
+
+**Attack:** <who they are, what they send, what comes back>
+**Why it works:** <the missing check, and where it belongs>
+**Fix:** <the smallest change that closes it>
+```
+
+Rank by severity. If a pass found nothing, say which — a reviewer needs to know
+what was looked at, not only what was found.
+
+End with **what you could not verify**: anything needing a running system, real
+credentials, or a browser. Be honest about it rather than implying coverage you
+do not have.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -2,13 +2,20 @@
 
 ## Overview
 
-Commands to invoke the [Code Reviewer agent](../agents/code-reviewer.md) — the
-pre-PR gate for GT Automotives. It runs the mechanical checks, then reviews the
-branch diff for correctness, security, project invariants, clean code and test
-coverage.
+Commands to invoke the pre-PR gate for GT Automotives. Two agents, run together:
 
-The agent is **read-only** (no Write/Edit tools). It reports; you decide what to
+| Agent                                               | Covers                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [Code Reviewer](../agents/code-reviewer.md)         | Mechanical gates, correctness, project invariants, clean code, test coverage                                             |
+| [Security Reviewer](../agents/security-reviewer.md) | Authorization, IDOR and ownership, injection, what leaves the system, mass assignment, secrets and logging, availability |
+
+Both are **read-only** (no Write/Edit tools). They report; you decide what to
 change.
+
+Why two rather than one longer checklist: a security pass done at the end of a
+correctness review gets the tired half of the attention, and the two ask
+different questions of the same diff. Run in parallel they also finish in about
+the time one used to take.
 
 ---
 
@@ -19,20 +26,30 @@ change.
 **Purpose**: Full pre-PR review of the current branch
 **Usage**: `/review`
 
-**What it does**:
+**What it does**: launches **both agents in parallel** on the same branch diff.
+
+`code-reviewer`:
 
 1. Establishes scope from `git diff origin/main...HEAD` and confirms the branch
    was cut from `main`
 2. Runs the mechanical gates — clean working tree, **committed tree typechecks**
    (in a throwaway worktree, so your working tree is untouched), lint, tests,
    build, migration integrity, no stray artifacts or secrets
-3. Reviews the diff across five dimensions: correctness, security, project
-   invariants, clean code, tests
+3. Reviews the diff for correctness, project invariants, clean code and tests
 4. Verifies each candidate finding before reporting it, and drops the ones it
    cannot make fail
-5. Returns a pass/fail gate summary, a verdict, and findings ranked by severity
 
-**Run it before every `gh pr create`.**
+`security-reviewer`:
+
+1. Works the attack surface this application has — the Clerk → `JwtAuthGuard` →
+   `RoleGuard` → ownership chain, per-record IDOR, raw SQL, generated PDFs and
+   emails, SAS URLs, mass assignment, secrets and logging, availability
+2. Reports only findings it can write the attack for
+
+Both return a verdict and findings ranked by severity.
+
+**Run it before every `gh pr create`.** A Blocker from either agent means the
+PR does not open yet.
 
 **Example output**:
 
@@ -67,12 +84,11 @@ reads it. @Roles('STAFF') gates the route but not the row.
 **Purpose**: Security-only pass — faster, for a branch whose logic is already reviewed
 **Usage**: `/review security`
 
-**What it does**: Runs §3 (authorization, IDOR/ownership, injection, XSS in
-generated documents, mass assignment, secrets and data exposure) plus the
-secrets and artifact gate. Skips clean-code and test-coverage review.
+**What it does**: runs [security-reviewer](../agents/security-reviewer.md) alone.
 
 Use when you have already had a full review and then changed only an endpoint,
-a guard or a query.
+a guard, a query, or anything that leaves the system — a template, an email, an
+SMS, a notification, a blob URL.
 
 ---
 
@@ -117,6 +133,9 @@ exactly what will land on the PR — and your working tree is never touched.
 | Secrets, stray artifacts | —                          | —           | ✅                    |
 | Clean code, duplication  | —                          | —           | ✅                    |
 | Commit message accuracy  | —                          | —           | ✅                    |
+| Ownership / IDOR per row | —                          | —           | ✅ security-reviewer  |
+| What leaves the system   | —                          | —           | ✅ security-reviewer  |
+| Availability under load  | —                          | —           | ✅ security-reviewer  |
 
 CI tells you the branch compiles. `/review` tells you it is safe and clean.
 

--- a/.claude/docs/messaging-integration-plan.md
+++ b/.claude/docs/messaging-integration-plan.md
@@ -128,8 +128,11 @@ stream useless for debugging.
 
 ### 4.4 Polling discipline
 
-1. **Pause on `document.hidden`** (Page Visibility API) — tabs left open overnight are what
-   turn 54k requests into 130k. Cuts 60–80%.
+1. **Back off on `document.hidden`** (Page Visibility API) — tabs left open overnight are
+   what turn 54k requests into 130k. A hidden tab drops to one plain request a minute
+   (§10.1) instead of holding a connection open. It originally stopped polling altogether,
+   which cut more but left nothing able to notice a message had arrived while somebody was
+   in another tab — the one moment being told is worth anything.
 2. **Idle backoff** — 10s while the thread is active, 60s after 2 minutes of silence.
 3. **Skip the poll route** in the proxy's request logger.
 4. Optional: 60s in-memory `clerkId → user` cache in the Clerk strategy.
@@ -783,7 +786,7 @@ Neither is caused by this epic; both are worth their own tickets.
 | Reply to a private message leaks it                                   | Privacy inheritance (§6.2)                                                                                                                                                                                                                          |
 | Private message leaks via API payload                                 | Filter in the repository; assert on network response in tests                                                                                                                                                                                       |
 | Log flood degrades B1                                                 | Phase 0, before any polling ships                                                                                                                                                                                                                   |
-| Idle tabs polling overnight                                           | Page Visibility pause + idle backoff (§4.4)                                                                                                                                                                                                         |
+| Idle tabs polling overnight                                           | Page Visibility backoff to one request a minute (§4.4, §10.1)                                                                                                                                                                                       |
 | Timezone bug in timestamps                                            | Real instants only; never business-calendar helpers (§6.6)                                                                                                                                                                                          |
 | Client-forged mentions or visibility                                  | Server re-derives everything from the body                                                                                                                                                                                                          |
 | Accidental RO close destroys the thread                               | 30-day delay before purge (§12.1); `reopen()` removes it from the purge set entirely                                                                                                                                                                |

--- a/.claude/docs/messaging-integration-plan.md
+++ b/.claude/docs/messaging-integration-plan.md
@@ -530,21 +530,58 @@ composer visibility strip, polling discipline (§4.4), long-polling swap, and th
 retention purge job (§12). **This phase completes notifications** — there is no separate
 notification phase.
 
-### Notifications — in-app only, no separate phase ⛔
+### Notifications — no SMS, no email, no separate phase ⛔
 
-Messaging sends **no SMS, no email, and no browser push.** It does not import `SmsModule` or
-`EmailService`, and adds no `SmsType` enum value. Telnyx stays scoped to customer appointment
-confirmations and reminders as documented in the
-[SMS Integration Plan](./sms-integration-plan.md).
+Messaging sends **no SMS and no email.** It does not import `SmsModule` or `EmailService`,
+and adds no `SmsType` enum value. Telnyx stays scoped to customer appointment confirmations
+and reminders as documented in the [SMS Integration Plan](./sms-integration-plan.md).
 
-Everything a user needs to notice is delivered by the poll in §8.1:
+Everything is carried by the poll in §8.1, on four surfaces:
 
-- **Unread badge** on the Messages sidebar entry (count of unread mentions)
-- **Per-conversation unread dots** in the conversation list and on the RO detail tab
+- **Unread badge** on the floating messages button — mentions _and_ unread messages, the
+  same total the sound listens to
+- **A two-note ping** on any rise in that total, muted from the panel header, remembered in
+  localStorage
+- **The browser tab title** — `(3) GT Automotives`, which costs nobody a permission prompt
+- **A desktop notification** while the tab is in the background (§10.1)
 - **My Mentions inbox** as the catch-up surface
 
-This is genuinely sufficient for a shop floor where staff keep the app open all day, and it
-costs nothing beyond the poll that's already running. See §13 for the one tradeoff it carries.
+**Web Push is still out** — see §10.1 for the line between the two.
+
+### 10.1 Desktop notifications — added Aug 21, 2026
+
+Shipped in-app-only first, and the gap showed up within a day of real use: the badge and the
+ping only reach somebody with the app in front of them, and the tagged work that goes unseen
+is the work tagged while they were in another tab.
+
+The **Notification API** closes that without a service worker, a vendor, or a monthly cost.
+It is not Web Push, and the difference is what each one reaches:
+
+|                                | Reaches                                                     | Needs                                                |
+| ------------------------------ | ----------------------------------------------------------- | ---------------------------------------------------- |
+| **Notification API** (shipped) | any tab, background or minimised, while the browser is open | a permission click                                   |
+| **Web Push** (still GA-72)     | the browser closed entirely                                 | service worker + VAPID; iOS only as an installed PWA |
+
+Three rules the implementation holds to, all covered by
+`useBrowserNotifications.spec.ts`:
+
+1. **Nothing about the message is in the toast** — no author, no body, no RO number. A
+   private message exists so only the people in it can read it, and a notification on a shop
+   counter screen is read by whoever walks past. It says how much arrived; the rest stays
+   behind the login.
+2. **Only while the tab is hidden.** With the page in front of them the badge already moved
+   and the ping already sounded.
+3. **Only on a rise, never on the first reading**, or opening the app would announce
+   everything that arrived while it was shut. All notifications share one `tag`, so stepping
+   away for an hour leaves one notification that updated rather than a stack.
+
+The permission prompt is wired to a bell in the panel header, never to page load — browsers
+refuse an ungestured prompt, and the ones that allow it penalise the site.
+
+**This changed the polling contract.** A backgrounded tab used to stop polling entirely,
+which would have made all of the above dead on arrival. It now drops to one plain request a
+minute (`BACKGROUND_GAP_MS`) instead of holding a connection open — roughly 15 requests a
+minute across the shop, against the 1.5 req/s budget in §4.2.
 
 ### Phase 3 — Optional — [GA-72](https://gt-automotives.atlassian.net/browse/GA-72)
 
@@ -740,19 +777,19 @@ Neither is caused by this epic; both are worth their own tickets.
 
 ## 13. Risks
 
-| Risk                                                                  | Mitigation                                                                                                                                                                               |
-| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Tagged work goes unseen when that person is off or not in the app** | Accepted tradeoff of in-app-only notification. Mitigations: My Mentions inbox, tag a second person for time-critical work. If this bites in practice, revisit Web Push — free, no vendor |
-| Reply to a private message leaks it                                   | Privacy inheritance (§6.2)                                                                                                                                                               |
-| Private message leaks via API payload                                 | Filter in the repository; assert on network response in tests                                                                                                                            |
-| Log flood degrades B1                                                 | Phase 0, before any polling ships                                                                                                                                                        |
-| Idle tabs polling overnight                                           | Page Visibility pause + idle backoff (§4.4)                                                                                                                                              |
-| Timezone bug in timestamps                                            | Real instants only; never business-calendar helpers (§6.6)                                                                                                                               |
-| Client-forged mentions or visibility                                  | Server re-derives everything from the body                                                                                                                                               |
-| Accidental RO close destroys the thread                               | 30-day delay before purge (§12.1); `reopen()` removes it from the purge set entirely                                                                                                     |
-| Purge deletes more than intended                                      | Scoped to `entityType: REPAIR_ORDER`; explicit tests that general chat and RO/invoice rows survive                                                                                       |
-| Schema drift                                                          | `migration-create.sh`, never `db push`                                                                                                                                                   |
-| Staff privacy expectations                                            | D4: no role bypass at all, so the composer's "Only Sarah will see this" is literally true                                                                                                |
+| Risk                                                                  | Mitigation                                                                                                                                                                                                                                          |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tagged work goes unseen when that person is off or not in the app** | Largely closed by desktop notifications (§10.1), which reach any background tab while the browser is open. Remaining gap is a closed browser — mitigations: My Mentions inbox, tag a second person for time-critical work, and Web Push if it bites |
+| Reply to a private message leaks it                                   | Privacy inheritance (§6.2)                                                                                                                                                                                                                          |
+| Private message leaks via API payload                                 | Filter in the repository; assert on network response in tests                                                                                                                                                                                       |
+| Log flood degrades B1                                                 | Phase 0, before any polling ships                                                                                                                                                                                                                   |
+| Idle tabs polling overnight                                           | Page Visibility pause + idle backoff (§4.4)                                                                                                                                                                                                         |
+| Timezone bug in timestamps                                            | Real instants only; never business-calendar helpers (§6.6)                                                                                                                                                                                          |
+| Client-forged mentions or visibility                                  | Server re-derives everything from the body                                                                                                                                                                                                          |
+| Accidental RO close destroys the thread                               | 30-day delay before purge (§12.1); `reopen()` removes it from the purge set entirely                                                                                                                                                                |
+| Purge deletes more than intended                                      | Scoped to `entityType: REPAIR_ORDER`; explicit tests that general chat and RO/invoice rows survive                                                                                                                                                  |
+| Schema drift                                                          | `migration-create.sh`, never `db push`                                                                                                                                                                                                              |
+| Staff privacy expectations                                            | D4: no role bypass at all, so the composer's "Only Sarah will see this" is literally true                                                                                                                                                           |
 
 ---
 

--- a/.claude/docs/messaging-integration-plan.md
+++ b/.claude/docs/messaging-integration-plan.md
@@ -23,7 +23,7 @@
 | D1  | **@mention = private.** Tagging someone makes the message visible to them only. No tag = visible to everyone.                               | ✅ Confirmed                |
 | D2  | Messages **never appear on printed/PDF repair orders**. Internal communication only.                                                        | ✅ Confirmed                |
 | D3  | Chat lives **inside each RO** (auto-linked, clickable) **and** in a **general chat** outside ROs. Both support public and private messages. | ✅ Confirmed                |
-| D4  | Admin can read all messages, with a visible notice on private ones.                                                                         | ⚠️ Assumed — flag to change |
+| D4  | **Nobody reads past the rule, admins included.** An admin sees a private message only by being tagged in it or writing it.                  | ✅ Confirmed Aug 21, 2026   |
 | D5  | Internal users only (STAFF, SUPERVISOR, FOREMAN, ACCOUNTANT, ADMIN). Customers excluded — no `clerkId`, no login.                           | ⚠️ Assumed — flag to change |
 | D6  | **No retention after an RO closes.** Purged 30 days after close (§12).                                                                      | ✅ Confirmed                |
 
@@ -305,8 +305,8 @@ CSS-hiding anywhere.
 
 ```ts
 // server/src/messaging/repositories/message.repository.ts
-private visibilityFilter(user: AuthUser): Prisma.MessageWhereInput {
-  if (user.role.name === 'ADMIN') return {};        // D4: admin sees all
+visibilityFilter(user: MessagingUser): Prisma.MessageWhereInput {
+  // No role bypass — D4. An admin reads a private message only by being in it.
   return {
     OR: [
       { visibility: 'PUBLIC' },
@@ -328,7 +328,6 @@ that":
 │ @Sarah please order 4 Michelins for this RO    │
 │                                                │
 │ 🔒 Only Sarah Chen will see this               │
-│ ℹ️  Admins can also view this message           │
 │                                    [ Send ]    │
 └────────────────────────────────────────────────┘
 ```
@@ -564,7 +563,7 @@ DMs, photo attachments (reusing the `ROMedia` blob + SAS-URL pattern), appointme
 | Message with `@Sarah`, Mike                           | **hidden**                                          |
 | Message with `@Sarah`, author                         | visible                                             |
 | Message with `@Sarah @Mike`, either                   | visible; third party hidden                         |
-| Private message, admin                                | visible (per D4)                                    |
+| Private message, admin not tagged                     | **hidden** (per D4)                                 |
 | Untagged **reply** to a private message               | inherits `MENTIONED_ONLY` (§6.2)                    |
 | Forged mention token in body                          | server re-derives; grants nothing                   |
 | Client sends `visibility: PUBLIC` on a tagged message | ignored; derived server-side                        |
@@ -661,6 +660,29 @@ and it's a reasonable one; noting it so it isn't a surprise later.
 The plan below is what was designed. These are the places the build departed
 from it, and why.
 
+### D4 reversed: admins do not read private messages either
+
+Shipped with the assumed rule — admin sees everything — and it was rejected on
+first use in production (Aug 21, 2026): a locked message showed up in shop chat
+for an admin who was not tagged in it.
+
+The bypass is gone. `visibilityFilter()` now returns the same clause for every
+role, so the audience of a private message is exactly the people in it. The
+composer's "Admins can also view this message" line went with it, because it
+no longer described anything true.
+
+Two consequences worth knowing:
+
+- **Deleting is bounded by reading.** `deleteMessage` still lets an admin
+  remove somebody else's message, but it loads that message through
+  `findByIdForUser` — so a private message they are not part of 404s rather
+  than being deletable.
+- **The long-poll wake was narrowed to match.** Having a thread open used to be
+  enough to be woken by any message landing in it, private ones included. The
+  poll returned nothing, so no content leaked, but the early return still
+  announced that _something_ had been said. `waitForMessage` now wakes only on
+  messages the reader can actually see, and no longer takes a conversation id.
+
 ### The token format lives in `libs/data`, not the server
 
 Originally the parser sat in `server/src/messaging/mention-parser.ts`. It moved
@@ -718,25 +740,25 @@ Neither is caused by this epic; both are worth their own tickets.
 
 ## 13. Risks
 
-| Risk                                                                  | Mitigation                                                                                                                                                                                               |
-| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Tagged work goes unseen when that person is off or not in the app** | Accepted tradeoff of in-app-only notification. Mitigations: My Mentions inbox, admin sees all, tag a second person for time-critical work. If this bites in practice, revisit Web Push — free, no vendor |
-| Reply to a private message leaks it                                   | Privacy inheritance (§6.2)                                                                                                                                                                               |
-| Private message leaks via API payload                                 | Filter in the repository; assert on network response in tests                                                                                                                                            |
-| Log flood degrades B1                                                 | Phase 0, before any polling ships                                                                                                                                                                        |
-| Idle tabs polling overnight                                           | Page Visibility pause + idle backoff (§4.4)                                                                                                                                                              |
-| Timezone bug in timestamps                                            | Real instants only; never business-calendar helpers (§6.6)                                                                                                                                               |
-| Client-forged mentions or visibility                                  | Server re-derives everything from the body                                                                                                                                                               |
-| Accidental RO close destroys the thread                               | 30-day delay before purge (§12.1); `reopen()` removes it from the purge set entirely                                                                                                                     |
-| Purge deletes more than intended                                      | Scoped to `entityType: REPAIR_ORDER`; explicit tests that general chat and RO/invoice rows survive                                                                                                       |
-| Schema drift                                                          | `migration-create.sh`, never `db push`                                                                                                                                                                   |
-| Staff privacy expectations                                            | D4 disclosure notice in the composer                                                                                                                                                                     |
+| Risk                                                                  | Mitigation                                                                                                                                                                               |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tagged work goes unseen when that person is off or not in the app** | Accepted tradeoff of in-app-only notification. Mitigations: My Mentions inbox, tag a second person for time-critical work. If this bites in practice, revisit Web Push — free, no vendor |
+| Reply to a private message leaks it                                   | Privacy inheritance (§6.2)                                                                                                                                                               |
+| Private message leaks via API payload                                 | Filter in the repository; assert on network response in tests                                                                                                                            |
+| Log flood degrades B1                                                 | Phase 0, before any polling ships                                                                                                                                                        |
+| Idle tabs polling overnight                                           | Page Visibility pause + idle backoff (§4.4)                                                                                                                                              |
+| Timezone bug in timestamps                                            | Real instants only; never business-calendar helpers (§6.6)                                                                                                                               |
+| Client-forged mentions or visibility                                  | Server re-derives everything from the body                                                                                                                                               |
+| Accidental RO close destroys the thread                               | 30-day delay before purge (§12.1); `reopen()` removes it from the purge set entirely                                                                                                     |
+| Purge deletes more than intended                                      | Scoped to `entityType: REPAIR_ORDER`; explicit tests that general chat and RO/invoice rows survive                                                                                       |
+| Schema drift                                                          | `migration-create.sh`, never `db push`                                                                                                                                                   |
+| Staff privacy expectations                                            | D4: no role bypass at all, so the composer's "Only Sarah will see this" is literally true                                                                                                |
 
 ---
 
 ## 14. Remaining Questions
 
-1. **D4** — admin reads all with disclosure? (assumed yes)
+1. ~~**D4** — admin reads all with disclosure?~~ **Answered Aug 21, 2026: no.** Admins are held to the same rule as everyone else; the bypass and the composer's admin notice were both removed.
 2. **D5** — internal users only? (assumed yes)
 3. **Closed ROs** — does the thread go read-only at close, or stay writable until purge? (assumed read-only)
 4. **General chat retention** — indefinite, or cap it too? (assumed indefinite)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,8 @@ git push origin main
 
 ## 🤖 Specialized Agents & Workflows
 
-- **Code Reviewer** (`.claude/agents/code-reviewer.md`) - **CRITICAL**: Pre-PR gate. Run `/review` before every `gh pr create` — mechanical gates (incl. typechecking the _committed_ tree), security, project invariants, clean code ⭐ NEW
+- **Code Reviewer** (`.claude/agents/code-reviewer.md`) - **CRITICAL**: Pre-PR gate. Run `/review` before every `gh pr create` — mechanical gates (incl. typechecking the _committed_ tree), correctness, project invariants, clean code ⭐ NEW
+- **Security Reviewer** (`.claude/agents/security-reviewer.md`) - **CRITICAL**: Runs alongside the code reviewer on `/review`, and alone on `/review security` — authorization, IDOR/ownership, injection, what leaves the system (PDFs, emails, SMS, SAS URLs, notifications), mass assignment, secrets and logging, availability ⭐ NEW
 - **Migration Manager** (`.claude/agents/migration-manager.md`) - **CRITICAL**: Enforces proper database migration workflows
 - **Migration Enforcement** (`.claude/workflows/migration-enforcement.md`) - Automated migration validation and CI/CD integration
 - **SMS Feature Manager** (`.claude/agents/sms-feature-manager.md`) - Complete SMS/text messaging management and troubleshooting ⭐ NEW
@@ -155,7 +156,8 @@ git push origin main
 - **Enhanced Git Workflows** (`.claude/scripts/git-workflows-enhanced.sh`) - Build-validated git operations
 - **Integration Workflows** (`.claude/workflows/dto-git-integration.md`) - Combined DTO + Git workflows
 - **Commands**:
-  - `/review` | `/review security` | `/review gates` - Pre-PR code review (run before opening any PR) ⭐ NEW
+  - `/review` - Pre-PR review: code-reviewer + security-reviewer in parallel (run before opening any PR) ⭐ NEW
+  - `/review security` - Security-only pass | `/review gates` - Mechanical gates only
   - `/dto create|update|validate|fix-imports` - DTO management commands
   - `/migration check|create|deploy|status|validate` - Migration management commands
   - `/sms test|history|preferences|troubleshoot` - SMS feature management ⭐ NEW

--- a/apps/webApp/src/app/components/messaging/MessageComposer.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageComposer.tsx
@@ -16,7 +16,6 @@ import {
 import SendIcon from '@mui/icons-material/Send';
 import LockIcon from '@mui/icons-material/Lock';
 import GroupIcon from '@mui/icons-material/Group';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   buildMentionToken,
   buildReferenceToken,
@@ -335,19 +334,6 @@ export function MessageComposer({
           </>
         )}
       </Box>
-
-      {isPrivate && (
-        <Box
-          sx={{ mt: 0.25, display: 'flex', alignItems: 'center', gap: 0.75 }}
-        >
-          <InfoOutlinedIcon
-            sx={{ fontSize: 14, color: colors.text.secondary }}
-          />
-          <Typography variant="caption" sx={{ color: colors.text.secondary }}>
-            Admins can also view this message
-          </Typography>
-        </Box>
-      )}
     </Box>
   );
 }

--- a/apps/webApp/src/app/components/messaging/MessageComposer.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageComposer.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
-  Chip,
   CircularProgress,
   ClickAwayListener,
   IconButton,
@@ -56,6 +55,17 @@ interface Props {
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Enter sends on a real keyboard only.
+ *
+ * On a phone the same key is Return: taking it to mean "send" makes a second
+ * line impossible and fires half-written messages at the shop. Checked at
+ * press time rather than at mount so a tablet that gains a keyboard is right.
+ */
+const sendsOnEnter = () =>
+  typeof window.matchMedia !== 'function' ||
+  window.matchMedia('(pointer: fine)').matches;
 
 /**
  * Turns what is on screen into what gets sent.
@@ -227,10 +237,14 @@ export function MessageComposer({
   };
 
   const open = Boolean(trigger) && (suggestions.length > 0 || searching);
+  const canSend = Boolean(body.trim()) && !sending && !disabled;
 
   return (
     <Box>
-      <Box ref={anchorRef}>
+      <Box
+        ref={anchorRef}
+        sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}
+      >
         <TextField
           inputRef={inputRef}
           fullWidth
@@ -240,33 +254,54 @@ export function MessageComposer({
           value={text}
           disabled={disabled || sending}
           autoFocus={autoFocus}
-          placeholder={placeholder ?? 'Write a message. Type @ to tag someone.'}
+          placeholder={placeholder ?? 'Write a message…  @ to tag someone'}
           onChange={(e) =>
             handleChange(e.target.value, e.target.selectionStart ?? 0)
           }
           onKeyDown={(e) => {
             if (e.key === 'Escape') setTrigger(null);
             // Enter sends; Shift+Enter is a newline. Never send while the
-            // suggestion list is open — Enter belongs to the list then.
-            if (e.key === 'Enter' && !e.shiftKey && !open) {
+            // suggestion list is open — Enter belongs to the list then. And
+            // never on a touch keyboard, where Return is how you write a
+            // second line and the only send anyone looks for is the button.
+            if (e.key === 'Enter' && !e.shiftKey && !open && sendsOnEnter()) {
               e.preventDefault();
               void handleSend();
             }
           }}
-          InputProps={{
-            endAdornment: (
-              <IconButton
-                size="small"
-                color="primary"
-                disabled={!body.trim() || sending || disabled}
-                onClick={() => void handleSend()}
-                aria-label="Send message"
-              >
-                {sending ? <CircularProgress size={18} /> : <SendIcon />}
-              </IconButton>
-            ),
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: 3,
+              bgcolor: colors.neutral[50],
+              py: 0.75,
+            },
           }}
         />
+        <IconButton
+          color="primary"
+          disabled={!canSend}
+          onClick={() => void handleSend()}
+          aria-label="Send message"
+          sx={{
+            mb: 0.25,
+            width: 40,
+            height: 40,
+            flexShrink: 0,
+            color: colors.primary.contrast,
+            bgcolor: canSend ? colors.primary.main : colors.neutral[300],
+            '&:hover': { bgcolor: colors.primary.dark },
+            '&.Mui-disabled': {
+              bgcolor: colors.neutral[200],
+              color: colors.text.disabled,
+            },
+          }}
+        >
+          {sending ? (
+            <CircularProgress size={18} sx={{ color: 'inherit' }} />
+          ) : (
+            <SendIcon sx={{ fontSize: 20 }} />
+          )}
+        </IconButton>
       </Box>
 
       <Popper
@@ -308,28 +343,47 @@ export function MessageComposer({
       <Box
         sx={{
           mt: 0.75,
+          px: 0.75,
           display: 'flex',
           alignItems: 'center',
-          gap: 1,
-          flexWrap: 'wrap',
+          gap: 0.75,
+          minWidth: 0,
         }}
       >
         {isPrivate ? (
           <>
-            <LockIcon sx={{ fontSize: 16, color: colors.semantic.warning }} />
-            <Typography variant="caption" sx={{ color: colors.text.secondary }}>
-              Only {mentionedNames.join(' and ') || 'the people tagged'} will
-              see this
+            <LockIcon
+              sx={{
+                fontSize: 14,
+                flexShrink: 0,
+                color: colors.semantic.warning,
+              }}
+            />
+            <Typography
+              variant="caption"
+              noWrap
+              sx={{
+                minWidth: 0,
+                fontWeight: 600,
+                color: colors.semantic.warning,
+              }}
+            >
+              Private — only{' '}
+              {mentionedNames.join(' and ') || 'the people tagged'} will see
+              this
             </Typography>
-            {mentionedNames.map((name) => (
-              <Chip key={name} label={name} size="small" variant="outlined" />
-            ))}
           </>
         ) : (
           <>
-            <GroupIcon sx={{ fontSize: 16, color: colors.text.secondary }} />
-            <Typography variant="caption" sx={{ color: colors.text.secondary }}>
-              Everyone can see this
+            <GroupIcon
+              sx={{ fontSize: 14, flexShrink: 0, color: colors.text.secondary }}
+            />
+            <Typography
+              variant="caption"
+              noWrap
+              sx={{ minWidth: 0, color: colors.text.secondary }}
+            >
+              Everyone in the shop can see this
             </Typography>
           </>
         )}

--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, Chip, IconButton, Tooltip, Typography } from '@mui/material';
 import LockIcon from '@mui/icons-material/Lock';
@@ -22,6 +23,11 @@ interface Props {
   }) => void;
   /** Arrived since this reader last looked. */
   unread?: boolean;
+  /**
+   * Same person, moments after their last one. Drops the repeated name, face
+   * and clock so a burst of messages reads as one turn instead of three.
+   */
+  grouped?: boolean;
   /** Clicking a message is a deliberate "I have read this". */
   onSeen?: () => void;
 }
@@ -36,10 +42,22 @@ const displayName = (
  * Times are real instants formatted for the shop's timezone, not business
  * calendar dates — a message sent at 6pm belongs at 6pm, whatever the server
  * thinks the business day is.
+ *
+ * Clock only: the day is carried by the separator above the first message of
+ * each day, so repeating the date on every row was noise.
  */
 const formatTime = (iso: string) =>
   new Date(iso).toLocaleString('en-CA', {
     timeZone: 'America/Vancouver',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+/** Full date and time, for the hover title on a grouped message. */
+const formatFull = (iso: string) =>
+  new Date(iso).toLocaleString('en-CA', {
+    timeZone: 'America/Vancouver',
+    weekday: 'short',
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
@@ -54,15 +72,21 @@ export function MessageItem({
   showReferences = true,
   onReply,
   unread = false,
+  grouped = false,
   onSeen,
 }: Props) {
   const navigate = useNavigate();
   const baseRoute = useRoleBaseRoute();
+  const [actionsPinned, setActionsPinned] = useState(false);
 
   const isPrivate = message.visibility === 'MENTIONED_ONLY';
   const isMine = message.author.id === currentUserId;
   const author = displayName(message.author.firstName, message.author.lastName);
   const segments = segmentMessageBody(message.body);
+
+  const privateTooltip = `Private — only ${message.mentions
+    .map((m) => displayName(m.firstName, m.lastName))
+    .join(', ')} can see this`;
 
   const accent = isPrivate
     ? colors.semantic.warning
@@ -90,106 +114,164 @@ export function MessageItem({
       sx={{
         display: 'flex',
         justifyContent: isMine ? 'flex-end' : 'flex-start',
-        pl: isMine ? 4 : 0,
-        mb: 0.5,
+        pl: isMine ? { xs: 2, sm: 5 } : 0,
+        pr: isMine ? 0 : { xs: 2, sm: 5 },
+        mt: grouped ? 0.25 : 1,
       }}
-      onClick={() => onSeen?.()}
+      onClick={() => {
+        onSeen?.();
+        // No hover on a touch screen, so a tap is what reveals reply and
+        // delete. It doubles as the "I have read this" the thread already
+        // took a click to mean.
+        setActionsPinned((pinned) => !pinned);
+      }}
     >
       <Box
         sx={{
-          maxWidth: '88%',
+          position: 'relative',
+          maxWidth: { xs: '94%', sm: '80%' },
           minWidth: 0,
-          py: 1,
+          py: 0.875,
           px: 1.5,
-          borderRadius: 1.5,
+          borderRadius: 2,
+          // Flattened on the corner nearest its author, which is what makes a
+          // turn read as coming from one side without mirroring anything.
+          ...(grouped
+            ? {}
+            : isMine
+            ? { borderTopRightRadius: 4 }
+            : { borderTopLeftRadius: 4 }),
           cursor: onSeen ? 'pointer' : 'default',
           bgcolor: background,
+          border: `1px solid ${accent ? `${accent}55` : colors.neutral[200]}`,
           ...(accent ? { borderLeft: `3px solid ${accent}` } : {}),
-          '&:hover .message-actions': { opacity: 1 },
+          '@media (hover: hover)': {
+            '&:hover .message-actions': { opacity: 1, pointerEvents: 'auto' },
+          },
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <UserAvatar name={author} userId={message.author.id} size={24} />
-          <Typography
-            variant="subtitle2"
-            noWrap
-            sx={{ fontWeight: unread ? 800 : 600, flexShrink: 0 }}
+        {(onReply || isMine || canDelete) && (
+          <Box
+            className="message-actions"
+            sx={{
+              position: 'absolute',
+              top: -12,
+              ...(isMine ? { left: 4 } : { right: 4 }),
+              display: 'flex',
+              alignItems: 'center',
+              borderRadius: 5,
+              bgcolor: colors.background.paper,
+              border: `1px solid ${colors.neutral[200]}`,
+              boxShadow: 1,
+              opacity: actionsPinned ? 1 : 0,
+              pointerEvents: actionsPinned ? 'auto' : 'none',
+              transition: 'opacity 120ms',
+            }}
           >
-            {author}
-          </Typography>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            noWrap
-            sx={{ flexShrink: 0 }}
+            {onReply && (
+              <IconButton
+                size="small"
+                sx={{ p: 0.5 }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onReply({
+                    messageId: message.id,
+                    authorName: author,
+                    // Carried through so the composer can say who a reply reaches.
+                    audience: isPrivate
+                      ? message.mentions.map((m) =>
+                          displayName(m.firstName, m.lastName)
+                        )
+                      : [],
+                  });
+                }}
+                aria-label="Reply to message"
+              >
+                <ReplyIcon sx={{ fontSize: 16 }} />
+              </IconButton>
+            )}
+            {(isMine || canDelete) && (
+              <IconButton
+                size="small"
+                sx={{ p: 0.5 }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete(message.id);
+                }}
+                aria-label="Delete message"
+              >
+                <DeleteOutlineIcon sx={{ fontSize: 16 }} />
+              </IconButton>
+            )}
+          </Box>
+        )}
+
+        {!grouped && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              mb: 0.25,
+              minWidth: 0,
+            }}
           >
-            {formatTime(message.createdAt)}
-          </Typography>
-          {message.editedAt && (
-            <Typography variant="caption" color="text.disabled">
-              edited
+            <UserAvatar name={author} userId={message.author.id} size={22} />
+            <Typography
+              variant="subtitle2"
+              noWrap
+              sx={{ fontWeight: unread ? 800 : 600, minWidth: 0 }}
+            >
+              {author}
             </Typography>
-          )}
-          {isPrivate && (
-            <Tooltip
-              title={`Private — visible to ${message.mentions
-                .map((m) => displayName(m.firstName, m.lastName))
-                .join(', ')} and admins`}
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              noWrap
+              sx={{ flexShrink: 0 }}
             >
-              <LockIcon sx={{ fontSize: 15, color: colors.semantic.warning }} />
-            </Tooltip>
-          )}
-
-          <Box sx={{ flexGrow: 1 }} />
-
-          {onReply && (
-            <IconButton
-              className="message-actions"
-              size="small"
-              sx={{ opacity: 0, transition: 'opacity 120ms' }}
-              onClick={(event) => {
-                event.stopPropagation();
-                onReply({
-                  messageId: message.id,
-                  authorName: author,
-                  // Carried through so the composer can say who a reply reaches.
-                  audience: isPrivate
-                    ? message.mentions.map((m) =>
-                        displayName(m.firstName, m.lastName)
-                      )
-                    : [],
-                });
-              }}
-              aria-label="Reply to message"
-            >
-              <ReplyIcon fontSize="small" />
-            </IconButton>
-          )}
-          {(isMine || canDelete) && (
-            <IconButton
-              className="message-actions"
-              size="small"
-              sx={{ opacity: 0, transition: 'opacity 120ms' }}
-              onClick={(event) => {
-                event.stopPropagation();
-                onDelete(message.id);
-              }}
-              aria-label="Delete message"
-            >
-              <DeleteOutlineIcon fontSize="small" />
-            </IconButton>
-          )}
-        </Box>
+              {formatTime(message.createdAt)}
+            </Typography>
+            {message.editedAt && (
+              <Typography variant="caption" color="text.disabled">
+                edited
+              </Typography>
+            )}
+            {isPrivate && (
+              <Tooltip title={privateTooltip}>
+                <LockIcon
+                  sx={{ fontSize: 15, color: colors.semantic.warning }}
+                />
+              </Tooltip>
+            )}
+          </Box>
+        )}
 
         <Typography
           variant="body2"
           component="div"
+          title={grouped ? formatFull(message.createdAt) : undefined}
           sx={{
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-word',
-            mt: 0.25,
           }}
         >
+          {/*
+            A grouped message has no header to carry the padlock, and a private
+            message must never look public — so it keeps one inline.
+          */}
+          {grouped && isPrivate && (
+            <Tooltip title={privateTooltip}>
+              <LockIcon
+                sx={{
+                  fontSize: 13,
+                  mr: 0.5,
+                  verticalAlign: 'baseline',
+                  color: colors.semantic.warning,
+                }}
+              />
+            </Tooltip>
+          )}
           {segments.map((segment, index) => {
             if (segment.kind === 'text') {
               return <span key={index}>{segment.text}</span>;

--- a/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
@@ -8,6 +8,7 @@ const mockPollMessages = jest.fn();
 jest.mock('../../requests/messaging.requests', () => ({
   getEntityThread: (...args: unknown[]) => mockGetEntityThread(...args),
   getGeneralThread: jest.fn(),
+  getEarlierMessages: jest.fn(),
   pollMessages: (...args: unknown[]) => mockPollMessages(...args),
   sendMessage: jest.fn(),
   deleteMessage: jest.fn(),

--- a/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
@@ -93,6 +93,35 @@ describe('MessageThread', () => {
     ).toBeLessThan(3);
   });
 
+  /*
+   * The server only answers a held poll when it has something to send, so the
+   * first request on an empty thread — every repair order nobody has written
+   * in yet — used to sit open for the full twenty-five second hold. The panel
+   * showed a spinner that entire time before admitting there was nothing,
+   * which is what "the chat tab takes forever to load" turned out to be.
+   */
+  it('asks once without a hold, so an empty thread paints at once', async () => {
+    renderThread();
+
+    await waitFor(() => expect(mockPollMessages).toHaveBeenCalled());
+
+    expect(mockPollMessages.mock.calls[0][0].waitMs).toBeUndefined();
+    await waitFor(() =>
+      expect(screen.getByText('No messages yet')).toBeTruthy()
+    );
+
+    // Only then does it settle into holding the connection open.
+    await waitFor(
+      () =>
+        expect(
+          mockPollMessages.mock.calls.some(
+            (call: [{ waitMs?: number }]) => call[0].waitMs === 25_000
+          )
+        ).toBe(true),
+      { timeout: 3000 }
+    );
+  });
+
   it('shows an error rather than an empty thread when opening fails', async () => {
     mockGetEntityThread.mockRejectedValue(new Error('nope'));
 

--- a/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.spec.tsx
@@ -53,6 +53,7 @@ describe('MessageThread', () => {
       messages: [],
       unreadMentions: 0,
       conversationUnreads: {},
+      unreadTotal: 0,
       serverTime: '2026-08-20T17:00:00.000Z',
     });
   });

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -1,18 +1,28 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Alert,
   Box,
-  CircularProgress,
-  Divider,
+  Button,
+  Chip,
   IconButton,
+  Skeleton,
   Typography,
 } from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
 import ReplyIcon from '@mui/icons-material/Reply';
 import CloseIcon from '@mui/icons-material/Close';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import { colors } from '../../theme/colors';
-import type { ConversationEntity } from '@gt-automotive/data';
+import type { ConversationEntity, MessageDto } from '@gt-automotive/data';
 import { useMessagePolling } from './hooks/useMessagePolling';
+import { useViewportFill } from './hooks/useViewportFill';
 import { MessageComposer } from './MessageComposer';
 import { MessageItem } from './MessageItem';
 import {
@@ -42,9 +52,62 @@ interface Props {
   currentUserId: string;
   isAdmin: boolean;
   height?: number | string;
+  /**
+   * Size the panel to the space left on screen instead of to `height`, so the
+   * composer sits at the bottom of the viewport rather than below the fold.
+   */
+  fillViewport?: boolean;
+  /**
+   * Draw the panel as a card. Off when it already sits inside its own surface,
+   * like the messages drawer, where a rounded outline against the drawer edge
+   * reads as a box inside a box.
+   */
+  framed?: boolean;
   /** Opens with a reply already aimed at this message. */
   initialReplyTo?: ReplyTarget;
 }
+
+/** Vancouver calendar day of an instant, as a sortable key. */
+const dayKey = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-CA', { timeZone: 'America/Vancouver' });
+
+/**
+ * "Today" / "Yesterday" / "Mon, Aug 18".
+ *
+ * Days are the shop's, not the reader's: a message written at 6pm here should
+ * sit under today's heading for a phone in another timezone too.
+ */
+const dayLabel = (iso: string) => {
+  const key = dayKey(iso);
+  const now = Date.now();
+  if (key === dayKey(new Date(now).toISOString())) return 'Today';
+  if (key === dayKey(new Date(now - 86_400_000).toISOString()))
+    return 'Yesterday';
+
+  return new Date(iso).toLocaleDateString('en-CA', {
+    timeZone: 'America/Vancouver',
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+/** Consecutive messages by one person close together read as one turn. */
+const GROUPING_WINDOW_MS = 5 * 60 * 1000;
+
+const isSameTurn = (message: MessageDto, previous?: MessageDto) =>
+  Boolean(
+    previous &&
+      previous.author.id === message.author.id &&
+      previous.visibility === message.visibility &&
+      dayKey(previous.createdAt) === dayKey(message.createdAt) &&
+      new Date(message.createdAt).getTime() -
+        new Date(previous.createdAt).getTime() <
+        GROUPING_WINDOW_MS
+  );
+
+/** How close to the bottom still counts as "following the conversation". */
+const AT_BOTTOM_SLACK_PX = 80;
 
 export function MessageThread({
   conversationId: knownConversationId,
@@ -53,6 +116,8 @@ export function MessageThread({
   currentUserId,
   isAdmin,
   height = 480,
+  fillViewport = false,
+  framed = true,
   initialReplyTo,
 }: Props) {
   const { showApiError } = useErrorHelpers();
@@ -71,7 +136,15 @@ export function MessageThread({
   const { messages, loading, appendLocal, removeLocal } =
     useMessagePolling(conversationId);
 
+  const { ref: panelRef, height: filledHeight } =
+    useViewportFill<HTMLDivElement>({ enabled: fillViewport, min: 340 });
+
+  const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const followingRef = useRef(true);
+  const paintedRef = useRef(false);
+  const seenCountRef = useRef(0);
+  const [missed, setMissed] = useState(0);
 
   /*
    * useErrorHelpers and useConfirmationHelpers build a fresh object of fresh
@@ -140,9 +213,43 @@ export function MessageThread({
     return () => clearTimeout(handle);
   }, [conversationId, markRead, messages.length]);
 
+  const jumpToLatest = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    followingRef.current = true;
+    setMissed(0);
+    bottomRef.current?.scrollIntoView({ behavior, block: 'end' });
+  }, []);
+
+  /*
+   * Only chase the bottom for a reader who is already there.
+   *
+   * Scrolling on every arrival yanks the view out from under somebody reading
+   * back through the thread. They get a count instead, and decide when to
+   * follow it.
+   */
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages.length]);
+    const arrived = messages.length - seenCountRef.current;
+    seenCountRef.current = messages.length;
+    if (arrived <= 0) return;
+
+    if (followingRef.current) {
+      // The first paint should look settled rather than animate up from the
+      // top of a thread the reader never saw.
+      jumpToLatest(paintedRef.current ? 'smooth' : 'auto');
+      paintedRef.current = true;
+    } else {
+      setMissed((count) => count + arrived);
+    }
+  }, [messages.length, jumpToLatest]);
+
+  const handleScroll = useCallback(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+
+    const distanceFromBottom =
+      node.scrollHeight - node.scrollTop - node.clientHeight;
+    followingRef.current = distanceFromBottom < AT_BOTTOM_SLACK_PX;
+    if (followingRef.current) setMissed(0);
+  }, []);
 
   const handleSend = useCallback(
     async (body: string) => {
@@ -155,6 +262,8 @@ export function MessageThread({
         );
         appendLocal(created);
         setReplyTo(undefined);
+        // You always want to see what you just said.
+        followingRef.current = true;
       } catch (error) {
         helpersRef.current.showApiError(error);
       }
@@ -177,136 +286,287 @@ export function MessageThread({
     [removeLocal]
   );
 
-  if (opening) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-        <CircularProgress />
-      </Box>
-    );
-  }
+  /** Day headings and turn grouping worked out once per change, not per row. */
+  const rows = useMemo(() => {
+    let unreadMarked = false;
+
+    return messages.map((message, index) => {
+      const previous = messages[index - 1];
+      const startsDay =
+        !previous || dayKey(previous.createdAt) !== dayKey(message.createdAt);
+
+      const unread =
+        message.author.id !== currentUserId &&
+        (!readMark || message.createdAt > readMark);
+      const firstUnread = unread && !unreadMarked;
+      if (firstUnread) unreadMarked = true;
+
+      return {
+        message,
+        startsDay,
+        unread,
+        firstUnread,
+        grouped: !startsDay && !firstUnread && isSameTurn(message, previous),
+      };
+    });
+  }, [messages, currentUserId, readMark]);
+
+  const panelHeight = fillViewport ? filledHeight ?? height : height;
+  const showSkeleton = opening || (loading && messages.length === 0);
 
   if (openError) {
     return <Alert severity="error">{openError}</Alert>;
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height }}>
-      <Box sx={{ flexGrow: 1, overflowY: 'auto', mb: 1.5 }}>
-        {loading && messages.length === 0 ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-            <CircularProgress size={24} />
-          </Box>
+    <Box
+      ref={panelRef}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: panelHeight,
+        minHeight: 0,
+        overflow: 'hidden',
+        ...(framed
+          ? {
+              borderRadius: 2,
+              border: `1px solid ${colors.neutral[200]}`,
+            }
+          : {}),
+        bgcolor: colors.background.light,
+      }}
+    >
+      <Box
+        ref={scrollRef}
+        onScroll={handleScroll}
+        sx={{
+          flexGrow: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          overscrollBehavior: 'contain',
+          px: { xs: 1, sm: 1.5 },
+          py: 1.5,
+        }}
+      >
+        {showSkeleton ? (
+          <ThreadSkeleton />
         ) : messages.length === 0 ? (
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: 1,
-              py: 6,
-            }}
-          >
-            <ChatIcon sx={{ fontSize: 40, color: 'text.disabled' }} />
-            <Typography variant="body2" color="text.secondary">
-              No messages yet
-            </Typography>
-            <Typography variant="caption" color="text.disabled">
-              Type @ to tag someone — only they will see it.
-            </Typography>
-          </Box>
+          <EmptyThread />
         ) : (
-          messages.map((message, index) => {
-            const isUnread =
-              message.author.id !== currentUserId &&
-              (!readMark || message.createdAt > readMark);
-            const firstUnread =
-              isUnread &&
-              !messages
-                .slice(0, index)
-                .some(
-                  (earlier) =>
-                    earlier.author.id !== currentUserId &&
-                    (!readMark || earlier.createdAt > readMark)
-                );
-
-            return (
-              <Box key={message.id}>
-                {firstUnread && (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1,
-                      my: 1,
-                    }}
-                  >
-                    <Divider sx={{ flexGrow: 1 }} />
-                    <Typography
-                      variant="caption"
-                      sx={{ color: colors.semantic.error, fontWeight: 700 }}
-                    >
-                      New
-                    </Typography>
-                    <Divider sx={{ flexGrow: 1 }} />
-                  </Box>
-                )}
-                <MessageItem
-                  message={message}
-                  currentUserId={currentUserId}
-                  canDelete={isAdmin}
-                  onDelete={handleDelete}
-                  showReferences={!entityId}
-                  onReply={setReplyTo}
-                  unread={isUnread}
-                  onSeen={markRead}
-                />
-              </Box>
-            );
-          })
+          rows.map(({ message, startsDay, unread, firstUnread, grouped }) => (
+            /*
+             * Flat, not one wrapper per message: a sticky day heading only
+             * holds its place if the scrolling box is its containing block.
+             * Wrapped, each heading stuck to a container one message tall and
+             * scrolled straight out of view.
+             */
+            <Fragment key={message.id}>
+              {startsDay && (
+                <DaySeparator label={dayLabel(message.createdAt)} />
+              )}
+              {firstUnread && <NewSeparator />}
+              <MessageItem
+                message={message}
+                currentUserId={currentUserId}
+                canDelete={isAdmin}
+                onDelete={handleDelete}
+                showReferences={!entityId}
+                onReply={setReplyTo}
+                unread={unread}
+                grouped={grouped}
+                onSeen={markRead}
+              />
+            </Fragment>
+          ))
         )}
         <div ref={bottomRef} />
       </Box>
 
-      {replyTo && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            px: 1,
-            py: 0.5,
-            mb: 0.5,
-            borderLeft: `3px solid ${colors.primary.main}`,
-            bgcolor: 'action.hover',
-          }}
-        >
-          <ReplyIcon sx={{ fontSize: 15, color: 'text.secondary' }} />
-          <Typography variant="caption" sx={{ flexGrow: 1 }}>
-            Replying to {replyTo.authorName}
-          </Typography>
-          <IconButton
+      {missed > 0 && (
+        <Box sx={{ position: 'relative', height: 0 }}>
+          <Button
             size="small"
-            onClick={() => setReplyTo(undefined)}
-            aria-label="Cancel reply"
+            variant="contained"
+            startIcon={<ArrowDownwardIcon sx={{ fontSize: 16 }} />}
+            onClick={() => jumpToLatest()}
+            sx={{
+              position: 'absolute',
+              bottom: 8,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              borderRadius: 5,
+              textTransform: 'none',
+              boxShadow: 3,
+              px: 1.75,
+            }}
           >
-            <CloseIcon sx={{ fontSize: 15 }} />
-          </IconButton>
+            {missed} new {missed === 1 ? 'message' : 'messages'}
+          </Button>
         </Box>
       )}
 
-      <MessageComposer
-        onSend={handleSend}
-        disabled={!conversationId}
-        autoFocus={Boolean(initialReplyTo)}
-        // A reply cannot be more visible than what it answers, so the strip
-        // must name who it will actually reach rather than claiming the shop
-        // can see it.
-        inheritedAudience={
-          replyTo && replyTo.audience.length > 0
-            ? [replyTo.authorName, ...replyTo.audience]
-            : undefined
-        }
+      <Box
+        sx={{
+          borderTop: `1px solid ${colors.neutral[200]}`,
+          bgcolor: colors.background.paper,
+          px: { xs: 1, sm: 1.5 },
+          pt: 1,
+          pb: { xs: 1, sm: 1.25 },
+        }}
+      >
+        {replyTo && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              px: 1,
+              py: 0.5,
+              mb: 0.75,
+              borderRadius: 1.5,
+              borderLeft: `3px solid ${colors.primary.main}`,
+              bgcolor: colors.neutral[100],
+            }}
+          >
+            <ReplyIcon sx={{ fontSize: 15, color: colors.text.secondary }} />
+            <Typography variant="caption" sx={{ flexGrow: 1 }} noWrap>
+              Replying to {replyTo.authorName}
+            </Typography>
+            <IconButton
+              size="small"
+              onClick={() => setReplyTo(undefined)}
+              aria-label="Cancel reply"
+            >
+              <CloseIcon sx={{ fontSize: 15 }} />
+            </IconButton>
+          </Box>
+        )}
+
+        <MessageComposer
+          onSend={handleSend}
+          disabled={!conversationId}
+          autoFocus={Boolean(initialReplyTo)}
+          // A reply cannot be more visible than what it answers, so the strip
+          // must name who it will actually reach rather than claiming the shop
+          // can see it.
+          inheritedAudience={
+            replyTo && replyTo.audience.length > 0
+              ? [replyTo.authorName, ...replyTo.audience]
+              : undefined
+          }
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function DaySeparator({ label }: { label: string }) {
+  return (
+    <Box
+      sx={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
+        display: 'flex',
+        justifyContent: 'center',
+        py: 0.75,
+        pointerEvents: 'none',
+      }}
+    >
+      <Chip
+        label={label}
+        size="small"
+        sx={{
+          height: 22,
+          fontSize: 11,
+          fontWeight: 600,
+          color: colors.text.secondary,
+          bgcolor: colors.neutral[200],
+        }}
       />
+    </Box>
+  );
+}
+
+function NewSeparator() {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, my: 1 }}>
+      <Box sx={{ flexGrow: 1, height: 1, bgcolor: colors.semantic.error }} />
+      <Typography
+        variant="caption"
+        sx={{ color: colors.semantic.error, fontWeight: 700 }}
+      >
+        New
+      </Typography>
+      <Box sx={{ flexGrow: 1, height: 1, bgcolor: colors.semantic.error }} />
+    </Box>
+  );
+}
+
+/**
+ * Shaped like the messages it stands in for, so the panel does not jump when
+ * they arrive — and so an empty thread is never mistaken for a slow one.
+ */
+function ThreadSkeleton() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, px: 0.5 }}>
+      {[0, 1, 2].map((row) => (
+        <Box
+          key={row}
+          sx={{
+            display: 'flex',
+            justifyContent: row === 1 ? 'flex-end' : 'flex-start',
+          }}
+        >
+          <Skeleton
+            variant="rounded"
+            width={row === 1 ? '55%' : '70%'}
+            height={row === 2 ? 44 : 58}
+            sx={{ borderRadius: 2 }}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function EmptyThread() {
+  return (
+    <Box
+      sx={{
+        minHeight: 220,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        gap: 1,
+        px: 2,
+        py: 4,
+      }}
+    >
+      <Box
+        sx={{
+          width: 52,
+          height: 52,
+          borderRadius: '50%',
+          display: 'grid',
+          placeItems: 'center',
+          bgcolor: colors.neutral[100],
+        }}
+      >
+        <ChatIcon sx={{ fontSize: 26, color: colors.text.disabled }} />
+      </Box>
+      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+        No messages yet
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{ color: colors.text.secondary, maxWidth: 280 }}
+      >
+        Start the conversation below. Type <strong>@</strong> to tag someone —
+        then only they can see it.
+      </Typography>
     </Box>
   );
 }

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -130,7 +130,16 @@ export function MessageThread({
   const [replyTo, setReplyTo] = useState<ReplyTarget | undefined>(
     initialReplyTo
   );
-  const [readMark, setReadMark] = useState<string | null>(null);
+  /*
+   * Three states, not two: a timestamp, `null` for a thread this reader has
+   * never opened, and `undefined` for a thread opened by id — from the
+   * mentions inbox — where nobody fetched the mark. Collapsing the last two
+   * drew a red "New" line above the whole history of a thread somebody had
+   * read a dozen times.
+   */
+  const [readMark, setReadMark] = useState<string | null | undefined>(
+    knownConversationId ? undefined : null
+  );
   const [openError, setOpenError] = useState<string | null>(null);
 
   const { messages, loading, appendLocal, removeLocal } =
@@ -296,8 +305,9 @@ export function MessageThread({
         !previous || dayKey(previous.createdAt) !== dayKey(message.createdAt);
 
       const unread =
+        readMark !== undefined &&
         message.author.id !== currentUserId &&
-        (!readMark || message.createdAt > readMark);
+        (readMark === null || message.createdAt > readMark);
       const firstUnread = unread && !unreadMarked;
       if (firstUnread) unreadMarked = true;
 

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -27,6 +27,7 @@ import { MessageComposer } from './MessageComposer';
 import { MessageItem } from './MessageItem';
 import {
   deleteMessage,
+  getEarlierMessages,
   getEntityThread,
   getGeneralThread,
   markConversationRead,
@@ -142,8 +143,16 @@ export function MessageThread({
   );
   const [openError, setOpenError] = useState<string | null>(null);
 
-  const { messages, loading, appendLocal, removeLocal } =
-    useMessagePolling(conversationId);
+  const {
+    messages,
+    loading,
+    hasOlder,
+    appendLocal,
+    prependLocal,
+    removeLocal,
+  } = useMessagePolling(conversationId);
+
+  const [loadingOlder, setLoadingOlder] = useState(false);
 
   const { ref: panelRef, height: filledHeight } =
     useViewportFill<HTMLDivElement>({ enabled: fillViewport, min: 340 });
@@ -153,6 +162,7 @@ export function MessageThread({
   const followingRef = useRef(true);
   const paintedRef = useRef(false);
   const seenCountRef = useRef(0);
+  const loadingOlderRef = useRef(false);
   const [missed, setMissed] = useState(0);
 
   /*
@@ -240,6 +250,10 @@ export function MessageThread({
     seenCountRef.current = messages.length;
     if (arrived <= 0) return;
 
+    // A page of history also grows the list, and following that would scroll
+    // to the bottom of a thread somebody just asked to read the top of.
+    if (loadingOlderRef.current) return;
+
     if (followingRef.current) {
       // The first paint should look settled rather than animate up from the
       // top of a thread the reader never saw.
@@ -279,6 +293,43 @@ export function MessageThread({
     },
     [conversationId, appendLocal, replyTo]
   );
+
+  /*
+   * Reading back through a thread.
+   *
+   * A conversation opens with a window rather than its whole history — shop
+   * chat is never purged, so "everything" grows without limit. Prepending
+   * moves the content under the reader, so the scroll position is put back by
+   * however much taller the list got: without that, loading earlier messages
+   * throws you to the top of the page you were reading.
+   */
+  const handleLoadEarlier = useCallback(async () => {
+    const node = scrollRef.current;
+    const oldest = messages[0];
+    if (!conversationId || !oldest || loadingOlder) return;
+
+    setLoadingOlder(true);
+    loadingOlderRef.current = true;
+    const heightBefore = node?.scrollHeight ?? 0;
+
+    try {
+      const page = await getEarlierMessages(conversationId, oldest.createdAt);
+      prependLocal(page.messages, page.hasOlder);
+
+      requestAnimationFrame(() => {
+        if (!node) return;
+        node.scrollTop += node.scrollHeight - heightBefore;
+      });
+    } catch (error) {
+      helpersRef.current.showApiError(error);
+    } finally {
+      setLoadingOlder(false);
+      // Cleared after the effect that reacts to the new length has run.
+      requestAnimationFrame(() => {
+        loadingOlderRef.current = false;
+      });
+    }
+  }, [conversationId, messages, loadingOlder, prependLocal]);
 
   const handleDelete = useCallback(
     async (id: string) => {
@@ -358,6 +409,19 @@ export function MessageThread({
           py: 1.5,
         }}
       >
+        {hasOlder && !showSkeleton && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', pb: 1 }}>
+            <Button
+              size="small"
+              onClick={() => void handleLoadEarlier()}
+              disabled={loadingOlder}
+              sx={{ textTransform: 'none', borderRadius: 5 }}
+            >
+              {loadingOlder ? 'Loading…' : 'Load earlier messages'}
+            </Button>
+          </Box>
+        )}
+
         {showSkeleton ? (
           <ThreadSkeleton />
         ) : messages.length === 0 ? (

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -90,14 +90,11 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
 
   // No conversation id: this poll exists for the counts alone. The server
   // returns them whether or not a thread is open.
-  const { unreadMentions, conversationUnreads, refresh } =
-    useMessagePolling(undefined);
-
   // Everything unread, not only mentions: an untagged message in the shop
-  // channel is still something somebody has not seen.
-  const unreadTotal =
-    unreadMentions +
-    Object.values(conversationUnreads).reduce((sum, n) => sum + n, 0);
+  // channel is still something somebody has not seen. The total is counted by
+  // the server rather than added up here, because a tagged message is both a
+  // mention and an unread message and adding the two showed two of everything.
+  const { unreadMentions, unreadTotal, refresh } = useMessagePolling(undefined);
 
   const { enabled: soundEnabled, setEnabled: setSoundEnabled } =
     useNotificationSound(unreadTotal);

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -16,8 +16,13 @@ import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import VolumeOffIcon from '@mui/icons-material/VolumeOff';
+import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
+import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
+import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import { useMessagePolling } from './hooks/useMessagePolling';
 import { useNotificationSound } from './hooks/useNotificationSound';
+import { useBrowserNotifications } from './hooks/useBrowserNotifications';
+import { useDocumentTitleBadge } from './hooks/useDocumentTitleBadge';
 import { MessageThread } from './MessageThread';
 import { MentionsList } from './MentionsList';
 import { onReadAnnounced } from './messaging-read-signal';
@@ -97,9 +102,29 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
   const { enabled: soundEnabled, setEnabled: setSoundEnabled } =
     useNotificationSound(unreadTotal);
 
+  // Works in a background tab with nobody's permission needed, which makes it
+  // the floor under everything else here.
+  useDocumentTitleBadge(unreadTotal);
+
+  const notifications = useBrowserNotifications({
+    unreadTotal,
+    unreadMentions,
+    // Clicking the toast should land on the messages, not just the app.
+    onActivate: () => setOpen(true),
+  });
+
   // The count is held open in a long poll, so it would otherwise stay wrong
   // for up to twenty-five seconds after something was read.
   useEffect(() => onReadAnnounced(() => void refresh()), [refresh]);
+
+  const notificationTooltip =
+    notifications.permission === 'denied'
+      ? 'Notifications are blocked in your browser settings'
+      : notifications.permission !== 'granted'
+      ? 'Notify me when I am not on this tab'
+      : notifications.enabled
+      ? 'Turn off notifications when I am away'
+      : 'Notify me when I am not on this tab';
 
   return (
     <>
@@ -107,9 +132,7 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
         <Fab
           color="primary"
           aria-label={
-            unreadMentions > 0
-              ? `Messages, ${unreadMentions} unread`
-              : 'Messages'
+            unreadTotal > 0 ? `Messages, ${unreadTotal} unread` : 'Messages'
           }
           onClick={() => setOpen(true)}
           sx={{
@@ -119,7 +142,13 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
             zIndex: (theme) => theme.zIndex.drawer - 1,
           }}
         >
-          <Badge badgeContent={unreadMentions} color="error" max={99}>
+          {/*
+            Everything unread, matching the ping and the tab title. The badge
+            used to count mentions alone, so a shop-chat message rang a sound
+            with no number anywhere to explain it. The Mentions tab inside
+            still carries the narrower count.
+          */}
+          <Badge badgeContent={unreadTotal} color="error" max={99}>
             <ChatIcon />
           </Badge>
         </Fab>
@@ -166,6 +195,32 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            {notifications.permission !== 'unsupported' && (
+              <Tooltip title={notificationTooltip}>
+                {/* Wrapped: a disabled button gives a Tooltip nothing to hang on. */}
+                <span>
+                  <IconButton
+                    disabled={notifications.permission === 'denied'}
+                    onClick={() => {
+                      if (notifications.permission === 'granted') {
+                        notifications.setEnabled(!notifications.enabled);
+                      } else {
+                        void notifications.request();
+                      }
+                    }}
+                    aria-label={notificationTooltip}
+                  >
+                    {notifications.permission === 'denied' ? (
+                      <NotificationsOffIcon />
+                    ) : notifications.active ? (
+                      <NotificationsActiveIcon />
+                    ) : (
+                      <NotificationsNoneIcon />
+                    )}
+                  </IconButton>
+                </span>
+              </Tooltip>
+            )}
             <Tooltip title={soundEnabled ? 'Mute new-message sound' : 'Unmute'}>
               <IconButton
                 onClick={() => setSoundEnabled(!soundEnabled)}

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -35,13 +35,14 @@ interface Props {
 }
 
 /**
- * Always-present entry point to messaging, with the count of things tagged at
- * you.
+ * Always-present entry point to messaging, and the thing that carries every
+ * count.
  *
- * Notification for this feature is in-app only, so the badge is the whole
- * mechanism — nothing else tells somebody they were tagged. It therefore polls
- * with no conversation open, which is what keeps the count live wherever the
- * user happens to be in the app.
+ * Nothing here sends an SMS or an email, so what this component does is the
+ * whole of how anybody finds out: the badge, the ping, the tab title and — for
+ * a tab that is not in front of them — a desktop notification. It therefore
+ * polls with no conversation open, which is what keeps all four live wherever
+ * the user happens to be in the app.
  */
 export function MessagingFab({ currentUserId, isAdmin }: Props) {
   const [open, setOpen] = useState(false);

--- a/apps/webApp/src/app/components/messaging/MessagingFab.tsx
+++ b/apps/webApp/src/app/components/messaging/MessagingFab.tsx
@@ -211,7 +211,8 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
           sx={{
             flexGrow: 1,
             overflowY: 'auto',
-            px: openedThread || tab === 0 ? 1.5 : 0,
+            // Each child pads itself; doubling it here squeezed the thread.
+            px: 0,
           }}
         >
           {/*
@@ -226,6 +227,7 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
               currentUserId={currentUserId}
               isAdmin={isAdmin}
               height="100%"
+              framed={false}
             />
           )}
           {open && !openedThread && tab === 0 && (
@@ -233,6 +235,7 @@ export function MessagingFab({ currentUserId, isAdmin }: Props) {
               currentUserId={currentUserId}
               isAdmin={isAdmin}
               height="100%"
+              framed={false}
             />
           )}
           {open && !openedThread && tab === 1 && (

--- a/apps/webApp/src/app/components/messaging/hooks/useBrowserNotifications.spec.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useBrowserNotifications.spec.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from '@testing-library/react';
+import { useBrowserNotifications } from './useBrowserNotifications';
+
+/**
+ * The rules worth pinning down are the ones about restraint: this thing is
+ * allowed to interrupt somebody, so every case where it must not is a test.
+ */
+describe('useBrowserNotifications', () => {
+  const shown: Array<{ title: string; options?: NotificationOptions }> = [];
+  let hidden = true;
+
+  class FakeNotification {
+    static permission: NotificationPermission = 'granted';
+    static requestPermission = jest.fn(async () => FakeNotification.permission);
+
+    onclick: (() => void) | null = null;
+    close = jest.fn();
+
+    constructor(title: string, options?: NotificationOptions) {
+      shown.push({ title, options });
+    }
+  }
+
+  beforeEach(() => {
+    shown.length = 0;
+    hidden = true;
+    FakeNotification.permission = 'granted';
+    (window as unknown as { Notification: unknown }).Notification =
+      FakeNotification;
+    localStorage.clear();
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+  });
+
+  const render = (onActivate?: () => void) =>
+    renderHook(
+      ({ unreadTotal, unreadMentions }) =>
+        useBrowserNotifications({ unreadTotal, unreadMentions, onActivate }),
+      { initialProps: { unreadTotal: 0, unreadMentions: 0 } }
+    );
+
+  it('says nothing on the first reading', () => {
+    render();
+    // Opening the app with three waiting is not three things happening now.
+    const { rerender } = renderHook(
+      ({ unreadTotal }) =>
+        useBrowserNotifications({ unreadTotal, unreadMentions: 0 }),
+      { initialProps: { unreadTotal: 3 } }
+    );
+    rerender({ unreadTotal: 3 });
+
+    expect(shown).toHaveLength(0);
+  });
+
+  it('notifies when the total rises and the tab is hidden', () => {
+    const { rerender } = render();
+
+    rerender({ unreadTotal: 2, unreadMentions: 0 });
+
+    expect(shown).toHaveLength(1);
+    expect(shown[0].options?.body).toBe('2 new messages');
+    // One notification that updates, rather than a stack.
+    expect(shown[0].options?.tag).toBe('gt-messaging');
+  });
+
+  it('names being tagged, because that is the part somebody must act on', () => {
+    const { rerender } = render();
+
+    rerender({ unreadTotal: 1, unreadMentions: 1 });
+
+    expect(shown[0].options?.body).toBe('You were tagged in 1 message');
+  });
+
+  it('never repeats the message itself', () => {
+    const { rerender } = render();
+
+    rerender({ unreadTotal: 1, unreadMentions: 1 });
+
+    // A private message is private from whoever is walking past the screen too.
+    const text = `${shown[0].title} ${shown[0].options?.body}`;
+    expect(text).not.toMatch(/RO-|@/);
+  });
+
+  it('stays quiet while the page is in front of them', () => {
+    hidden = false;
+    const { rerender } = render();
+
+    rerender({ unreadTotal: 4, unreadMentions: 1 });
+
+    // The badge moved and the ping sounded; a toast on top is noise.
+    expect(shown).toHaveLength(0);
+  });
+
+  it('stays quiet when the count drops or holds', () => {
+    const { rerender } = render();
+
+    rerender({ unreadTotal: 0, unreadMentions: 0 });
+    rerender({ unreadTotal: 0, unreadMentions: 0 });
+
+    expect(shown).toHaveLength(0);
+  });
+
+  it('stays quiet without permission', () => {
+    FakeNotification.permission = 'denied';
+    const { rerender } = render();
+
+    rerender({ unreadTotal: 5, unreadMentions: 2 });
+
+    expect(shown).toHaveLength(0);
+  });
+
+  it('stays quiet once switched off, permission or not', () => {
+    const { result, rerender } = render();
+
+    act(() => result.current.setEnabled(false));
+    rerender({ unreadTotal: 5, unreadMentions: 2 });
+
+    expect(shown).toHaveLength(0);
+    expect(localStorage.getItem('gt.messaging.desktopNotifications')).toBe(
+      'false'
+    );
+  });
+
+  it('reports itself unsupported rather than throwing', () => {
+    delete (window as unknown as { Notification?: unknown }).Notification;
+
+    const { result } = render();
+
+    expect(result.current.permission).toBe('unsupported');
+    expect(result.current.active).toBe(false);
+  });
+});

--- a/apps/webApp/src/app/components/messaging/hooks/useBrowserNotifications.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useBrowserNotifications.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const PREFERENCE_KEY = 'gt.messaging.desktopNotifications';
+
+/** What the browser will let us do, plus the case where it has no idea. */
+export type NotificationPermissionState =
+  | 'unsupported'
+  | 'default'
+  | 'granted'
+  | 'denied';
+
+interface Options {
+  /** Mentions plus unread messages — the same total the ping listens to. */
+  unreadTotal: number;
+  /** How much of that total is somebody tagging you. */
+  unreadMentions: number;
+  /** Clicking the notification should land them in the conversation. */
+  onActivate?: () => void;
+}
+
+function readPreference(): boolean {
+  try {
+    return localStorage.getItem(PREFERENCE_KEY) !== 'false';
+  } catch {
+    // Private browsing throws on access. Permission is still the real gate.
+    return true;
+  }
+}
+
+function currentPermission(): NotificationPermissionState {
+  if (typeof window === 'undefined' || !('Notification' in window)) {
+    return 'unsupported';
+  }
+  return Notification.permission as NotificationPermissionState;
+}
+
+/**
+ * Tells somebody a message arrived when they are not looking at the page.
+ *
+ * The badge and the ping only reach a person with the app in front of them,
+ * which is the easy half of the problem — the tagged work that goes unseen is
+ * the work tagged while they were in another tab. A notification is the
+ * cheapest thing that crosses that line: no service worker, no vendor, no
+ * monthly cost, and it works in every browser the shop uses.
+ *
+ * Two deliberate limits:
+ *
+ * - **Nothing is said about the message.** No author, no body, no repair order.
+ *   A private message exists so that only the people in it can read it, and a
+ *   toast on a shop counter screen is read by whoever walks past. The
+ *   notification says how much arrived and leaves the rest behind the login.
+ * - **Only while the tab is hidden.** With the page in front of them the badge
+ *   moved and the ping already sounded; a toast on top of that is noise.
+ */
+export function useBrowserNotifications({
+  unreadTotal,
+  unreadMentions,
+  onActivate,
+}: Options) {
+  const [permission, setPermission] =
+    useState<NotificationPermissionState>(currentPermission);
+  const [enabled, setEnabledState] = useState(readPreference);
+
+  const previousTotal = useRef<number | null>(null);
+  const previousMentions = useRef(0);
+
+  const onActivateRef = useRef(onActivate);
+  onActivateRef.current = onActivate;
+
+  const setEnabled = useCallback((next: boolean) => {
+    setEnabledState(next);
+    try {
+      localStorage.setItem(PREFERENCE_KEY, String(next));
+    } catch {
+      // Preference is lost on reload; the toggle still works for this session.
+    }
+  }, []);
+
+  /**
+   * Asking has to come from a click.
+   *
+   * Browsers refuse a permission prompt that no gesture asked for, and the
+   * ones that do not refuse it punish the site for prompting on load. So this
+   * is wired to the bell in the panel header rather than to mount.
+   */
+  const request = useCallback(async () => {
+    if (currentPermission() === 'unsupported') return;
+
+    try {
+      const result = await Notification.requestPermission();
+      setPermission(result as NotificationPermissionState);
+      if (result === 'granted') setEnabled(true);
+    } catch {
+      // Older Safari hands back a callback API rather than a promise. Nothing
+      // to do but leave the state as it was.
+      setPermission(currentPermission());
+    }
+  }, [setEnabled]);
+
+  useEffect(() => {
+    const priorTotal = previousTotal.current;
+    const priorMentions = previousMentions.current;
+    previousTotal.current = unreadTotal;
+    previousMentions.current = unreadMentions;
+
+    // Never on the first reading, or opening the app would announce everything
+    // that arrived while it was shut.
+    if (priorTotal === null || unreadTotal <= priorTotal) return;
+    if (!enabled || permission !== 'granted') return;
+    if (!document.hidden) return;
+
+    const taggedArrived = unreadMentions - priorMentions;
+    const arrived = unreadTotal - priorTotal;
+
+    const body =
+      taggedArrived > 0
+        ? `You were tagged in ${taggedArrived} ${
+            taggedArrived === 1 ? 'message' : 'messages'
+          }`
+        : `${arrived} new ${arrived === 1 ? 'message' : 'messages'}`;
+
+    try {
+      const notification = new Notification('GT Automotives', {
+        body,
+        icon: '/logo.png',
+        // One notification that updates, rather than a stack of them building
+        // up behind somebody who stepped away for an hour.
+        tag: 'gt-messaging',
+        silent: false,
+      });
+
+      notification.onclick = () => {
+        window.focus();
+        notification.close();
+        onActivateRef.current?.();
+      };
+    } catch {
+      // iOS Safari throws on the constructor unless the page is an installed
+      // PWA with a service worker. The badge and the ping still did their job.
+    }
+  }, [unreadTotal, unreadMentions, enabled, permission]);
+
+  return {
+    permission,
+    /** Granted *and* not switched off in the panel. */
+    active: permission === 'granted' && enabled,
+    enabled,
+    setEnabled,
+    request,
+  };
+}

--- a/apps/webApp/src/app/components/messaging/hooks/useDocumentTitleBadge.spec.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useDocumentTitleBadge.spec.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { useDocumentTitleBadge } from './useDocumentTitleBadge';
+
+describe('useDocumentTitleBadge', () => {
+  beforeEach(() => {
+    document.title = 'GT Automotives';
+  });
+
+  it('puts the count in front of the title', () => {
+    const { rerender } = renderHook(
+      ({ count }) => useDocumentTitleBadge(count),
+      {
+        initialProps: { count: 0 },
+      }
+    );
+    expect(document.title).toBe('GT Automotives');
+
+    rerender({ count: 3 });
+    expect(document.title).toBe('(3) GT Automotives');
+  });
+
+  it('replaces the count rather than stacking badges', () => {
+    const { rerender } = renderHook(
+      ({ count }) => useDocumentTitleBadge(count),
+      {
+        initialProps: { count: 1 },
+      }
+    );
+
+    rerender({ count: 2 });
+    rerender({ count: 9 });
+
+    expect(document.title).toBe('(9) GT Automotives');
+  });
+
+  it('takes the badge away when everything has been read', () => {
+    const { rerender } = renderHook(
+      ({ count }) => useDocumentTitleBadge(count),
+      {
+        initialProps: { count: 4 },
+      }
+    );
+
+    rerender({ count: 0 });
+
+    expect(document.title).toBe('GT Automotives');
+  });
+
+  it('puts the plain title back on unmount', () => {
+    const { unmount, rerender } = renderHook(
+      ({ count }) => useDocumentTitleBadge(count),
+      { initialProps: { count: 0 } }
+    );
+
+    rerender({ count: 5 });
+    unmount();
+
+    expect(document.title).toBe('GT Automotives');
+  });
+});

--- a/apps/webApp/src/app/components/messaging/hooks/useDocumentTitleBadge.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useDocumentTitleBadge.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+
+const EXISTING_BADGE = /^\(\d+\)\s*/;
+
+/**
+ * Puts the unread count in the browser tab title: "(3) GT Automotives".
+ *
+ * The one notification surface that survives the tab being in the background
+ * without asking anyone's permission. A row of tabs is scanned dozens of times
+ * an hour, and a number appearing in one of them is noticed by people who
+ * would never have thought to open the app.
+ *
+ * The base title is captured once, so repeated updates cannot stack badges on
+ * top of each other, and it is put back on unmount.
+ */
+export function useDocumentTitleBadge(count: number) {
+  const baseTitle = useRef('');
+
+  useEffect(() => {
+    baseTitle.current = document.title.replace(EXISTING_BADGE, '');
+    return () => {
+      document.title = baseTitle.current;
+    };
+  }, []);
+
+  useEffect(() => {
+    const base =
+      baseTitle.current || document.title.replace(EXISTING_BADGE, '');
+    document.title = count > 0 ? `(${count}) ${base}` : base;
+  }, [count]);
+}

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.spec.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.spec.ts
@@ -22,6 +22,7 @@ describe('useMessagePolling', () => {
       messages: [],
       unreadMentions: 0,
       conversationUnreads: {},
+      unreadTotal: 0,
       serverTime: '2026-08-21T17:00:00.000Z',
     });
   });

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.spec.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.spec.ts
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMessagePolling } from './useMessagePolling';
+import { pollMessages } from '../../../requests/messaging.requests';
+
+jest.mock('../../../requests/messaging.requests', () => ({
+  pollMessages: jest.fn(),
+}));
+
+const mockPoll = pollMessages as jest.MockedFunction<typeof pollMessages>;
+
+describe('useMessagePolling', () => {
+  let hidden = false;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hidden = false;
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+    mockPoll.mockResolvedValue({
+      messages: [],
+      unreadMentions: 0,
+      conversationUnreads: {},
+      serverTime: '2026-08-21T17:00:00.000Z',
+    });
+  });
+
+  it('asks once without a hold before settling into holding', async () => {
+    renderHook(() => useMessagePolling('conv-1'));
+
+    await waitFor(() => expect(mockPoll).toHaveBeenCalled());
+    expect(mockPoll.mock.calls[0][0].waitMs).toBeUndefined();
+
+    await waitFor(
+      () =>
+        expect(
+          mockPoll.mock.calls.some((call) => call[0].waitMs === 25_000)
+        ).toBe(true),
+      { timeout: 3000 }
+    );
+  });
+
+  /*
+   * A backgrounded tab used to stop asking altogether, so nothing could tell
+   * anybody a message had arrived while they were somewhere else — which is
+   * the only moment being told is worth anything.
+   */
+  it('keeps asking while the tab is hidden, without holding a connection', async () => {
+    hidden = true;
+
+    renderHook(() => useMessagePolling('conv-1'));
+
+    await waitFor(() => expect(mockPoll).toHaveBeenCalled());
+    expect(mockPoll.mock.calls.every((call) => !call[0].waitMs)).toBe(true);
+  });
+});

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
@@ -36,6 +36,8 @@ interface PollingState {
   conversationUnreads: Record<string, number>;
   /** Every unread message counted once — see PollResponseDto. */
   unreadTotal: number;
+  /** Whether the thread holds messages older than the ones loaded. */
+  hasOlder: boolean;
   loading: boolean;
 }
 
@@ -56,6 +58,7 @@ export function useMessagePolling(conversationId?: string) {
     unreadMentions: 0,
     conversationUnreads: {},
     unreadTotal: 0,
+    hasOlder: false,
     loading: Boolean(conversationId),
   });
 
@@ -83,6 +86,9 @@ export function useMessagePolling(conversationId?: string) {
           unreadMentions: result.unreadMentions,
           conversationUnreads: result.conversationUnreads,
           unreadTotal: result.unreadTotal,
+          // Only the opening poll answers this; later ones say nothing about
+          // history and must not overwrite what it said.
+          hasOlder: result.hasOlderMessages ?? prev.hasOlder,
           loading: false,
         };
       });
@@ -111,6 +117,7 @@ export function useMessagePolling(conversationId?: string) {
       unreadMentions: 0,
       conversationUnreads: {},
       unreadTotal: 0,
+      hasOlder: false,
       loading: Boolean(conversationId),
     });
 
@@ -195,6 +202,15 @@ export function useMessagePolling(conversationId?: string) {
     };
   }, [conversationId, applyResult, runPoll]);
 
+  /** Put a page of history in front of what is already loaded. */
+  const prependLocal = useCallback((older: MessageDto[], hasOlder: boolean) => {
+    setState((prev) => {
+      const seen = new Set(prev.messages.map((m) => m.id));
+      const added = older.filter((m) => !seen.has(m.id));
+      return { ...prev, messages: [...added, ...prev.messages], hasOlder };
+    });
+  }, []);
+
   /** Show a just-sent message without waiting for the next round trip. */
   const appendLocal = useCallback((message: MessageDto) => {
     setState((prev) =>
@@ -218,5 +234,12 @@ export function useMessagePolling(conversationId?: string) {
     }));
   }, []);
 
-  return { ...state, refresh: runPoll, appendLocal, replaceLocal, removeLocal };
+  return {
+    ...state,
+    refresh: runPoll,
+    appendLocal,
+    prependLocal,
+    replaceLocal,
+    removeLocal,
+  };
 }

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
@@ -34,6 +34,8 @@ interface PollingState {
   messages: MessageDto[];
   unreadMentions: number;
   conversationUnreads: Record<string, number>;
+  /** Every unread message counted once — see PollResponseDto. */
+  unreadTotal: number;
   loading: boolean;
 }
 
@@ -53,6 +55,7 @@ export function useMessagePolling(conversationId?: string) {
     messages: [],
     unreadMentions: 0,
     conversationUnreads: {},
+    unreadTotal: 0,
     loading: Boolean(conversationId),
   });
 
@@ -77,6 +80,7 @@ export function useMessagePolling(conversationId?: string) {
           messages: added.length ? [...prev.messages, ...added] : prev.messages,
           unreadMentions: result.unreadMentions,
           conversationUnreads: result.conversationUnreads,
+          unreadTotal: result.unreadTotal,
           loading: false,
         };
       });
@@ -104,6 +108,7 @@ export function useMessagePolling(conversationId?: string) {
       messages: [],
       unreadMentions: 0,
       conversationUnreads: {},
+      unreadTotal: 0,
       loading: Boolean(conversationId),
     });
 

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
@@ -97,6 +97,18 @@ export function useMessagePolling(conversationId?: string) {
       new Promise((resolve) => setTimeout(resolve, ms));
 
     const loop = async () => {
+      /*
+       * The first trip must not hold.
+       *
+       * The server only returns early when it has something to send, so an
+       * empty thread — every repair order nobody has written in yet — held the
+       * very first request for the full twenty-five seconds. The panel sat on
+       * a spinner that whole time before admitting it had nothing to show,
+       * which read as "messaging is broken" rather than "no messages yet".
+       * Ask once without a hold to paint what exists, then settle into holds.
+       */
+      let holdThisPass = false;
+
       while (!stoppedRef.current) {
         if (document.hidden) {
           await sleep(GAP_MS);
@@ -110,9 +122,10 @@ export function useMessagePolling(conversationId?: string) {
           const result = await pollMessages({
             conversationId,
             since: cursorRef.current,
-            waitMs: HOLD_MS,
+            waitMs: holdThisPass ? HOLD_MS : undefined,
             signal: controller.signal,
           });
+          holdThisPass = true;
           if (stoppedRef.current) return;
           applyResult(result);
           await sleep(GAP_MS);

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
@@ -65,6 +65,8 @@ export function useMessagePolling(conversationId?: string) {
   const cursorRef = useRef<string | undefined>(undefined);
   const abortRef = useRef<AbortController | undefined>(undefined);
   const stoppedRef = useRef(false);
+  /** Ends the current wait early. Set only while the loop is between polls. */
+  const cutSleepShortRef = useRef<(() => void) | null>(null);
 
   const applyResult = useCallback(
     (result: Awaited<ReturnType<typeof pollMessages>>) => {
@@ -112,8 +114,24 @@ export function useMessagePolling(conversationId?: string) {
       loading: Boolean(conversationId),
     });
 
+    /*
+     * Interruptible, because the background wait is a minute long.
+     *
+     * Coming back to the tab used to fire a one-off catch-up while the loop
+     * itself stayed asleep, so the next held poll could be up to a minute
+     * away — a message written ten seconds after somebody returned would not
+     * arrive until the interval that started while they were gone ran out.
+     */
     const sleep = (ms: number) =>
-      new Promise((resolve) => setTimeout(resolve, ms));
+      new Promise<void>((resolve) => {
+        const finish = () => {
+          clearTimeout(timer);
+          cutSleepShortRef.current = null;
+          resolve();
+        };
+        const timer = setTimeout(finish, ms);
+        cutSleepShortRef.current = finish;
+      });
 
     const loop = async () => {
       /*
@@ -161,13 +179,18 @@ export function useMessagePolling(conversationId?: string) {
     void loop();
 
     const onVisibilityChange = () => {
-      if (!document.hidden) void runPoll();
+      if (document.hidden) return;
+      // Catch up now, and let the loop stop waiting so its next pass holds a
+      // connection open again rather than finishing a background interval.
+      void runPoll();
+      cutSleepShortRef.current?.();
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
       stoppedRef.current = true;
       abortRef.current?.abort();
+      cutSleepShortRef.current?.();
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [conversationId, applyResult, runPoll]);

--- a/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useMessagePolling.ts
@@ -15,6 +15,18 @@ const HOLD_MS = 25_000;
 /** Breather between holds, so a server answering instantly cannot spin. */
 const GAP_MS = 500;
 
+/**
+ * Poll rate while the tab is in the background.
+ *
+ * Backgrounded tabs used to stop asking altogether, which meant nothing could
+ * tell you a message had arrived while you were somewhere else — the one
+ * moment being told is worth anything. A plain request a minute costs about
+ * fifteen requests a minute across the whole shop and keeps the badge, the
+ * ping and the desktop notification alive without holding a connection open
+ * for a tab nobody is looking at.
+ */
+const BACKGROUND_GAP_MS = 60_000;
+
 /** Backoff after a failure, so an outage is not hammered. */
 const ERROR_BACKOFF_MS = 5_000;
 
@@ -29,10 +41,12 @@ interface PollingState {
  * Every bit of transport for messaging lives here, so components only ever see
  * an accumulated message list.
  *
- * Polling stops entirely while the tab is hidden — a window left open
- * overnight is what turns a reasonable number of requests into a silly one —
- * and resumes with an immediate catch-up when someone comes back, rather than
- * making them wait out a hold that started before they left.
+ * A tab in front holds a request open, so a message appears the moment it is
+ * written. A tab in the background drops to one plain request a minute — cheap
+ * enough for a window left open overnight, but still enough to raise the
+ * badge, the ping and the desktop notification while somebody is working
+ * somewhere else. Coming back polls immediately rather than making them wait
+ * out an interval that started before they left.
  */
 export function useMessagePolling(conversationId?: string) {
   const [state, setState] = useState<PollingState>({
@@ -110,10 +124,9 @@ export function useMessagePolling(conversationId?: string) {
       let holdThisPass = false;
 
       while (!stoppedRef.current) {
-        if (document.hidden) {
-          await sleep(GAP_MS);
-          continue;
-        }
+        // Read once per pass: whether the tab is in front decides both how the
+        // request is made and how long to wait before the next one.
+        const backgrounded = document.hidden;
 
         const controller = new AbortController();
         abortRef.current = controller;
@@ -122,13 +135,14 @@ export function useMessagePolling(conversationId?: string) {
           const result = await pollMessages({
             conversationId,
             since: cursorRef.current,
-            waitMs: holdThisPass ? HOLD_MS : undefined,
+            // Never hold a connection open for a tab nobody is looking at.
+            waitMs: backgrounded || !holdThisPass ? undefined : HOLD_MS,
             signal: controller.signal,
           });
           holdThisPass = true;
           if (stoppedRef.current) return;
           applyResult(result);
-          await sleep(GAP_MS);
+          await sleep(backgrounded ? BACKGROUND_GAP_MS : GAP_MS);
         } catch {
           if (stoppedRef.current || controller.signal.aborted) return;
           // A failed poll is not worth interrupting anyone over. Back off and

--- a/apps/webApp/src/app/components/messaging/hooks/useViewportFill.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useViewportFill.ts
@@ -89,5 +89,5 @@ export function useViewportFill<T extends HTMLElement>({
     };
   }, [enabled, measure]);
 
-  return { ref, height, remeasure: measure };
+  return { ref, height };
 }

--- a/apps/webApp/src/app/components/messaging/hooks/useViewportFill.ts
+++ b/apps/webApp/src/app/components/messaging/hooks/useViewportFill.ts
@@ -1,0 +1,93 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+interface Options {
+  /** Never shrink below this, however little room is left. */
+  min?: number;
+  /** Breathing room between the bottom of the panel and the bottom of the screen. */
+  gap?: number;
+  /** Skip the work entirely when the panel is sized by its parent instead. */
+  enabled?: boolean;
+}
+
+/**
+ * Sizes an element to run from wherever it sits down to the bottom of the
+ * screen.
+ *
+ * A chat panel with a height picked in advance is wrong on every device but
+ * the one it was picked on. At 480px under a tall repair-order header it put
+ * the composer below the fold on a phone: the thread looked like a read-only
+ * list of messages with no way to write one, and you had to know to scroll to
+ * find out otherwise. Measuring means the input is on screen to begin with,
+ * whatever is above it.
+ *
+ * Measured on mount and on resize, but deliberately **not** on scroll — the
+ * element's distance from the top of the viewport changes as the page moves,
+ * and following that would resize the panel continuously while you read.
+ *
+ * `visualViewport` rather than `innerHeight` is what handles a phone keyboard:
+ * opening one shrinks the visual viewport, so the panel shortens and the
+ * composer stays above the keys instead of behind them.
+ */
+export function useViewportFill<T extends HTMLElement>({
+  min = 320,
+  gap = 12,
+  enabled = true,
+}: Options = {}) {
+  const ref = useRef<T | null>(null);
+  const [height, setHeight] = useState<number | undefined>(undefined);
+
+  const measure = useCallback(() => {
+    const node = ref.current;
+    if (!node || !enabled) return;
+
+    const viewport = window.visualViewport?.height ?? window.innerHeight;
+    // Clamped at zero: once the panel's top has scrolled off, the space left
+    // is the whole screen, not more than it.
+    const top = Math.max(0, node.getBoundingClientRect().top);
+
+    setHeight(Math.max(min, Math.round(viewport - top - gap)));
+  }, [enabled, gap, min]);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setHeight(undefined);
+      return;
+    }
+
+    measure();
+
+    // One more pass after layout settles: fonts and images above the panel can
+    // land after the first measurement, and a tab that scrolls itself into
+    // view does so after its children have already measured once.
+    const settle = window.setTimeout(measure, 200);
+
+    /*
+     * Re-measure when the page stops moving, never while it moves.
+     *
+     * Following every scroll event would resize the panel continuously under
+     * whoever is reading it; ignoring scrolling altogether leaves the height
+     * wrong for good once the page has moved. Waiting for the pause is both.
+     */
+    let idle = 0;
+    const onScroll = () => {
+      window.clearTimeout(idle);
+      idle = window.setTimeout(measure, 180);
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', measure);
+    window.addEventListener('orientationchange', measure);
+    window.visualViewport?.addEventListener('resize', measure);
+
+    return () => {
+      window.clearTimeout(settle);
+      window.clearTimeout(idle);
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('orientationchange', measure);
+      window.visualViewport?.removeEventListener('resize', measure);
+    };
+  }, [enabled, measure]);
+
+  return { ref, height, remeasure: measure };
+}

--- a/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
+++ b/apps/webApp/src/app/pages/repair-orders/RODetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { MessageThread } from '../../components/messaging/MessageThread';
 import {
@@ -2060,7 +2060,7 @@ function HistoryTab({ ro, baseRoute }: { ro: RepairOrder; baseRoute: string }) {
   );
 }
 
-// ---- Chat tab (placeholder) ----
+// ---- Chat tab ----
 
 function ChatTab({
   roId,
@@ -2071,13 +2071,33 @@ function ChatTab({
   currentUserId: string;
   isAdmin: boolean;
 }) {
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  /*
+   * Bring the panel to the top of the screen when the tab is opened.
+   *
+   * Everything above it — header, status cards, tab bar — is a screenful on a
+   * phone, so the thread opened below the fold and the composer was off it
+   * entirely. Scrolling to the panel first also gives MessageThread a stable
+   * top to measure its height from.
+   */
+  useEffect(() => {
+    // Instant, not smooth: the panel measures the room left below itself, and
+    // a scroll still animating when it measures leaves it sized for wherever
+    // the page happened to be.
+    anchorRef.current?.scrollIntoView({ block: 'start' });
+  }, []);
+
   return (
-    <MessageThread
-      entityType="REPAIR_ORDER"
-      entityId={roId}
-      currentUserId={currentUserId}
-      isAdmin={isAdmin}
-    />
+    <Box ref={anchorRef} sx={{ scrollMarginTop: 8 }}>
+      <MessageThread
+        entityType="REPAIR_ORDER"
+        entityId={roId}
+        currentUserId={currentUserId}
+        isAdmin={isAdmin}
+        fillViewport
+      />
+    </Box>
   );
 }
 

--- a/apps/webApp/src/app/requests/messaging.requests.ts
+++ b/apps/webApp/src/app/requests/messaging.requests.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import type {
   ConversationDto,
+  MessagePageDto,
   MentionInboxItemDto,
   MentionableUserDto,
   MessageDto,
@@ -72,6 +73,24 @@ export async function getEntityThread(
 export async function getGeneralThread(): Promise<ConversationDto> {
   const { data } = await apiClient.get<ConversationDto>(
     '/messaging/conversations/general'
+  );
+  return data;
+}
+
+/**
+ * The page before what is already on screen.
+ *
+ * `before` is the `createdAt` of the oldest message held, echoed back from the
+ * server's own value rather than a browser clock — same rule as the poll
+ * cursor, for the same reason.
+ */
+export async function getEarlierMessages(
+  conversationId: string,
+  before: string
+): Promise<MessagePageDto> {
+  const { data } = await apiClient.get<MessagePageDto>(
+    `/messaging/conversations/${conversationId}/messages`,
+    { params: { before } }
   );
   return data;
 }

--- a/libs/data/src/lib/message.dto.ts
+++ b/libs/data/src/lib/message.dto.ts
@@ -44,6 +44,16 @@ export class UpdateMessageDto {
   body!: string;
 }
 
+/** Query for a page of messages older than the ones already on screen. */
+export class OlderMessagesQueryDto {
+  /**
+   * `createdAt` of the oldest message the caller already holds. Everything
+   * strictly before it comes back, newest first, one page at a time.
+   */
+  @IsISO8601()
+  before!: string;
+}
+
 /** Query for the single poll endpoint. */
 export class PollQueryDto {
   /** Thread currently open, if any. Counts come back either way. */
@@ -149,6 +159,14 @@ export interface PollResponseDto {
   unreadMentions: number;
   conversationUnreads: Record<string, number>;
   /**
+   * Whether the thread has messages older than the ones in `messages`.
+   *
+   * Present only on the first poll of a conversation, which is the one that
+   * returns a window rather than everything since a cursor. Later polls leave
+   * it undefined and the client keeps what it had.
+   */
+  hasOlderMessages?: boolean;
+  /**
    * Every unread message, counted once.
    *
    * Not the sum of the two fields above: a message that tags you is both an
@@ -159,6 +177,12 @@ export interface PollResponseDto {
   unreadTotal: number;
   /** Send this back as `since` on the next poll. */
   serverTime: string;
+}
+
+/** A page of older messages, oldest first, plus whether more remain behind it. */
+export interface MessagePageDto {
+  messages: MessageDto[];
+  hasOlder: boolean;
 }
 
 export interface MentionableUserDto {

--- a/libs/data/src/lib/message.dto.ts
+++ b/libs/data/src/lib/message.dto.ts
@@ -148,6 +148,15 @@ export interface PollResponseDto {
   messages: MessageDto[];
   unreadMentions: number;
   conversationUnreads: Record<string, number>;
+  /**
+   * Every unread message, counted once.
+   *
+   * Not the sum of the two fields above: a message that tags you is both an
+   * unread mention and an unread message in its conversation, so adding them
+   * showed two of everything. Derived server-side because only the server can
+   * see which mentions sit in threads the reader has never opened.
+   */
+  unreadTotal: number;
   /** Send this back as `since` on the next poll. */
   serverTime: string;
 }

--- a/server/src/messaging/message-events.service.spec.ts
+++ b/server/src/messaging/message-events.service.spec.ts
@@ -15,6 +15,7 @@ describe('MessageEventsService', () => {
     events.publish({
       conversationId: 'conv-1',
       mentionedUserIds: [],
+      visibility: 'PUBLIC' as const,
       authorId: 'someone-else',
       ...overrides,
     });
@@ -31,7 +32,11 @@ describe('MessageEventsService', () => {
   // is a private message you are not part of.
   it('does not wake for a private message you are not in', async () => {
     const waiting = events.waitForMessage('sarah-1', 60);
-    publish({ conversationId: 'conv-2', mentionedUserIds: ['mike-1'] });
+    publish({
+      conversationId: 'conv-2',
+      mentionedUserIds: ['mike-1'],
+      visibility: 'MENTIONED_ONLY',
+    });
 
     await expect(waiting).resolves.toBe(false);
   });
@@ -40,14 +45,22 @@ describe('MessageEventsService', () => {
   // something else — that is the whole point of the mentions badge.
   it('wakes a tagged user with no thread open', async () => {
     const waiting = events.waitForMessage('sarah-1', 1000);
-    publish({ conversationId: 'conv-9', mentionedUserIds: ['sarah-1'] });
+    publish({
+      conversationId: 'conv-9',
+      mentionedUserIds: ['sarah-1'],
+      visibility: 'MENTIONED_ONLY',
+    });
 
     await expect(waiting).resolves.toBe(true);
   });
 
   it('does not wake someone who was not tagged', async () => {
     const waiting = events.waitForMessage('mike-1', 60);
-    publish({ conversationId: 'conv-9', mentionedUserIds: ['sarah-1'] });
+    publish({
+      conversationId: 'conv-9',
+      mentionedUserIds: ['sarah-1'],
+      visibility: 'MENTIONED_ONLY',
+    });
 
     await expect(waiting).resolves.toBe(false);
   });
@@ -128,7 +141,28 @@ describe('MessageEventsService', () => {
     // people tagged in it, which the poll re-checks after any wake-up.
     it('does not widen who a private message wakes', async () => {
       const waiting = events.waitForMessage('mike-1', 60);
-      publish({ conversationId: 'conv-1', mentionedUserIds: ['sarah-1'] });
+      publish({
+        conversationId: 'conv-1',
+        mentionedUserIds: ['sarah-1'],
+        visibility: 'MENTIONED_ONLY',
+      });
+
+      await expect(waiting).resolves.toBe(false);
+    });
+
+    /*
+     * A message tagging nobody but its own author is stored MENTIONED_ONLY
+     * with an empty audience — the author is taken out of their own mention
+     * list. Reading "public" off that empty list woke the whole shop for a
+     * message only one person can see.
+     */
+    it('does not wake anyone for a note somebody tagged themselves in', async () => {
+      const waiting = events.waitForMessage('mike-1', 60);
+      publish({
+        conversationId: 'conv-1',
+        mentionedUserIds: [],
+        visibility: 'MENTIONED_ONLY',
+      });
 
       await expect(waiting).resolves.toBe(false);
     });
@@ -142,7 +176,11 @@ describe('MessageEventsService', () => {
      */
     it('does not wake a bystander watching the thread it lands in', async () => {
       const waiting = events.waitForMessage('admin-1', 60);
-      publish({ conversationId: 'conv-1', mentionedUserIds: ['sarah-1'] });
+      publish({
+        conversationId: 'conv-1',
+        mentionedUserIds: ['sarah-1'],
+        visibility: 'MENTIONED_ONLY',
+      });
 
       await expect(waiting).resolves.toBe(false);
     });

--- a/server/src/messaging/message-events.service.spec.ts
+++ b/server/src/messaging/message-events.service.spec.ts
@@ -19,8 +19,8 @@ describe('MessageEventsService', () => {
       ...overrides,
     });
 
-  it('wakes a reader when a message lands in the thread they have open', async () => {
-    const waiting = events.waitForMessage('sarah-1', 'conv-1', 1000);
+  it('wakes a reader when a public message lands', async () => {
+    const waiting = events.waitForMessage('sarah-1', 1000);
     publish({});
 
     await expect(waiting).resolves.toBe(true);
@@ -29,8 +29,8 @@ describe('MessageEventsService', () => {
   // A public message in another thread does wake you, deliberately: it moves
   // your unread count, which is the badge's whole job. What must not wake you
   // is a private message you are not part of.
-  it('does not wake for a private message in a different thread', async () => {
-    const waiting = events.waitForMessage('sarah-1', 'conv-1', 60);
+  it('does not wake for a private message you are not in', async () => {
+    const waiting = events.waitForMessage('sarah-1', 60);
     publish({ conversationId: 'conv-2', mentionedUserIds: ['mike-1'] });
 
     await expect(waiting).resolves.toBe(false);
@@ -39,35 +39,33 @@ describe('MessageEventsService', () => {
   // A tagged message must reach its target even when they are looking at
   // something else — that is the whole point of the mentions badge.
   it('wakes a tagged user with no thread open', async () => {
-    const waiting = events.waitForMessage('sarah-1', undefined, 1000);
+    const waiting = events.waitForMessage('sarah-1', 1000);
     publish({ conversationId: 'conv-9', mentionedUserIds: ['sarah-1'] });
 
     await expect(waiting).resolves.toBe(true);
   });
 
-  it('does not wake someone who was not tagged, in a thread they are not in', async () => {
-    const waiting = events.waitForMessage('mike-1', undefined, 60);
+  it('does not wake someone who was not tagged', async () => {
+    const waiting = events.waitForMessage('mike-1', 60);
     publish({ conversationId: 'conv-9', mentionedUserIds: ['sarah-1'] });
 
     await expect(waiting).resolves.toBe(false);
   });
 
   it('does not wake the author for their own message', async () => {
-    const waiting = events.waitForMessage('sarah-1', 'conv-1', 60);
+    const waiting = events.waitForMessage('sarah-1', 60);
     publish({ authorId: 'sarah-1' });
 
     await expect(waiting).resolves.toBe(false);
   });
 
   it('resolves false once the wait elapses', async () => {
-    await expect(events.waitForMessage('sarah-1', 'conv-1', 40)).resolves.toBe(
-      false
-    );
+    await expect(events.waitForMessage('sarah-1', 40)).resolves.toBe(false);
   });
 
-  it('wakes every reader of the same thread', async () => {
-    const first = events.waitForMessage('sarah-1', 'conv-1', 1000);
-    const second = events.waitForMessage('mike-1', 'conv-1', 1000);
+  it('wakes every reader of a public message', async () => {
+    const first = events.waitForMessage('sarah-1', 1000);
+    const second = events.waitForMessage('mike-1', 1000);
     publish({});
 
     await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
@@ -75,17 +73,17 @@ describe('MessageEventsService', () => {
 
   // A held request that left its listener behind would leak one per poll.
   it('removes its listener whether it wakes or times out', async () => {
-    const woken = events.waitForMessage('sarah-1', 'conv-1', 1000);
+    const woken = events.waitForMessage('sarah-1', 1000);
     publish({});
     await woken;
 
-    await events.waitForMessage('sarah-1', 'other', 30);
+    await events.waitForMessage('sarah-1', 30);
 
     expect(events['emitter'].listenerCount('message')).toBe(0);
   });
 
   it('settles only once when several messages arrive', async () => {
-    const waiting = events.waitForMessage('sarah-1', 'conv-1', 1000);
+    const waiting = events.waitForMessage('sarah-1', 1000);
     publish({});
     publish({});
     publish({});
@@ -102,21 +100,21 @@ describe('MessageEventsService', () => {
    */
   describe('public messages', () => {
     it('wakes a reader with no thread open', async () => {
-      const waiting = events.waitForMessage('sarah-1', undefined, 1000);
+      const waiting = events.waitForMessage('sarah-1', 1000);
       publish({ conversationId: 'general-1', mentionedUserIds: [] });
 
       await expect(waiting).resolves.toBe(true);
     });
 
-    it('wakes a reader sitting in a different thread', async () => {
-      const waiting = events.waitForMessage('sarah-1', 'conv-9', 1000);
+    it('wakes a reader sitting in another thread', async () => {
+      const waiting = events.waitForMessage('sarah-1', 1000);
       publish({ conversationId: 'general-1', mentionedUserIds: [] });
 
       await expect(waiting).resolves.toBe(true);
     });
 
     it('still does not wake the author of it', async () => {
-      const waiting = events.waitForMessage('sarah-1', undefined, 60);
+      const waiting = events.waitForMessage('sarah-1', 60);
       publish({
         conversationId: 'general-1',
         mentionedUserIds: [],
@@ -129,7 +127,21 @@ describe('MessageEventsService', () => {
     // Waking is not reading: a private message must still only reach the
     // people tagged in it, which the poll re-checks after any wake-up.
     it('does not widen who a private message wakes', async () => {
-      const waiting = events.waitForMessage('mike-1', undefined, 60);
+      const waiting = events.waitForMessage('mike-1', 60);
+      publish({ conversationId: 'conv-1', mentionedUserIds: ['sarah-1'] });
+
+      await expect(waiting).resolves.toBe(false);
+    });
+
+    /*
+     * Sitting in the thread used to be enough to be woken by a private message
+     * in it. The poll then returned nothing, so no content leaked — but the
+     * early return still told an outsider that something had just been said
+     * where they could not see it. An admin watching shop chat is exactly the
+     * case that made this worth closing.
+     */
+    it('does not wake a bystander watching the thread it lands in', async () => {
+      const waiting = events.waitForMessage('admin-1', 60);
       publish({ conversationId: 'conv-1', mentionedUserIds: ['sarah-1'] });
 
       await expect(waiting).resolves.toBe(false);

--- a/server/src/messaging/message-events.service.ts
+++ b/server/src/messaging/message-events.service.ts
@@ -5,6 +5,14 @@ export interface MessageEvent {
   conversationId: string;
   /** Who the message was made private to, if anyone. */
   mentionedUserIds: string[];
+  /**
+   * As stored on the message, not inferred from the audience.
+   *
+   * They part company on a message that tags only its own author: the row is
+   * MENTIONED_ONLY, but the audience is empty once the author is removed from
+   * it, so an empty list read as "public" and woke the whole shop.
+   */
+  visibility: 'PUBLIC' | 'MENTIONED_ONLY';
   /** Excluded from their own wake-up: they already have the message. */
   authorId: string;
 }
@@ -67,7 +75,7 @@ export class MessageEventsService implements OnModuleDestroy {
         // An untagged message is visible to everybody, so it moves everybody's
         // unread count — including people with no thread open, which is the
         // whole reason the badge exists.
-        const isPublic = event.mentionedUserIds.length === 0;
+        const isPublic = event.visibility === 'PUBLIC';
 
         // Only readers the message actually reaches. Having the thread open
         // used to be enough on its own, which meant a private message returned

--- a/server/src/messaging/message-events.service.ts
+++ b/server/src/messaging/message-events.service.ts
@@ -47,11 +47,7 @@ export class MessageEventsService implements OnModuleDestroy {
    * re-queries through the visibility filter afterwards, so a wake-up can
    * never itself disclose anything.
    */
-  waitForMessage(
-    userId: string,
-    conversationId: string | undefined,
-    timeoutMs: number
-  ): Promise<boolean> {
+  waitForMessage(userId: string, timeoutMs: number): Promise<boolean> {
     return new Promise((resolve) => {
       let settled = false;
 
@@ -66,19 +62,19 @@ export class MessageEventsService implements OnModuleDestroy {
       const onMessage = (event: MessageEvent) => {
         if (event.authorId === userId) return;
 
-        const inOpenThread =
-          conversationId !== undefined &&
-          event.conversationId === conversationId;
         const tagsMe = event.mentionedUserIds.includes(userId);
 
         // An untagged message is visible to everybody, so it moves everybody's
         // unread count — including people with no thread open, which is the
-        // whole reason the badge exists. Waking on it is not a disclosure: the
-        // poll still re-queries through the visibility filter, and a reader who
-        // gained nothing simply gets the counts they already had.
+        // whole reason the badge exists.
         const isPublic = event.mentionedUserIds.length === 0;
 
-        if (inOpenThread || tagsMe || isPublic) finish(true);
+        // Only readers the message actually reaches. Having the thread open
+        // used to be enough on its own, which meant a private message returned
+        // an empty poll early to everyone watching that thread — no content,
+        // but a reliable "something just happened in here" they were not part
+        // of. Nobody outside the audience should learn even that much.
+        if (tagsMe || isPublic) finish(true);
       };
 
       const timer = setTimeout(() => finish(false), timeoutMs);

--- a/server/src/messaging/messaging.controller.ts
+++ b/server/src/messaging/messaging.controller.ts
@@ -12,6 +12,7 @@ import {
 import {
   CreateMessageDto,
   MentionSearchDto,
+  OlderMessagesQueryDto,
   PollQueryDto,
   UpdateMessageDto,
 } from '@gt-automotive/data';
@@ -64,6 +65,21 @@ export class MessagingController {
     @Param('entityId') entityId: string
   ) {
     return this.messaging.getEntityConversation(entityType, entityId, user.id);
+  }
+
+  /**
+   * A page of a thread older than what the caller already has on screen.
+   *
+   * Opening a conversation returns a window rather than its whole history, so
+   * this is how somebody reads back through it.
+   */
+  @Get('conversations/:id/messages')
+  older(
+    @CurrentUser() user: MessagingUser,
+    @Param('id') conversationId: string,
+    @Query() query: OlderMessagesQueryDto
+  ) {
+    return this.messaging.getOlderMessages(conversationId, user, query.before);
   }
 
   @Post('conversations/:id/messages')

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -101,6 +101,12 @@ describe('MessagingService', () => {
     messages = {
       findByIdForUser: jest.fn(),
       findForConversation: jest.fn().mockResolvedValue([]),
+      findRecentForConversation: jest
+        .fn()
+        .mockResolvedValue({ messages: [], hasOlder: false }),
+      findOlderForConversation: jest
+        .fn()
+        .mockResolvedValue({ messages: [], hasOlder: false }),
       countUnreadMentions: jest.fn().mockResolvedValue(0),
       unreadCountsByConversation: jest.fn().mockResolvedValue({}),
       countUnreadMentionsOutsideMemberships: jest.fn().mockResolvedValue(0),
@@ -413,10 +419,45 @@ describe('MessagingService', () => {
       expect(result.unreadTotal).toBe(3);
     });
 
+    /*
+     * Shop chat is never purged, so "every message in this conversation" is a
+     * read that grows for as long as the shop exists. Opening one takes a
+     * window; only the incremental polls after it follow the cursor.
+     */
+    it('opens a thread with a window, not its whole history', async () => {
+      (messages.findRecentForConversation as jest.Mock).mockResolvedValue({
+        messages: [messageRow()],
+        hasOlder: true,
+      });
+
+      const result = await service.poll(author, 'conv-1');
+
+      expect(messages.findRecentForConversation).toHaveBeenCalledWith(
+        'conv-1',
+        author
+      );
+      expect(messages.findForConversation).not.toHaveBeenCalled();
+      expect(result.hasOlderMessages).toBe(true);
+    });
+
+    it('follows the cursor once the client has one, and says nothing about history', async () => {
+      const result = await service.poll(
+        author,
+        'conv-1',
+        '2026-08-20T17:00:00.000Z'
+      );
+
+      expect(messages.findForConversation).toHaveBeenCalled();
+      expect(messages.findRecentForConversation).not.toHaveBeenCalled();
+      // Undefined, not false — a cursor poll must not clear the client's flag.
+      expect(result.hasOlderMessages).toBeUndefined();
+    });
+
     it('emits createdAt as a real instant, not a business date', async () => {
-      (messages.findForConversation as jest.Mock).mockResolvedValue([
-        messageRow(),
-      ]);
+      (messages.findRecentForConversation as jest.Mock).mockResolvedValue({
+        messages: [messageRow()],
+        hasOlder: false,
+      });
 
       const result = await service.poll(author, 'conv-1');
 
@@ -432,9 +473,10 @@ describe('MessagingService', () => {
     });
 
     it('does not hold when there is already something to return', async () => {
-      (messages.findForConversation as jest.Mock).mockResolvedValue([
-        messageRow(),
-      ]);
+      (messages.findRecentForConversation as jest.Mock).mockResolvedValue({
+        messages: [messageRow()],
+        hasOlder: false,
+      });
 
       await service.poll(author, 'conv-1', undefined, 25_000);
 
@@ -458,13 +500,13 @@ describe('MessagingService', () => {
     // Waking says something happened, not that this user may read it.
     it('re-queries through the visibility filter after waking', async () => {
       events.waitForMessage.mockResolvedValue(true);
-      (messages.findForConversation as jest.Mock)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([messageRow()]);
+      (messages.findRecentForConversation as jest.Mock)
+        .mockResolvedValueOnce({ messages: [], hasOlder: false })
+        .mockResolvedValueOnce({ messages: [messageRow()], hasOlder: false });
 
       const result = await service.poll(author, 'conv-1', undefined, 25_000);
 
-      expect(messages.findForConversation).toHaveBeenCalledTimes(2);
+      expect(messages.findRecentForConversation).toHaveBeenCalledTimes(2);
       expect(result.messages).toHaveLength(1);
     });
 
@@ -475,13 +517,13 @@ describe('MessagingService', () => {
      */
     it('re-queries on timeout rather than returning the pre-wait answer', async () => {
       events.waitForMessage.mockResolvedValue(false);
-      (messages.findForConversation as jest.Mock)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([messageRow()]);
+      (messages.findRecentForConversation as jest.Mock)
+        .mockResolvedValueOnce({ messages: [], hasOlder: false })
+        .mockResolvedValueOnce({ messages: [messageRow()], hasOlder: false });
 
       const result = await service.poll(author, 'conv-1', undefined, 25_000);
 
-      expect(messages.findForConversation).toHaveBeenCalledTimes(2);
+      expect(messages.findRecentForConversation).toHaveBeenCalledTimes(2);
       expect(result.messages).toHaveLength(1);
     });
   });
@@ -506,6 +548,40 @@ describe('MessagingService', () => {
       expect(events.publish).toHaveBeenCalledWith(
         expect.objectContaining({ mentionedUserIds: [], visibility: 'PUBLIC' })
       );
+    });
+  });
+
+  describe('reading back through a thread', () => {
+    it('returns the page before what the caller holds, and whether more remain', async () => {
+      (messages.findOlderForConversation as jest.Mock).mockResolvedValue({
+        messages: [messageRow()],
+        hasOlder: true,
+      });
+
+      const result = await service.getOlderMessages(
+        'conv-1',
+        author,
+        '2026-08-20T17:00:00.000Z'
+      );
+
+      expect(messages.findOlderForConversation).toHaveBeenCalledWith(
+        'conv-1',
+        author,
+        new Date('2026-08-20T17:00:00.000Z')
+      );
+      expect(result.messages).toHaveLength(1);
+      expect(result.hasOlder).toBe(true);
+    });
+
+    // Not a way into a conversation somebody could not otherwise open.
+    it('checks membership the same way the poll does', async () => {
+      await service.getOlderMessages(
+        'conv-1',
+        author,
+        '2026-08-20T17:00:00.000Z'
+      );
+
+      expect(prisma.conversationMember.upsert).toHaveBeenCalled();
     });
   });
 

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -103,6 +103,7 @@ describe('MessagingService', () => {
       findForConversation: jest.fn().mockResolvedValue([]),
       countUnreadMentions: jest.fn().mockResolvedValue(0),
       unreadCountsByConversation: jest.fn().mockResolvedValue({}),
+      countUnreadMentionsOutsideMemberships: jest.fn().mockResolvedValue(0),
     };
 
     events = {
@@ -343,6 +344,43 @@ describe('MessagingService', () => {
 
       expect(result.unreadMentions).toBe(3);
       expect(messages.findForConversation).not.toHaveBeenCalled();
+    });
+
+    /*
+     * A message that tags you is both an unread mention and an unread message
+     * in its conversation. Adding the two fields showed two of everything on
+     * the badge, so the total is counted here instead: once per conversation,
+     * plus the tags waiting in threads this reader has never opened and so has
+     * no membership in.
+     */
+    it('counts each unread message once, not once per reason', async () => {
+      (messages.countUnreadMentions as jest.Mock).mockResolvedValue(2);
+      (messages.unreadCountsByConversation as jest.Mock).mockResolvedValue({
+        'conv-1': 2,
+        'conv-2': 1,
+      });
+      (
+        messages.countUnreadMentionsOutsideMemberships as jest.Mock
+      ).mockResolvedValue(0);
+
+      const result = await service.poll(author);
+
+      expect(result.unreadTotal).toBe(3);
+    });
+
+    it('adds tags waiting in threads the reader has never opened', async () => {
+      (messages.unreadCountsByConversation as jest.Mock).mockResolvedValue({
+        'conv-1': 1,
+      });
+      (
+        messages.countUnreadMentionsOutsideMemberships as jest.Mock
+      ).mockResolvedValue(2);
+
+      const result = await service.poll(author);
+
+      // Those two have no membership to be counted against, and they are the
+      // whole point of the mention badge.
+      expect(result.unreadTotal).toBe(3);
     });
 
     it('emits createdAt as a real instant, not a business date', async () => {

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -268,6 +268,36 @@ describe('MessagingService', () => {
         service.updateMessage('msg-1', author, 'edited')
       ).rejects.toThrow(ForbiddenException);
     });
+
+    /*
+     * A reply must not gain an audience by losing the message it answers.
+     *
+     * The parent is read back through the visibility filter, which excludes
+     * soft-deleted rows — so once somebody deleted the private message that
+     * started the thread, fixing a typo on the reply re-derived it as public
+     * and put it in front of the whole shop.
+     */
+    it('keeps a private reply private when its parent has been deleted', async () => {
+      (messages.findByIdForUser as jest.Mock).mockImplementation((id: string) =>
+        Promise.resolve(
+          id === 'msg-1'
+            ? messageRow({
+                id: 'msg-1',
+                authorId: author.id,
+                parentMessageId: 'parent-1',
+                visibility: 'MENTIONED_ONLY',
+                mentions: [{ userId: 'sarah-1', user: {} }],
+              })
+            : // The parent is soft-deleted, so the filtered read finds nothing.
+              null
+        )
+      );
+
+      await service.updateMessage('msg-1', author, 'calling them back now');
+
+      expect(createdMessage.visibility).toBe('MENTIONED_ONLY');
+      expect(createdMessage.mentions.create).toEqual([{ userId: 'sarah-1' }]);
+    });
   });
 
   describe('deleting', () => {

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -463,6 +463,9 @@ describe('MessagingService', () => {
       expect(events.publish).toHaveBeenCalledWith({
         conversationId: 'conv-1',
         mentionedUserIds: ['sarah-1'],
+        // Carried so the wake predicate reads the visibility the row was
+        // stored with rather than guessing it from an empty audience.
+        visibility: 'MENTIONED_ONLY',
         authorId: author.id,
       });
     });
@@ -471,7 +474,7 @@ describe('MessagingService', () => {
       await send('rear brakes done');
 
       expect(events.publish).toHaveBeenCalledWith(
-        expect.objectContaining({ mentionedUserIds: [] })
+        expect.objectContaining({ mentionedUserIds: [], visibility: 'PUBLIC' })
       );
     });
   });

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -294,7 +294,12 @@ describe('MessagingService', () => {
       );
     });
 
-    it('lets an admin delete anyone’s message', async () => {
+    /*
+     * Delete reach is bounded by what the admin can read: findByIdForUser
+     * applies the visibility filter, so a private message they are not part of
+     * never gets this far — it 404s instead.
+     */
+    it('lets an admin delete any message they can see', async () => {
       (messages.findByIdForUser as jest.Mock).mockResolvedValue(
         messageRow({ authorId: 'mike-1' })
       );
@@ -371,11 +376,7 @@ describe('MessagingService', () => {
     it('holds when there is nothing new', async () => {
       await service.poll(author, 'conv-1', undefined, 25_000);
 
-      expect(events.waitForMessage).toHaveBeenCalledWith(
-        author.id,
-        'conv-1',
-        25_000
-      );
+      expect(events.waitForMessage).toHaveBeenCalledWith(author.id, 25_000);
     });
 
     // The proxy in front of this gives up at 30s, so a longer hold would
@@ -383,11 +384,7 @@ describe('MessagingService', () => {
     it('caps the hold below the reverse proxy timeout', async () => {
       await service.poll(author, 'conv-1', undefined, 120_000);
 
-      expect(events.waitForMessage).toHaveBeenCalledWith(
-        author.id,
-        'conv-1',
-        25_000
-      );
+      expect(events.waitForMessage).toHaveBeenCalledWith(author.id, 25_000);
     });
 
     // Waking says something happened, not that this user may read it.

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -285,7 +285,8 @@ export class MessagingService {
 
     // An edit re-derives visibility from the new body, so removing the last
     // mention makes a message public. Editing a reply cannot widen it, though:
-    // the inherited floor is recomputed from the parent, same as on create.
+    // the inherited floor comes from the parent, same as on create, and from
+    // what was stored if the parent has since been deleted.
     let visibility: MessageVisibility =
       audience.size > 0 ? 'MENTIONED_ONLY' : 'PUBLIC';
 
@@ -294,10 +295,22 @@ export class MessagingService {
         existing.parentMessageId,
         user
       );
+
       if (parent?.visibility === 'MENTIONED_ONLY') {
         visibility = 'MENTIONED_ONLY';
         parent.mentions.forEach((m) => audience.add(m.userId));
         audience.add(parent.authorId);
+        audience.delete(user.id);
+      } else if (!parent && existing.visibility === 'MENTIONED_ONLY') {
+        /*
+         * The parent is gone — soft-deleted, so the filtered read cannot see
+         * it any more. A reply must not gain an audience by losing the message
+         * it answers: without this, fixing a typo on a private reply whose
+         * parent had been deleted republished it to the whole shop. Hold the
+         * floor from what was stored instead.
+         */
+        visibility = 'MENTIONED_ONLY';
+        existing.mentions.forEach((m) => audience.add(m.userId));
         audience.delete(user.id);
       }
     }

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -256,6 +256,7 @@ export class MessagingService {
     this.events.publish({
       conversationId,
       mentionedUserIds: [...audience],
+      visibility,
       authorId: user.id,
     });
 

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -8,6 +8,7 @@ import {
   ConversationEntity,
   CreateMessageDto,
   MessageDto,
+  MessagePageDto,
   MessageVisibility,
   PollResponseDto,
 } from '@gt-automotive/data';
@@ -100,9 +101,30 @@ export class MessagingService {
     const serverTime = new Date();
     const sinceDate = since ? new Date(since) : undefined;
 
-    const messages = conversationId
-      ? await this.messages.findForConversation(conversationId, user, sinceDate)
-      : [];
+    /*
+     * Opening a thread reads a window; every poll after it reads the cursor.
+     *
+     * The window is what keeps shop chat from returning a year of messages to
+     * anybody who opens the panel — that conversation is never purged, so it
+     * only grows.
+     */
+    let messages: MessageWithRelations[] = [];
+    let hasOlderMessages: boolean | undefined;
+
+    if (conversationId && sinceDate) {
+      messages = await this.messages.findForConversation(
+        conversationId,
+        user,
+        sinceDate
+      );
+    } else if (conversationId) {
+      const page = await this.messages.findRecentForConversation(
+        conversationId,
+        user
+      );
+      messages = page.messages;
+      hasOlderMessages = page.hasOlder;
+    }
 
     const [unreadMentions, conversationUnreads, unjoinedMentions] =
       await Promise.all([
@@ -123,7 +145,34 @@ export class MessagingService {
       unreadMentions,
       conversationUnreads,
       unreadTotal,
+      ...(hasOlderMessages === undefined ? {} : { hasOlderMessages }),
       serverTime: serverTime.toISOString(),
+    };
+  }
+
+  /**
+   * The page of a thread before what the caller already holds.
+   *
+   * Membership is checked the same way the poll checks it, so this is not a
+   * way to read a conversation you could not otherwise open — and every row
+   * still goes through the visibility filter.
+   */
+  async getOlderMessages(
+    conversationId: string,
+    user: MessagingUser,
+    before: string
+  ): Promise<MessagePageDto> {
+    await this.ensureMembership(conversationId, user.id);
+
+    const page = await this.messages.findOlderForConversation(
+      conversationId,
+      user,
+      new Date(before)
+    );
+
+    return {
+      messages: page.messages.map((m) => this.toDto(m)),
+      hasOlder: page.hasOlder,
     };
   }
 

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -81,7 +81,6 @@ export class MessagingService {
     // MessageEventsService for why that distinction matters.
     const woke = await this.events.waitForMessage(
       user.id,
-      conversationId,
       Math.min(waitMs, MAX_HOLD_MS)
     );
 

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -104,15 +104,25 @@ export class MessagingService {
       ? await this.messages.findForConversation(conversationId, user, sinceDate)
       : [];
 
-    const [unreadMentions, conversationUnreads] = await Promise.all([
-      this.messages.countUnreadMentions(user.id),
-      this.messages.unreadCountsByConversation(user),
-    ]);
+    const [unreadMentions, conversationUnreads, unjoinedMentions] =
+      await Promise.all([
+        this.messages.countUnreadMentions(user.id),
+        this.messages.unreadCountsByConversation(user),
+        this.messages.countUnreadMentionsOutsideMemberships(user.id),
+      ]);
+
+    // Each unread message once: the per-conversation counts cover everything
+    // in a thread this reader has joined, mentions included, and the rest are
+    // the tags waiting in threads they have never opened.
+    const unreadTotal =
+      Object.values(conversationUnreads).reduce((sum, n) => sum + n, 0) +
+      unjoinedMentions;
 
     return {
       messages: messages.map((m) => this.toDto(m)),
       unreadMentions,
       conversationUnreads,
+      unreadTotal,
       serverTime: serverTime.toISOString(),
     };
   }

--- a/server/src/messaging/repositories/message.repository.spec.ts
+++ b/server/src/messaging/repositories/message.repository.spec.ts
@@ -3,8 +3,8 @@ import { MessageRepository, MessagingUser } from './message.repository';
 /**
  * The visibility filter decides who can read what, so it is tested as a value
  * rather than through a query. What matters is the shape of the clause handed
- * to Prisma — if it is ever `{}` for a non-admin, every private message in the
- * shop becomes readable.
+ * to Prisma — if it is ever `{}`, every private message in the shop becomes
+ * readable.
  */
 describe('MessageRepository.visibilityFilter', () => {
   const repo = new MessageRepository({} as never);
@@ -14,11 +14,17 @@ describe('MessageRepository.visibilityFilter', () => {
     role: { name: roleName },
   });
 
-  it('lets an admin see everything', () => {
-    expect(repo.visibilityFilter(asUser('admin1', 'ADMIN'))).toEqual({});
+  it('holds an admin to the same rule as everyone else', () => {
+    expect(repo.visibilityFilter(asUser('admin1', 'ADMIN'))).toEqual({
+      OR: [
+        { visibility: 'PUBLIC' },
+        { authorId: 'admin1' },
+        { mentions: { some: { userId: 'admin1' } } },
+      ],
+    });
   });
 
-  it.each(['STAFF', 'SUPERVISOR', 'FOREMAN', 'ACCOUNTANT'])(
+  it.each(['STAFF', 'SUPERVISOR', 'FOREMAN', 'ACCOUNTANT', 'ADMIN'])(
     'constrains %s to public, own, and mentioned',
     (roleName) => {
       const filter = repo.visibilityFilter(asUser('u1', roleName));
@@ -33,8 +39,14 @@ describe('MessageRepository.visibilityFilter', () => {
     }
   );
 
-  it('never returns an unrestricted filter for a non-admin', () => {
-    for (const roleName of ['STAFF', 'SUPERVISOR', 'FOREMAN', 'ACCOUNTANT']) {
+  it('never returns an unrestricted filter for any role', () => {
+    for (const roleName of [
+      'STAFF',
+      'SUPERVISOR',
+      'FOREMAN',
+      'ACCOUNTANT',
+      'ADMIN',
+    ]) {
       const filter = repo.visibilityFilter(asUser('u1', roleName));
 
       expect(filter).not.toEqual({});

--- a/server/src/messaging/repositories/message.repository.spec.ts
+++ b/server/src/messaging/repositories/message.repository.spec.ts
@@ -61,3 +61,73 @@ describe('MessageRepository.visibilityFilter', () => {
     expect(mine).not.toEqual(theirs);
   });
 });
+
+/**
+ * The badge query used to issue one count per conversation the reader had ever
+ * opened, on every poll — including the background poll a hidden tab now runs
+ * once a minute. What matters here is that it is one query, and that each
+ * conversation is still counted from its own read mark.
+ */
+describe('MessageRepository.unreadCountsByConversation', () => {
+  const prisma = {
+    conversationMember: { findMany: jest.fn() },
+    message: { groupBy: jest.fn(), count: jest.fn() },
+  };
+  const repo = new MessageRepository(prisma as never);
+
+  const reader: MessagingUser = { id: 'sarah-1', role: { name: 'STAFF' } };
+  const readMark = new Date('2026-08-21T17:00:00.000Z');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.conversationMember.findMany.mockResolvedValue([
+      { conversationId: 'general-1', lastReadAt: readMark },
+      { conversationId: 'ro-thread-1', lastReadAt: null },
+    ]);
+    prisma.message.groupBy.mockResolvedValue([
+      { conversationId: 'general-1', _count: { _all: 2 } },
+      { conversationId: 'ro-thread-1', _count: { _all: 1 } },
+    ]);
+  });
+
+  it('asks once, however many conversations the reader belongs to', async () => {
+    await repo.unreadCountsByConversation(reader);
+
+    expect(prisma.message.groupBy).toHaveBeenCalledTimes(1);
+    expect(prisma.message.count).not.toHaveBeenCalled();
+  });
+
+  it('counts each conversation from its own read mark', async () => {
+    await repo.unreadCountsByConversation(reader);
+
+    const where = prisma.message.groupBy.mock.calls[0][0].where;
+    expect(where.OR).toEqual([
+      { conversationId: 'general-1', createdAt: { gt: readMark } },
+      // Never opened, so everything in it is unread.
+      { conversationId: 'ro-thread-1' },
+    ]);
+  });
+
+  it('still composes the visibility filter — the badge must not betray a private message', async () => {
+    await repo.unreadCountsByConversation(reader);
+
+    const where = prisma.message.groupBy.mock.calls[0][0].where;
+    expect(where.AND).toEqual([repo.visibilityFilter(reader)]);
+    expect(where.authorId).toEqual({ not: 'sarah-1' });
+    expect(where.deletedAt).toBeNull();
+  });
+
+  it('returns a map of conversation id to count', async () => {
+    expect(await repo.unreadCountsByConversation(reader)).toEqual({
+      'general-1': 2,
+      'ro-thread-1': 1,
+    });
+  });
+
+  it('asks for nothing when the reader belongs to no conversation', async () => {
+    prisma.conversationMember.findMany.mockResolvedValue([]);
+
+    expect(await repo.unreadCountsByConversation(reader)).toEqual({});
+    expect(prisma.message.groupBy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/messaging/repositories/message.repository.spec.ts
+++ b/server/src/messaging/repositories/message.repository.spec.ts
@@ -131,3 +131,61 @@ describe('MessageRepository.unreadCountsByConversation', () => {
     expect(prisma.message.groupBy).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Opening a thread used to read every message it had ever held. Repair order
+ * threads are purged thirty days after the job closes, but shop chat is kept
+ * for good — so this is the read that grows for as long as the shop exists.
+ */
+describe('MessageRepository.findRecentForConversation', () => {
+  const prisma = { message: { findMany: jest.fn() } };
+  const repo = new MessageRepository(prisma as never);
+  const reader: MessagingUser = { id: 'sarah-1', role: { name: 'STAFF' } };
+
+  const rows = (count: number) =>
+    Array.from({ length: count }, (_, index) => ({ id: `m-${index}` }));
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('asks for one row more than the page, to know whether more remain', async () => {
+    prisma.message.findMany.mockResolvedValue(rows(3));
+
+    await repo.findRecentForConversation('conv-1', reader, 2);
+
+    const args = prisma.message.findMany.mock.calls[0][0];
+    expect(args.take).toBe(3);
+    // Newest first, so a window means the newest window.
+    expect(args.orderBy).toEqual({ createdAt: 'desc' });
+    expect(args.where.AND).toEqual([repo.visibilityFilter(reader)]);
+  });
+
+  it('returns the page oldest first, dropping the extra row', async () => {
+    // Newest first from the database: m-0 is newest, m-2 is the probe.
+    prisma.message.findMany.mockResolvedValue(rows(3));
+
+    const page = await repo.findRecentForConversation('conv-1', reader, 2);
+
+    expect(page.messages.map((m) => m.id)).toEqual(['m-1', 'm-0']);
+    expect(page.hasOlder).toBe(true);
+  });
+
+  it('reports no more history when the thread fits in one page', async () => {
+    prisma.message.findMany.mockResolvedValue(rows(2));
+
+    const page = await repo.findRecentForConversation('conv-1', reader, 2);
+
+    expect(page.messages.map((m) => m.id)).toEqual(['m-1', 'm-0']);
+    expect(page.hasOlder).toBe(false);
+  });
+
+  it('pages backwards from a point, still filtered', async () => {
+    prisma.message.findMany.mockResolvedValue(rows(1));
+    const before = new Date('2026-08-21T17:00:00.000Z');
+
+    await repo.findOlderForConversation('conv-1', reader, before, 2);
+
+    const args = prisma.message.findMany.mock.calls[0][0];
+    expect(args.where.createdAt).toEqual({ lt: before });
+    expect(args.where.AND).toEqual([repo.visibilityFilter(reader)]);
+  });
+});

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -31,6 +31,16 @@ export type MessageWithRelations = Prisma.MessageGetPayload<{
   include: typeof MESSAGE_INCLUDE;
 }>;
 
+/**
+ * How many messages a thread opens with.
+ *
+ * Opening a conversation used to read every message it had ever held. Repair
+ * order threads are purged thirty days after the job closes so they stay
+ * small, but shop chat is kept forever — so that read grew without limit, on
+ * every panel open, for every person.
+ */
+export const CONVERSATION_PAGE_SIZE = 50;
+
 @Injectable()
 export class MessageRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -59,7 +69,65 @@ export class MessageRepository {
     };
   }
 
-  /** Messages in a thread that this user may see, oldest first. */
+  /**
+   * The newest page of a thread, oldest first, plus whether more sit behind it.
+   *
+   * Reads one row more than the page to answer that question without a second
+   * count query.
+   */
+  async findRecentForConversation(
+    conversationId: string,
+    user: MessagingUser,
+    limit: number = CONVERSATION_PAGE_SIZE
+  ): Promise<{ messages: MessageWithRelations[]; hasOlder: boolean }> {
+    const newestFirst = await this.prisma.message.findMany({
+      where: {
+        conversationId,
+        deletedAt: null,
+        AND: [this.visibilityFilter(user)],
+      },
+      include: MESSAGE_INCLUDE,
+      orderBy: { createdAt: 'desc' },
+      take: limit + 1,
+    });
+
+    const hasOlder = newestFirst.length > limit;
+    const page = hasOlder ? newestFirst.slice(0, limit) : newestFirst;
+
+    return { messages: page.reverse(), hasOlder };
+  }
+
+  /** The page before a point in a thread, for scrolling back through it. */
+  async findOlderForConversation(
+    conversationId: string,
+    user: MessagingUser,
+    before: Date,
+    limit: number = CONVERSATION_PAGE_SIZE
+  ): Promise<{ messages: MessageWithRelations[]; hasOlder: boolean }> {
+    const newestFirst = await this.prisma.message.findMany({
+      where: {
+        conversationId,
+        deletedAt: null,
+        createdAt: { lt: before },
+        AND: [this.visibilityFilter(user)],
+      },
+      include: MESSAGE_INCLUDE,
+      orderBy: { createdAt: 'desc' },
+      take: limit + 1,
+    });
+
+    const hasOlder = newestFirst.length > limit;
+    const page = hasOlder ? newestFirst.slice(0, limit) : newestFirst;
+
+    return { messages: page.reverse(), hasOlder };
+  }
+
+  /**
+   * Everything in a thread after a cursor, oldest first.
+   *
+   * Bounded by the cursor rather than by a page size: this answers "what has
+   * happened since I last asked", which is a handful of messages at most.
+   */
   async findForConversation(
     conversationId: string,
     user: MessagingUser,

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -44,13 +44,12 @@ export class MessageRepository {
    * hiding one with CSS would be a leak, not a fix.
    *
    * A message is visible when it is public, or you wrote it, or you were tagged
-   * in it. Admins see everything, which the composer tells people up front.
+   * in it. There is no role that reads past this — an admin sees a private
+   * message only by being in it, the same as everyone else. "Only Sarah will
+   * see this" has to mean what it says, or the strip in the composer is a lie
+   * and people stop trusting the feature with anything worth keeping private.
    */
   visibilityFilter(user: MessagingUser): Prisma.MessageWhereInput {
-    if (user.role.name === 'ADMIN') {
-      return {};
-    }
-
     return {
       OR: [
         { visibility: 'PUBLIC' },

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -104,6 +104,30 @@ export class MessageRepository {
     });
   }
 
+  /**
+   * Unread mentions in threads this reader has never opened.
+   *
+   * Membership is created by opening a conversation, so being tagged in a
+   * repair order thread you have never looked at leaves no membership and no
+   * `lastReadAt` — which is exactly the case the mention badge exists for.
+   * Those messages are invisible to the per-conversation counts, so they are
+   * counted here and nowhere else; anything in a joined conversation is
+   * already counted there, and counting it twice is what made one tagged
+   * message read as two.
+   */
+  async countUnreadMentionsOutsideMemberships(userId: string): Promise<number> {
+    return this.prisma.messageMention.count({
+      where: {
+        userId,
+        readAt: null,
+        message: {
+          deletedAt: null,
+          conversation: { members: { none: { userId } } },
+        },
+      },
+    });
+  }
+
   async findMentionInbox(userId: string, unreadOnly: boolean) {
     return this.prisma.messageMention.findMany({
       where: {

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -153,10 +153,15 @@ export class MessageRepository {
   }
 
   /**
-   * Unread counts per conversation, for the sidebar dots.
+   * Unread counts per conversation, for the badges.
    *
    * Counts only messages this user may see, so a private message they are not
    * part of cannot betray its existence through a badge that never clears.
+   *
+   * One query, not one per membership. It used to loop, and memberships
+   * accumulate for life — one per repair-order thread anybody opens — so an
+   * idle tab polling in the background was issuing a count per thread that
+   * person had ever visited, every minute, all night.
    */
   async unreadCountsByConversation(
     user: MessagingUser
@@ -166,22 +171,30 @@ export class MessageRepository {
       select: { conversationId: true, lastReadAt: true },
     });
 
-    const counts: Record<string, number> = {};
-    for (const membership of memberships) {
-      const count = await this.prisma.message.count({
-        where: {
+    if (memberships.length === 0) return {};
+
+    const grouped = await this.prisma.message.groupBy({
+      by: ['conversationId'],
+      where: {
+        deletedAt: null,
+        authorId: { not: user.id },
+        AND: [this.visibilityFilter(user)],
+        // One clause per membership, because the read mark is per
+        // conversation: this thread, and only what arrived after this
+        // reader last looked at it.
+        OR: memberships.map((membership) => ({
           conversationId: membership.conversationId,
-          deletedAt: null,
-          authorId: { not: user.id },
           ...(membership.lastReadAt
             ? { createdAt: { gt: membership.lastReadAt } }
             : {}),
-          AND: [this.visibilityFilter(user)],
-        },
-      });
-      if (count > 0) {
-        counts[membership.conversationId] = count;
-      }
+        })),
+      },
+      _count: { _all: true },
+    });
+
+    const counts: Record<string, number> = {};
+    for (const row of grouped) {
+      if (row._count._all > 0) counts[row.conversationId] = row._count._all;
     }
     return counts;
   }


### PR DESCRIPTION
Seven commits, all messaging, plus one that adds a security reviewer to the pre-PR gate.

## What changed

### Admins no longer read private messages they are not in

`visibilityFilter()` handed admins an empty clause, so a message locked to one person still appeared in Shop Chat for anyone with the admin role — which made the composer's "Only Sarah will see this" untrue, the one thing this feature cannot afford to be. Every role now composes the same clause: public, or yours, or you were tagged.

This reverses **D4** in the plan, which had assumed the opposite. The composer's admin disclosure line and the tooltip's "and admins" went with it, since they described a bypass that no longer exists.

Deleting still reaches other people's messages for an admin, but only ones they can read — `findByIdForUser` applies the filter, so a private message they are not part of is not found rather than removable.

### The RO chat tab

Three things were wrong with it in production.

**It looked slow.** The first poll already asked the server to hold the request open, and the server only answers a held poll when it has something to send — so on a thread nobody had written in yet, which is every new repair order, the first request sat open for the full 25 seconds behind a spinner. It asks once without a hold now.

**The composer was off the screen.** The panel was 480px tall under a header that is a screenful on a phone, so the input landed below the fold and the thread looked read-only. It measures the room left below itself and fills it, from the visual viewport, so a keyboard opening shortens the panel instead of burying the box behind the keys.

**It read as a list of rows rather than a conversation.** Messages from one person minutes apart group into a turn; days carry a sticky heading; the first paint lands at the bottom without animating; arrivals only pull the view down for a reader already there, and anyone reading back gets a "3 new messages" button instead of having the thread yanked. Skeletons stand in for messages while loading. Reply and delete no longer depend on hovering, which a touch screen cannot do — a tap reveals them. Enter still sends on a real keyboard but not on a phone, where Return is how you write a second line.

### Being told about messages that arrive while you are elsewhere

The badge and the ping only reach somebody with the app in front of them. Now: the tab title carries the count, and a desktop notification fires while the tab is hidden, behind a bell in the panel header that asks for permission on click.

The notification says how much arrived and nothing about what — no author, no body, no repair order number. A private message exists so that only the people in it can read it, and a toast on a shop counter screen is read by whoever walks past.

This is the Notification API, not Web Push: it reaches a background or minimised tab while the browser is open, needs no service worker and no vendor. A closed browser stays GA-72.

All of it depended on a backgrounded tab still asking. It used to stop polling entirely; it now drops to one plain request a minute rather than holding a connection open.

### Counting

The badge added unread mentions to unread messages, and a message that tags you is both — so one tagged message showed as two. The total cannot be worked out in the browser, because being tagged in a repair order you have never opened leaves no membership at all, so the server returns `unreadTotal` and the client stops adding anything up.

## Found by the review gates, fixed here

- **Coming back to a backgrounded tab** fired a one-off catch-up while the loop stayed asleep, so the next held poll could be a minute away. The wait is interruptible now.
- **A thread opened from the mentions inbox** never fetched a read mark, which this branch had newly turned into a red "New" divider above the whole history of a thread the reader knows well. "No mark known" is now its own state.
- **The wake predicate inferred public from an empty audience**, which is also what a message tagging nobody but its own author looks like. It reads the stored visibility now, so a note to self stops waking the shop.
- **Editing a private reply whose parent had been deleted republished it to everyone** — the parent is read back through the visibility filter, which excludes soft-deleted rows, so the inherited floor silently vanished. A reply must not gain an audience by losing the message it answers.
- **The badge query ran one count per conversation** the reader had ever opened, on every poll. With hidden tabs now polling once a minute that was a query per thread per minute all night, so it is a single `groupBy`.

## New: a security reviewer in the pre-PR gate

`/review` now runs two agents in parallel — `code-reviewer` for correctness, invariants, clean code and the mechanical gates, and a new `security-reviewer` for authorization, per-record IDOR, injection, what leaves the system, mass assignment, secrets and availability. A security pass done at the end of a correctness review gets the tired half of the attention, and the two ask genuinely different questions of the same diff.

The last two fixes in the list above are its first catches, on this branch.

## Verification

- 102 server messaging tests and 190 webApp tests pass; typechecks and both builds clean; ESLint 0 errors
- New tests cover: admins getting the restricted filter, the deleted-parent edit case, the self-mention wake, the single-query badge count, the notification's restraint rules (silent when visible, silent without permission, silent on first reading, never repeats message content), and that a hidden tab keeps polling without holding
- No migration — the visibility change is a query-time filter, so private messages already in production become invisible to uninvolved admins the moment this deploys

**Not verified in a browser:** the permission prompt and the toast, the viewport maths with a phone keyboard open, and the touch interactions. Worth eyeballing on a phone before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)