### PR TITLE
Messaging: fix what the reviews found in the paging work

### DIFF
--- a/apps/webApp/src/app/components/messaging/MessageItem.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageItem.tsx
@@ -111,6 +111,8 @@ export function MessageItem({
      * two kinds of message.
      */
     <Box
+      // The anchor the thread scrolls back to after prepending history.
+      data-message-id={message.id}
       sx={{
         display: 'flex',
         justifyContent: isMine ? 'flex-end' : 'flex-start',

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -36,6 +36,7 @@ import {
 import { useErrorHelpers } from '../../contexts/ErrorContext';
 import { useConfirmationHelpers } from '../../contexts/ConfirmationContext';
 import { announceRead } from './messaging-read-signal';
+import { arrivalsSince } from './messaging-arrivals';
 
 export interface ReplyTarget {
   messageId: string;
@@ -107,6 +108,10 @@ const isSameTurn = (message: MessageDto, previous?: MessageDto) =>
         GROUPING_WINDOW_MS
   );
 
+/** Ids are cuids, but a selector built from data is escaped on principle. */
+const cssEscape = (value: string) =>
+  typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(value) : value;
+
 /** How close to the bottom still counts as "following the conversation". */
 const AT_BOTTOM_SLACK_PX = 80;
 
@@ -160,9 +165,8 @@ export function MessageThread({
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const followingRef = useRef(true);
-  const paintedRef = useRef(false);
-  const seenCountRef = useRef(0);
-  const loadingOlderRef = useRef(false);
+  /** The message that was last at the bottom, so an arrival is identity, not size. */
+  const seenNewestIdRef = useRef<string | undefined>(undefined);
   const [missed, setMissed] = useState(0);
 
   /*
@@ -246,23 +250,33 @@ export function MessageThread({
    * follow it.
    */
   useEffect(() => {
-    const arrived = messages.length - seenCountRef.current;
-    seenCountRef.current = messages.length;
-    if (arrived <= 0) return;
+    const newest = messages[messages.length - 1];
+    if (!newest) return;
 
-    // A page of history also grows the list, and following that would scroll
-    // to the bottom of a thread somebody just asked to read the top of.
-    if (loadingOlderRef.current) return;
+    const previous = seenNewestIdRef.current;
+    seenNewestIdRef.current = newest.id;
 
-    if (followingRef.current) {
+    // A page of history changes the list without changing what is newest, so
+    // arrivalsSince returns 0 for it — see that module for why this is
+    // identity rather than a count.
+    if (previous === newest.id) return;
+
+    if (previous === undefined) {
       // The first paint should look settled rather than animate up from the
       // top of a thread the reader never saw.
-      jumpToLatest(paintedRef.current ? 'smooth' : 'auto');
-      paintedRef.current = true;
+      jumpToLatest('auto');
+      return;
+    }
+
+    const arrived = arrivalsSince(messages, previous);
+    if (arrived <= 0) return;
+
+    if (followingRef.current) {
+      jumpToLatest('smooth');
     } else {
       setMissed((count) => count + arrived);
     }
-  }, [messages.length, jumpToLatest]);
+  }, [messages, jumpToLatest]);
 
   const handleScroll = useCallback(() => {
     const node = scrollRef.current;
@@ -299,9 +313,13 @@ export function MessageThread({
    *
    * A conversation opens with a window rather than its whole history — shop
    * chat is never purged, so "everything" grows without limit. Prepending
-   * moves the content under the reader, so the scroll position is put back by
-   * however much taller the list got: without that, loading earlier messages
-   * throws you to the top of the page you were reading.
+   * moves the content under the reader, so the message they were looking at
+   * has to be put back where it was.
+   *
+   * Anchored on that message rather than on the height the list gained: a
+   * message arriving from the poll while this request is in flight also adds
+   * height, and correcting by the total would push the reader down by a
+   * message that landed somewhere they were not looking.
    */
   const handleLoadEarlier = useCallback(async () => {
     const node = scrollRef.current;
@@ -309,25 +327,31 @@ export function MessageThread({
     if (!conversationId || !oldest || loadingOlder) return;
 
     setLoadingOlder(true);
-    loadingOlderRef.current = true;
-    const heightBefore = node?.scrollHeight ?? 0;
+    const anchorSelector = `[data-message-id="${cssEscape(oldest.id)}"]`;
+    const topBefore = node
+      ?.querySelector(anchorSelector)
+      ?.getBoundingClientRect().top;
 
     try {
-      const page = await getEarlierMessages(conversationId, oldest.createdAt);
+      const page = await getEarlierMessages(
+        conversationId,
+        oldest.createdAt,
+        oldest.id
+      );
       prependLocal(page.messages, page.hasOlder);
 
       requestAnimationFrame(() => {
-        if (!node) return;
-        node.scrollTop += node.scrollHeight - heightBefore;
+        if (!node || topBefore === undefined) return;
+        const topAfter = node
+          .querySelector(anchorSelector)
+          ?.getBoundingClientRect().top;
+        if (topAfter === undefined) return;
+        node.scrollTop += topAfter - topBefore;
       });
     } catch (error) {
       helpersRef.current.showApiError(error);
     } finally {
       setLoadingOlder(false);
-      // Cleared after the effect that reacts to the new length has run.
-      requestAnimationFrame(() => {
-        loadingOlderRef.current = false;
-      });
     }
   }, [conversationId, messages, loadingOlder, prependLocal]);
 

--- a/apps/webApp/src/app/components/messaging/MessageThread.tsx
+++ b/apps/webApp/src/app/components/messaging/MessageThread.tsx
@@ -251,10 +251,25 @@ export function MessageThread({
    */
   useEffect(() => {
     const newest = messages[messages.length - 1];
-    if (!newest) return;
-
     const previous = seenNewestIdRef.current;
-    seenNewestIdRef.current = newest.id;
+
+    /*
+     * Recorded before the empty check, not after it.
+     *
+     * The polling hook empties the list when the conversation changes, so a
+     * guard that returns first would leave the previous conversation's newest
+     * id behind — and the next thread would then find that id nowhere in its
+     * own messages, count no arrivals, and open scrolled to the top of its
+     * window with the old thread's count still showing. Nothing reaches that
+     * today because every caller remounts the component, but nothing states
+     * that either.
+     */
+    seenNewestIdRef.current = newest?.id;
+
+    if (!newest) {
+      setMissed(0);
+      return;
+    }
 
     // A page of history changes the list without changing what is newest, so
     // arrivalsSince returns 0 for it — see that module for why this is

--- a/apps/webApp/src/app/components/messaging/messaging-arrivals.spec.ts
+++ b/apps/webApp/src/app/components/messaging/messaging-arrivals.spec.ts
@@ -1,0 +1,41 @@
+import type { MessageDto } from '@gt-automotive/data';
+import { arrivalsSince } from './messaging-arrivals';
+
+const thread = (...ids: string[]) => ids.map((id) => ({ id } as MessageDto));
+
+describe('arrivalsSince', () => {
+  it('counts what landed after the message that was newest', () => {
+    expect(arrivalsSince(thread('a', 'b', 'c', 'd'), 'b')).toBe(2);
+  });
+
+  it('counts nothing when the bottom has not moved', () => {
+    expect(arrivalsSince(thread('a', 'b', 'c'), 'c')).toBe(0);
+  });
+
+  /*
+   * The case this exists for. A page of history grows the list without
+   * changing what is newest — and inferring that from the size instead, with a
+   * flag held up for the length of the "load earlier" request, silently ate
+   * anything that arrived while it was in flight.
+   */
+  it('counts nothing for a page of history loaded above', () => {
+    expect(arrivalsSince(thread('x', 'y', 'a', 'b', 'c'), 'c')).toBe(0);
+  });
+
+  it('still counts an arrival that lands during that same load', () => {
+    expect(arrivalsSince(thread('x', 'y', 'a', 'b', 'c', 'd'), 'c')).toBe(1);
+  });
+
+  it('counts nothing on the first paint, which the caller handles itself', () => {
+    expect(arrivalsSince(thread('a', 'b'), undefined)).toBe(0);
+  });
+
+  it('counts nothing when the newest message was deleted', () => {
+    // 'c' is gone and the thread has shrunk back onto 'b'. Nothing arrived.
+    expect(arrivalsSince(thread('a', 'b'), 'c')).toBe(0);
+  });
+
+  it('counts nothing in an empty thread', () => {
+    expect(arrivalsSince([], 'c')).toBe(0);
+  });
+});

--- a/apps/webApp/src/app/components/messaging/messaging-arrivals.ts
+++ b/apps/webApp/src/app/components/messaging/messaging-arrivals.ts
@@ -1,0 +1,35 @@
+import type { MessageDto } from '@gt-automotive/data';
+
+/**
+ * How many messages have landed at the bottom of a thread since it was last
+ * looked at, identified by the message that was newest then.
+ *
+ * Identity rather than a count, because the list grows for two unrelated
+ * reasons: messages arriving, and history being loaded above them. A count
+ * cannot tell those apart, and the attempt to — a flag held up for the
+ * duration of the "load earlier" request — swallowed anything that arrived
+ * while it was in flight: no notice of it, and no way to recover the count
+ * afterwards. Prepending leaves the newest message alone, so this returns 0
+ * for it without needing to know it happened.
+ */
+export function arrivalsSince(
+  messages: MessageDto[],
+  previousNewestId: string | undefined
+): number {
+  const newest = messages[messages.length - 1];
+
+  // An empty thread, or nothing new at the bottom.
+  if (!newest || newest.id === previousNewestId) return 0;
+
+  // Nothing to measure against yet — the caller treats the first paint as its
+  // own case, since there is no "since" to count from.
+  if (previousNewestId === undefined) return 0;
+
+  const previousIndex = messages.findIndex((m) => m.id === previousNewestId);
+
+  // Gone rather than overtaken: the newest message was deleted and the list
+  // shrank back onto an older one.
+  if (previousIndex === -1) return 0;
+
+  return messages.length - 1 - previousIndex;
+}

--- a/apps/webApp/src/app/requests/messaging.requests.ts
+++ b/apps/webApp/src/app/requests/messaging.requests.ts
@@ -82,15 +82,18 @@ export async function getGeneralThread(): Promise<ConversationDto> {
  *
  * `before` is the `createdAt` of the oldest message held, echoed back from the
  * server's own value rather than a browser clock — same rule as the poll
- * cursor, for the same reason.
+ * cursor, for the same reason — and `beforeId` is that message's id, without
+ * which two messages sharing a millisecond lose one of themselves at a page
+ * boundary.
  */
 export async function getEarlierMessages(
   conversationId: string,
-  before: string
+  before: string,
+  beforeId: string
 ): Promise<MessagePageDto> {
   const { data } = await apiClient.get<MessagePageDto>(
     `/messaging/conversations/${conversationId}/messages`,
-    { params: { before } }
+    { params: { before, beforeId } }
   );
   return data;
 }

--- a/libs/data/src/lib/message.dto.ts
+++ b/libs/data/src/lib/message.dto.ts
@@ -47,11 +47,21 @@ export class UpdateMessageDto {
 /** Query for a page of messages older than the ones already on screen. */
 export class OlderMessagesQueryDto {
   /**
-   * `createdAt` of the oldest message the caller already holds. Everything
-   * strictly before it comes back, newest first, one page at a time.
+   * `createdAt` of the oldest message the caller already holds.
    */
   @IsISO8601()
   before!: string;
+
+  /**
+   * Its id, which makes the cursor total.
+   *
+   * `createdAt` is millisecond precision, so two people sending inside the
+   * same millisecond share one. Paging on the timestamp alone then excluded
+   * whichever twin did not land on the boundary — from this page and from
+   * every page after it.
+   */
+  @IsString()
+  beforeId!: string;
 }
 
 /** Query for the single poll endpoint. */

--- a/libs/data/src/lib/message.dto.ts
+++ b/libs/data/src/lib/message.dto.ts
@@ -59,9 +59,14 @@ export class OlderMessagesQueryDto {
    * same millisecond share one. Paging on the timestamp alone then excluded
    * whichever twin did not land on the boundary — from this page and from
    * every page after it.
+   *
+   * Optional because the frontend and the backend deploy separately: a tab
+   * opened before the frontend caught up still sends the timestamp alone, and
+   * a 400 in its face is a worse trade than the tie it cannot break.
    */
+  @IsOptional()
   @IsString()
-  beforeId!: string;
+  beforeId?: string;
 }
 
 /** Query for the single poll endpoint. */

--- a/server/src/messaging/messaging.controller.ts
+++ b/server/src/messaging/messaging.controller.ts
@@ -79,7 +79,12 @@ export class MessagingController {
     @Param('id') conversationId: string,
     @Query() query: OlderMessagesQueryDto
   ) {
-    return this.messaging.getOlderMessages(conversationId, user, query.before);
+    return this.messaging.getOlderMessages(
+      conversationId,
+      user,
+      query.before,
+      query.beforeId
+    );
   }
 
   @Post('conversations/:id/messages')

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -297,10 +297,11 @@ describe('MessagingService', () => {
           mentions: [{ userId: 'sarah-1', user: {} }],
         })
       );
+      // Mike tagged her, which is how she came to be replying to it at all.
       (messages.findParentAudience as jest.Mock).mockResolvedValue({
         authorId: 'mike-1',
         visibility: 'MENTIONED_ONLY',
-        mentionUserIds: ['sarah-1'],
+        mentionUserIds: ['sarah-1', author.id],
       });
 
       await service.updateMessage('msg-1', author, 'calling them back now');
@@ -309,6 +310,43 @@ describe('MessagingService', () => {
       expect(createdMessage.mentions.create).toEqual(
         expect.arrayContaining([{ userId: 'sarah-1' }, { userId: 'mike-1' }])
       );
+    });
+
+    /*
+     * Being in the parent when the reply was written is not the same as being
+     * in it now: its author can edit it, drop somebody from it, or turn a
+     * public message private long afterwards. Copying its current audience
+     * onto the reply anyway echoed that audience back in the response — an
+     * editor could re-save an old reply on a timer and watch the membership of
+     * a message they cannot read.
+     */
+    it('does not copy the audience of a parent the editor is no longer in', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({
+          id: 'msg-1',
+          authorId: author.id,
+          parentMessageId: 'parent-1',
+          visibility: 'PUBLIC',
+          mentions: [],
+        })
+      );
+      // Mike has since made his message private, to Dave rather than to her.
+      (messages.findParentAudience as jest.Mock).mockResolvedValue({
+        authorId: 'mike-1',
+        visibility: 'MENTIONED_ONLY',
+        mentionUserIds: ['dave-1'],
+      });
+
+      await service.updateMessage('msg-1', author, 'still on it');
+
+      const audience = createdMessage.mentions.create.map(
+        (m: { userId: string }) => m.userId
+      );
+      expect(audience).not.toContain('dave-1');
+      expect(audience).not.toContain('mike-1');
+      // The floor still holds — the reply narrows rather than staying public
+      // under a parent that has been closed to her.
+      expect(createdMessage.visibility).toBe('MENTIONED_ONLY');
     });
 
     /*
@@ -333,7 +371,7 @@ describe('MessagingService', () => {
       (messages.findParentAudience as jest.Mock).mockResolvedValue({
         authorId: 'mike-1',
         visibility: 'MENTIONED_ONLY',
-        mentionUserIds: [],
+        mentionUserIds: [author.id],
       });
 
       await service.updateMessage(

--- a/server/src/messaging/messaging.service.spec.ts
+++ b/server/src/messaging/messaging.service.spec.ts
@@ -100,7 +100,11 @@ describe('MessagingService', () => {
 
     messages = {
       findByIdForUser: jest.fn(),
+      findParentAudience: jest.fn().mockResolvedValue(null),
       findForConversation: jest.fn().mockResolvedValue([]),
+      findSinceForConversation: jest
+        .fn()
+        .mockResolvedValue({ messages: [], truncated: false }),
       findRecentForConversation: jest
         .fn()
         .mockResolvedValue({ messages: [], hasOlder: false }),
@@ -278,31 +282,72 @@ describe('MessagingService', () => {
     /*
      * A reply must not gain an audience by losing the message it answers.
      *
-     * The parent is read back through the visibility filter, which excludes
-     * soft-deleted rows — so once somebody deleted the private message that
-     * started the thread, fixing a typo on the reply re-derived it as public
-     * and put it in front of the whole shop.
+     * The parent's audience is read directly rather than through the filtered
+     * read, which excludes soft-deleted rows — so once somebody deleted the
+     * private message that started the thread, fixing a typo on the reply
+     * re-derived it as public and put it in front of the whole shop.
      */
     it('keeps a private reply private when its parent has been deleted', async () => {
-      (messages.findByIdForUser as jest.Mock).mockImplementation((id: string) =>
-        Promise.resolve(
-          id === 'msg-1'
-            ? messageRow({
-                id: 'msg-1',
-                authorId: author.id,
-                parentMessageId: 'parent-1',
-                visibility: 'MENTIONED_ONLY',
-                mentions: [{ userId: 'sarah-1', user: {} }],
-              })
-            : // The parent is soft-deleted, so the filtered read finds nothing.
-              null
-        )
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({
+          id: 'msg-1',
+          authorId: author.id,
+          parentMessageId: 'parent-1',
+          visibility: 'MENTIONED_ONLY',
+          mentions: [{ userId: 'sarah-1', user: {} }],
+        })
       );
+      (messages.findParentAudience as jest.Mock).mockResolvedValue({
+        authorId: 'mike-1',
+        visibility: 'MENTIONED_ONLY',
+        mentionUserIds: ['sarah-1'],
+      });
 
       await service.updateMessage('msg-1', author, 'calling them back now');
 
       expect(createdMessage.visibility).toBe('MENTIONED_ONLY');
-      expect(createdMessage.mentions.create).toEqual([{ userId: 'sarah-1' }]);
+      expect(createdMessage.mentions.create).toEqual(
+        expect.arrayContaining([{ userId: 'sarah-1' }, { userId: 'mike-1' }])
+      );
+    });
+
+    /*
+     * The other half of the same rule, and the reason the audience is
+     * recomputed from the parent rather than accumulated from what was stored:
+     * holding on to the stored mentions would have kept a person somebody
+     * tagged by mistake on the message for good, with no way to take them off.
+     */
+    it('still lets the author drop somebody they tagged by mistake', async () => {
+      (messages.findByIdForUser as jest.Mock).mockResolvedValue(
+        messageRow({
+          id: 'msg-1',
+          authorId: author.id,
+          parentMessageId: 'parent-1',
+          visibility: 'MENTIONED_ONLY',
+          mentions: [
+            { userId: 'sarah-1', user: {} },
+            { userId: 'wrong-sarah', user: {} },
+          ],
+        })
+      );
+      (messages.findParentAudience as jest.Mock).mockResolvedValue({
+        authorId: 'mike-1',
+        visibility: 'MENTIONED_ONLY',
+        mentionUserIds: [],
+      });
+
+      await service.updateMessage(
+        'msg-1',
+        author,
+        '@[Sarah](user:sarah-1) can you look?'
+      );
+
+      const audience = createdMessage.mentions.create.map(
+        (m: { userId: string }) => m.userId
+      );
+      expect(audience).not.toContain('wrong-sarah');
+      // The parent's author keeps access to a reply to their own message.
+      expect(audience).toEqual(expect.arrayContaining(['sarah-1', 'mike-1']));
     });
   });
 
@@ -379,7 +424,7 @@ describe('MessagingService', () => {
       const result = await service.poll(author);
 
       expect(result.unreadMentions).toBe(3);
-      expect(messages.findForConversation).not.toHaveBeenCalled();
+      expect(messages.findSinceForConversation).not.toHaveBeenCalled();
     });
 
     /*
@@ -436,8 +481,45 @@ describe('MessagingService', () => {
         'conv-1',
         author
       );
-      expect(messages.findForConversation).not.toHaveBeenCalled();
+      expect(messages.findSinceForConversation).not.toHaveBeenCalled();
       expect(result.hasOlderMessages).toBe(true);
+    });
+
+    /*
+     * A tablet that slept through a long weekend wakes with a days-old cursor,
+     * and "everything since" is then the whole weekend in one response. The
+     * cursor comes back stopped at the last message actually returned, so the
+     * next trip resumes there rather than stepping over the rest.
+     */
+    it('hands back a cursor it can resume from when a catch-up is too big', async () => {
+      (messages.findSinceForConversation as jest.Mock).mockResolvedValue({
+        messages: [messageRow({ createdAt: new Date('2026-08-21T09:00:00Z') })],
+        truncated: true,
+      });
+
+      const result = await service.poll(
+        author,
+        'conv-1',
+        '2026-08-18T17:00:00.000Z'
+      );
+
+      expect(result.serverTime).toBe('2026-08-21T09:00:00.000Z');
+    });
+
+    it('hands back the clock when the catch-up fitted', async () => {
+      (messages.findSinceForConversation as jest.Mock).mockResolvedValue({
+        messages: [messageRow({ createdAt: new Date('2026-08-21T09:00:00Z') })],
+        truncated: false,
+      });
+
+      const result = await service.poll(
+        author,
+        'conv-1',
+        '2026-08-21T08:00:00.000Z'
+      );
+
+      // Not the message's time: everything up to now has been delivered.
+      expect(result.serverTime).not.toBe('2026-08-21T09:00:00.000Z');
     });
 
     it('follows the cursor once the client has one, and says nothing about history', async () => {
@@ -447,7 +529,7 @@ describe('MessagingService', () => {
         '2026-08-20T17:00:00.000Z'
       );
 
-      expect(messages.findForConversation).toHaveBeenCalled();
+      expect(messages.findSinceForConversation).toHaveBeenCalled();
       expect(messages.findRecentForConversation).not.toHaveBeenCalled();
       // Undefined, not false — a cursor poll must not clear the client's flag.
       expect(result.hasOlderMessages).toBeUndefined();
@@ -561,13 +643,15 @@ describe('MessagingService', () => {
       const result = await service.getOlderMessages(
         'conv-1',
         author,
-        '2026-08-20T17:00:00.000Z'
+        '2026-08-20T17:00:00.000Z',
+        'msg-1'
       );
 
       expect(messages.findOlderForConversation).toHaveBeenCalledWith(
         'conv-1',
         author,
-        new Date('2026-08-20T17:00:00.000Z')
+        new Date('2026-08-20T17:00:00.000Z'),
+        'msg-1'
       );
       expect(result.messages).toHaveLength(1);
       expect(result.hasOlder).toBe(true);
@@ -578,7 +662,8 @@ describe('MessagingService', () => {
       await service.getOlderMessages(
         'conv-1',
         author,
-        '2026-08-20T17:00:00.000Z'
+        '2026-08-20T17:00:00.000Z',
+        'msg-1'
       );
 
       expect(prisma.conversationMember.upsert).toHaveBeenCalled();

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -366,20 +366,37 @@ export class MessagingService {
        * it recomputed rather than accumulated — so an editor can still take
        * off somebody they tagged by mistake, which holding on to the stored
        * mentions would have made impossible.
-       *
-       * No disclosure in reading past the filter here: these are the ids this
-       * reply already carries as its own mentions, and the editor is its
-       * author.
        */
       const parent = await this.messages.findParentAudience(
         existing.parentMessageId
       );
 
       if (parent?.visibility === 'MENTIONED_ONLY') {
+        // The floor holds either way: a reply never widens by losing, or being
+        // shut out of, the message it answers.
         visibility = 'MENTIONED_ONLY';
-        parent.mentionUserIds.forEach((id) => audience.add(id));
-        audience.add(parent.authorId);
-        audience.delete(user.id);
+
+        /*
+         * Whose audience it becomes is a different question from whether it
+         * stays private, and this is where reading past the filter has to stop.
+         *
+         * Being in the parent when the reply was written does not mean being
+         * in it now — its author can edit it, take somebody out of it, or turn
+         * a public message private long afterwards. Copying its current
+         * audience onto the reply regardless would have echoed that audience
+         * straight back in the PATCH response, names and all: an editor could
+         * re-save an old reply on a timer and watch the membership of a
+         * message they cannot read.
+         */
+        const stillInIt =
+          parent.authorId === user.id ||
+          parent.mentionUserIds.includes(user.id);
+
+        if (stillInIt) {
+          parent.mentionUserIds.forEach((id) => audience.add(id));
+          audience.add(parent.authorId);
+          audience.delete(user.id);
+        }
       }
     }
 

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -110,13 +110,27 @@ export class MessagingService {
      */
     let messages: MessageWithRelations[] = [];
     let hasOlderMessages: boolean | undefined;
+    /*
+     * What the caller should send back next time.
+     *
+     * Normally the instant this poll ran. When a catch-up is too big to carry
+     * in one response, it becomes the last message actually returned instead,
+     * so the next trip resumes from there rather than stepping over the rest.
+     */
+    let cursor = serverTime;
 
     if (conversationId && sinceDate) {
-      messages = await this.messages.findForConversation(
+      const catchUp = await this.messages.findSinceForConversation(
         conversationId,
         user,
         sinceDate
       );
+      messages = catchUp.messages;
+
+      const last = messages[messages.length - 1];
+      if (catchUp.truncated && last) {
+        cursor = last.createdAt;
+      }
     } else if (conversationId) {
       const page = await this.messages.findRecentForConversation(
         conversationId,
@@ -146,7 +160,7 @@ export class MessagingService {
       conversationUnreads,
       unreadTotal,
       ...(hasOlderMessages === undefined ? {} : { hasOlderMessages }),
-      serverTime: serverTime.toISOString(),
+      serverTime: cursor.toISOString(),
     };
   }
 
@@ -160,14 +174,16 @@ export class MessagingService {
   async getOlderMessages(
     conversationId: string,
     user: MessagingUser,
-    before: string
+    before: string,
+    beforeId: string
   ): Promise<MessagePageDto> {
     await this.ensureMembership(conversationId, user.id);
 
     const page = await this.messages.findOlderForConversation(
       conversationId,
       user,
-      new Date(before)
+      new Date(before),
+      beforeId
     );
 
     return {
@@ -340,26 +356,29 @@ export class MessagingService {
       audience.size > 0 ? 'MENTIONED_ONLY' : 'PUBLIC';
 
     if (existing.parentMessageId) {
-      const parent = await this.messages.findByIdForUser(
-        existing.parentMessageId,
-        user
+      /*
+       * The parent's audience, read whether or not the parent still stands.
+       *
+       * A soft-deleted parent is invisible to the filtered read, and taking
+       * that to mean "no parent" dropped the inherited floor: fixing a typo on
+       * a private reply whose parent had been deleted republished it to the
+       * whole shop. Reading the audience directly keeps the floor, and keeps
+       * it recomputed rather than accumulated — so an editor can still take
+       * off somebody they tagged by mistake, which holding on to the stored
+       * mentions would have made impossible.
+       *
+       * No disclosure in reading past the filter here: these are the ids this
+       * reply already carries as its own mentions, and the editor is its
+       * author.
+       */
+      const parent = await this.messages.findParentAudience(
+        existing.parentMessageId
       );
 
       if (parent?.visibility === 'MENTIONED_ONLY') {
         visibility = 'MENTIONED_ONLY';
-        parent.mentions.forEach((m) => audience.add(m.userId));
+        parent.mentionUserIds.forEach((id) => audience.add(id));
         audience.add(parent.authorId);
-        audience.delete(user.id);
-      } else if (!parent && existing.visibility === 'MENTIONED_ONLY') {
-        /*
-         * The parent is gone — soft-deleted, so the filtered read cannot see
-         * it any more. A reply must not gain an audience by losing the message
-         * it answers: without this, fixing a typo on a private reply whose
-         * parent had been deleted republished it to the whole shop. Hold the
-         * floor from what was stored instead.
-         */
-        visibility = 'MENTIONED_ONLY';
-        existing.mentions.forEach((m) => audience.add(m.userId));
         audience.delete(user.id);
       }
     }

--- a/server/src/messaging/messaging.service.ts
+++ b/server/src/messaging/messaging.service.ts
@@ -175,7 +175,7 @@ export class MessagingService {
     conversationId: string,
     user: MessagingUser,
     before: string,
-    beforeId: string
+    beforeId?: string
   ): Promise<MessagePageDto> {
     await this.ensureMembership(conversationId, user.id);
 
@@ -350,8 +350,8 @@ export class MessagingService {
 
     // An edit re-derives visibility from the new body, so removing the last
     // mention makes a message public. Editing a reply cannot widen it, though:
-    // the inherited floor comes from the parent, same as on create, and from
-    // what was stored if the parent has since been deleted.
+    // the inherited floor comes from the parent, the same as on create, and
+    // still comes from it once the parent has been deleted.
     let visibility: MessageVisibility =
       audience.size > 0 ? 'MENTIONED_ONLY' : 'PUBLIC';
 

--- a/server/src/messaging/repositories/message.repository.spec.ts
+++ b/server/src/messaging/repositories/message.repository.spec.ts
@@ -206,6 +206,23 @@ describe('MessageRepository.findRecentForConversation', () => {
   });
 
   /*
+   * The two apps deploy separately, so a tab opened before the frontend caught
+   * up still pages on the timestamp alone. It gets the old behaviour rather
+   * than a validation error in its face.
+   */
+  it('falls back to the timestamp when the caller sends no id', async () => {
+    prisma.message.findMany.mockResolvedValue(rows(1));
+    const before = new Date('2026-08-21T17:00:00.000Z');
+
+    await repo.findOlderForConversation('conv-1', reader, before, undefined, 2);
+
+    const args = prisma.message.findMany.mock.calls[0][0];
+    expect(args.where.createdAt).toEqual({ lt: before });
+    expect(args.where.OR).toBeUndefined();
+    expect(args.where.AND).toEqual([repo.visibilityFilter(reader)]);
+  });
+
+  /*
    * The catch-up read is capped for the tablet that slept through a long
    * weekend and wakes with a days-old cursor.
    */

--- a/server/src/messaging/repositories/message.repository.spec.ts
+++ b/server/src/messaging/repositories/message.repository.spec.ts
@@ -143,7 +143,11 @@ describe('MessageRepository.findRecentForConversation', () => {
   const reader: MessagingUser = { id: 'sarah-1', role: { name: 'STAFF' } };
 
   const rows = (count: number) =>
-    Array.from({ length: count }, (_, index) => ({ id: `m-${index}` }));
+    Array.from({ length: count }, (_, index) => ({
+      id: `m-${index}`,
+      // Distinct instants, so the catch-up trim has a clean boundary to find.
+      createdAt: new Date(Date.UTC(2026, 7, 21, 17, 0, index)),
+    }));
 
   beforeEach(() => jest.clearAllMocks());
 
@@ -217,6 +221,32 @@ describe('MessageRepository.findRecentForConversation', () => {
 
     expect(prisma.message.findMany.mock.calls[0][0].take).toBe(3);
     expect(result.messages).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  /*
+   * The resume cursor is a timestamp, so the page has to end on a clean one:
+   * if the last message delivered shared its millisecond with the first one
+   * dropped, `gt` would step over the twin and never deliver it.
+   */
+  it('stops a truncated catch-up short of a shared millisecond', async () => {
+    const shared = new Date('2026-08-21T17:00:00.000Z');
+    prisma.message.findMany.mockResolvedValue([
+      { id: 'm-0', createdAt: new Date('2026-08-21T16:59:59.000Z') },
+      { id: 'm-1', createdAt: shared },
+      { id: 'm-2', createdAt: shared },
+    ]);
+
+    const result = await repo.findSinceForConversation(
+      'conv-1',
+      reader,
+      new Date('2026-08-18T17:00:00.000Z'),
+      2
+    );
+
+    // m-1 is dropped with its twin rather than becoming the cursor; the next
+    // trip asks for both.
+    expect(result.messages.map((m) => m.id)).toEqual(['m-0']);
     expect(result.truncated).toBe(true);
   });
 

--- a/server/src/messaging/repositories/message.repository.spec.ts
+++ b/server/src/messaging/repositories/message.repository.spec.ts
@@ -154,8 +154,9 @@ describe('MessageRepository.findRecentForConversation', () => {
 
     const args = prisma.message.findMany.mock.calls[0][0];
     expect(args.take).toBe(3);
-    // Newest first, so a window means the newest window.
-    expect(args.orderBy).toEqual({ createdAt: 'desc' });
+    // Newest first, so a window means the newest window — and the id breaks
+    // ties, without which a page boundary can lose a message for good.
+    expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'desc' }]);
     expect(args.where.AND).toEqual([repo.visibilityFilter(reader)]);
   });
 
@@ -178,14 +179,57 @@ describe('MessageRepository.findRecentForConversation', () => {
     expect(page.hasOlder).toBe(false);
   });
 
-  it('pages backwards from a point, still filtered', async () => {
+  /*
+   * `createdAt` is millisecond precision, so two people sending inside the
+   * same millisecond share one. Paging on the timestamp alone excluded
+   * whichever twin did not land on the boundary — from this page and from
+   * every page after it, permanently.
+   */
+  it('pages backwards on the timestamp and the id together, still filtered', async () => {
     prisma.message.findMany.mockResolvedValue(rows(1));
     const before = new Date('2026-08-21T17:00:00.000Z');
 
-    await repo.findOlderForConversation('conv-1', reader, before, 2);
+    await repo.findOlderForConversation('conv-1', reader, before, 'm-9', 2);
 
     const args = prisma.message.findMany.mock.calls[0][0];
-    expect(args.where.createdAt).toEqual({ lt: before });
+    expect(args.where.OR).toEqual([
+      { createdAt: { lt: before } },
+      // The twin: same instant, earlier id.
+      { createdAt: before, id: { lt: 'm-9' } },
+    ]);
     expect(args.where.AND).toEqual([repo.visibilityFilter(reader)]);
+    expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'desc' }]);
+  });
+
+  /*
+   * The catch-up read is capped for the tablet that slept through a long
+   * weekend and wakes with a days-old cursor.
+   */
+  it('caps a catch-up and says when it did not fit', async () => {
+    prisma.message.findMany.mockResolvedValue(rows(3));
+
+    const result = await repo.findSinceForConversation(
+      'conv-1',
+      reader,
+      new Date('2026-08-18T17:00:00.000Z'),
+      2
+    );
+
+    expect(prisma.message.findMany.mock.calls[0][0].take).toBe(3);
+    expect(result.messages).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('reports a catch-up that fitted', async () => {
+    prisma.message.findMany.mockResolvedValue(rows(2));
+
+    const result = await repo.findSinceForConversation(
+      'conv-1',
+      reader,
+      new Date('2026-08-21T17:00:00.000Z'),
+      2
+    );
+
+    expect(result.truncated).toBe(false);
   });
 });

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -135,17 +135,25 @@ export class MessageRepository {
     conversationId: string,
     user: MessagingUser,
     before: Date,
-    beforeId: string,
+    beforeId: string | undefined,
     limit: number = CONVERSATION_PAGE_SIZE
   ): Promise<{ messages: MessageWithRelations[]; hasOlder: boolean }> {
+    // Without an id — a client from before the two deployed apart — the
+    // timestamp has to stand on its own, tie and all.
+    const olderThanCursor = beforeId
+      ? {
+          OR: [
+            { createdAt: { lt: before } },
+            { createdAt: before, id: { lt: beforeId } },
+          ],
+        }
+      : { createdAt: { lt: before } };
+
     const newestFirst = await this.prisma.message.findMany({
       where: {
         conversationId,
         deletedAt: null,
-        OR: [
-          { createdAt: { lt: before } },
-          { createdAt: before, id: { lt: beforeId } },
-        ],
+        ...olderThanCursor,
         AND: [this.visibilityFilter(user)],
       },
       include: MESSAGE_INCLUDE,

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -41,6 +41,31 @@ export type MessageWithRelations = Prisma.MessageGetPayload<{
  */
 export const CONVERSATION_PAGE_SIZE = 50;
 
+/**
+ * How much of a backlog one catch-up poll will carry.
+ *
+ * A tab that slept through a long weekend wakes with a cursor days old, and
+ * "everything since" is then the whole weekend in one response with three
+ * nested includes. Bigger than a page because catching up should take one trip
+ * in the ordinary case, small enough that the pathological one stays bounded.
+ */
+export const CATCHUP_LIMIT = 200;
+
+/**
+ * Ordering for every windowed read, newest first.
+ *
+ * `createdAt` alone is not unique — it is `TIMESTAMP(3)` defaulting to the
+ * transaction clock, so two people sending inside the same millisecond get the
+ * same value. Which of them landed on a page boundary was then arbitrary, and
+ * paging on `createdAt < that` excluded its twin from the next page as well:
+ * the message existed and no amount of scrolling back would ever show it. The
+ * id breaks the tie and makes the cursor total.
+ */
+const NEWEST_FIRST = [
+  { createdAt: 'desc' },
+  { id: 'desc' },
+] satisfies Prisma.MessageOrderByWithRelationInput[];
+
 @Injectable()
 export class MessageRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -87,32 +112,7 @@ export class MessageRepository {
         AND: [this.visibilityFilter(user)],
       },
       include: MESSAGE_INCLUDE,
-      orderBy: { createdAt: 'desc' },
-      take: limit + 1,
-    });
-
-    const hasOlder = newestFirst.length > limit;
-    const page = hasOlder ? newestFirst.slice(0, limit) : newestFirst;
-
-    return { messages: page.reverse(), hasOlder };
-  }
-
-  /** The page before a point in a thread, for scrolling back through it. */
-  async findOlderForConversation(
-    conversationId: string,
-    user: MessagingUser,
-    before: Date,
-    limit: number = CONVERSATION_PAGE_SIZE
-  ): Promise<{ messages: MessageWithRelations[]; hasOlder: boolean }> {
-    const newestFirst = await this.prisma.message.findMany({
-      where: {
-        conversationId,
-        deletedAt: null,
-        createdAt: { lt: before },
-        AND: [this.visibilityFilter(user)],
-      },
-      include: MESSAGE_INCLUDE,
-      orderBy: { createdAt: 'desc' },
+      orderBy: NEWEST_FIRST,
       take: limit + 1,
     });
 
@@ -123,26 +123,105 @@ export class MessageRepository {
   }
 
   /**
-   * Everything in a thread after a cursor, oldest first.
+   * The page before a point in a thread, for scrolling back through it.
    *
-   * Bounded by the cursor rather than by a page size: this answers "what has
-   * happened since I last asked", which is a handful of messages at most.
+   * The cursor is the `(createdAt, id)` pair of the oldest message the caller
+   * holds, not the timestamp alone — see NEWEST_FIRST for what a bare
+   * timestamp loses.
    */
-  async findForConversation(
+  async findOlderForConversation(
     conversationId: string,
     user: MessagingUser,
-    since?: Date
-  ): Promise<MessageWithRelations[]> {
-    return this.prisma.message.findMany({
+    before: Date,
+    beforeId: string,
+    limit: number = CONVERSATION_PAGE_SIZE
+  ): Promise<{ messages: MessageWithRelations[]; hasOlder: boolean }> {
+    const newestFirst = await this.prisma.message.findMany({
       where: {
         conversationId,
         deletedAt: null,
-        ...(since ? { createdAt: { gt: since } } : {}),
+        OR: [
+          { createdAt: { lt: before } },
+          { createdAt: before, id: { lt: beforeId } },
+        ],
         AND: [this.visibilityFilter(user)],
       },
       include: MESSAGE_INCLUDE,
-      orderBy: { createdAt: 'asc' },
+      orderBy: NEWEST_FIRST,
+      take: limit + 1,
     });
+
+    const hasOlder = newestFirst.length > limit;
+    const page = hasOlder ? newestFirst.slice(0, limit) : newestFirst;
+
+    return { messages: page.reverse(), hasOlder };
+  }
+
+  /**
+   * What has happened in a thread since a cursor, oldest first.
+   *
+   * Usually a handful of messages — but not always, and the exception is what
+   * this is capped for: a tablet that slept through a long weekend wakes with
+   * a days-old cursor, and "everything since" is then the entire weekend in
+   * one response. `truncated` says the caller has not caught up yet, so the
+   * poll can hand back a cursor that stops at what it actually returned and
+   * let the next trip carry the rest.
+   */
+  async findSinceForConversation(
+    conversationId: string,
+    user: MessagingUser,
+    since: Date,
+    limit: number = CATCHUP_LIMIT
+  ): Promise<{ messages: MessageWithRelations[]; truncated: boolean }> {
+    const rows = await this.prisma.message.findMany({
+      where: {
+        conversationId,
+        deletedAt: null,
+        createdAt: { gt: since },
+        AND: [this.visibilityFilter(user)],
+      },
+      include: MESSAGE_INCLUDE,
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: limit + 1,
+    });
+
+    const truncated = rows.length > limit;
+    return {
+      messages: truncated ? rows.slice(0, limit) : rows,
+      truncated,
+    };
+  }
+
+  /**
+   * Who a message was private to, without its content.
+   *
+   * Deliberately outside the visibility filter and unfiltered by `deletedAt`,
+   * and deliberately returning ids only: it exists so an edit can recompute
+   * the floor a reply inherited even after the parent has been deleted. No
+   * body, no author name — nothing the caller could not already read off the
+   * mentions stored on their own reply.
+   */
+  async findParentAudience(id: string): Promise<{
+    authorId: string;
+    visibility: string;
+    mentionUserIds: string[];
+  } | null> {
+    const parent = await this.prisma.message.findUnique({
+      where: { id },
+      select: {
+        authorId: true,
+        visibility: true,
+        mentions: { select: { userId: true } },
+      },
+    });
+
+    if (!parent) return null;
+
+    return {
+      authorId: parent.authorId,
+      visibility: parent.visibility,
+      mentionUserIds: parent.mentions.map((m) => m.userId),
+    };
   }
 
   /** A single message, or null when this user may not see it. */

--- a/server/src/messaging/repositories/message.repository.ts
+++ b/server/src/messaging/repositories/message.repository.ts
@@ -46,10 +46,12 @@ export const CONVERSATION_PAGE_SIZE = 50;
  *
  * A tab that slept through a long weekend wakes with a cursor days old, and
  * "everything since" is then the whole weekend in one response with three
- * nested includes. Bigger than a page because catching up should take one trip
- * in the ordinary case, small enough that the pathological one stays bounded.
+ * nested includes. Kept close to a page because the cursor resumes: a real
+ * backlog costs an extra trip rather than one big response, and the size of
+ * that response is not something a caller should get to choose by sending an
+ * old enough cursor.
  */
-export const CATCHUP_LIMIT = 200;
+export const CATCHUP_LIMIT = 100;
 
 /**
  * Ordering for every windowed read, newest first.
@@ -186,8 +188,34 @@ export class MessageRepository {
     });
 
     const truncated = rows.length > limit;
+    if (!truncated) return { messages: rows, truncated };
+
+    /*
+     * Stop the page short of a shared millisecond.
+     *
+     * The cursor that resumes a truncated catch-up is a timestamp — one ISO
+     * string on the wire — so if the last message delivered shares its
+     * millisecond with the first one dropped, `gt` steps over the twin and
+     * that message is never delivered to this tab again. Trimming the trailing
+     * run means the cursor always lands on a clean boundary. The trimmed rows
+     * are not lost: the next trip asks for them.
+     */
+    const page = rows.slice(0, limit);
+    const boundary = page[page.length - 1].createdAt.getTime();
+    const firstDropped = rows[limit];
+
+    // Only when the boundary is genuinely straddled. Otherwise the cursor
+    // already lands cleanly and there is nothing to give up.
+    if (firstDropped.createdAt.getTime() !== boundary) {
+      return { messages: page, truncated };
+    }
+
+    const trimmed = page.filter((m) => m.createdAt.getTime() !== boundary);
+
+    // Unless the whole page is one millisecond, which no shop produces, and
+    // where trimming would leave nothing to advance the cursor with at all.
     return {
-      messages: truncated ? rows.slice(0, limit) : rows,
+      messages: trimmed.length > 0 ? trimmed : page,
       truncated,
     };
   }


### PR DESCRIPTION
Follow-up to #123. Three commits, all fixing things the two review agents found in the paging and notification work after it merged — including one hole the first fix opened.

## The reply-audience disclosure

The most interesting one, because the justification sounded right.

#123's edit path read a reply's parent through the visibility filter, which excludes soft-deleted rows — so once somebody deleted the private message that started a thread, fixing a typo on the reply re-derived it as **public** and put it in front of the whole shop. The first fix here read the parent's audience directly instead, defended as "the editor already carries those ids as mentions on their own reply."

That holds at the moment the reply is written and not afterwards. The parent's author can edit it, drop somebody from it, or turn a public message private long after somebody replied. Copying its *current* audience onto the reply regardless echoed that audience straight back in the PATCH response, first and last names included — so re-saving an old reply on a timer was a way to watch the membership of a message you cannot read.

Two questions had been collapsed into one:

- **Does the reply stay private?** Always. The floor holds whether the parent was deleted or the editor was shut out of it — a reply never widens by losing what it answers.
- **Whose audience does it become?** Only for somebody still inside that audience.

The deleted-parent case is unaffected (a deleted parent's audience still contains whoever replied to it), and an editor can still drop somebody they tagged by mistake — which was the point of recomputing rather than accumulating.

## The rest

**A message arriving mid-page-load went missing.** The thread told history apart from arrivals by holding a flag up for the whole "load earlier" request, so anything landing during it was swallowed: no "new messages" pill, and the counter had already moved past it. Arrivals are now identified by *which message is newest* — prepending doesn't change that, so the distinction falls out instead of being inferred. Extracted as a pure `arrivalsSince()` with its own spec. The same window skewed the scroll restore, which corrected by total height and so shoved the reader down by the height of a message that landed elsewhere; it now anchors on the message they were looking at.

**A millisecond tie could hide a message for good.** `createdAt` is `TIMESTAMP(3)`, so two people sending in the same millisecond share one, and paging on the timestamp alone excluded whichever twin missed the boundary — from that page and every page after it. The cursor is the `(createdAt, id)` pair now. The *same* defect then turned up on the catch-up resume path, which is a timestamp on the wire: that page now stops short of a straddled boundary, and the rows it gives up come back on the next trip.

**The catch-up read was unbounded**, for the case its comment said couldn't happen — a tablet that sleeps through a long weekend wakes with a days-old cursor and asks for the whole weekend at once. Capped, and a truncated catch-up hands back a cursor stopped at the last message actually delivered, so the next trip resumes there rather than stepping over the remainder. The cap is 100 rather than 200 because the caller chooses how much backlog to re-read by choosing its cursor, and a stale one is indistinguishable from a deliberate one.

**Two smaller ones:** the arrival tracker recorded the newest id after its empty check, so a list emptied by a conversation change kept the previous thread's id (unreachable today, but the code it replaced was robust to it for free); and `beforeId` was required, which would 400 a tab open across the deploy window, since the frontend and backend are separate Web Apps.

## Verification

697 server tests and 197 webApp tests pass, typechecks and lint clean. New tests cover the parent-edited-after-the-reply case, the shared-millisecond trim, the missing-`beforeId` fallback, and seven cases of `arrivalsSince` (append, prepend, prepend-with-arrival, first paint, deletion, empty).

No migration. Nothing here changes what is stored — only which rows are read, and who a reply's audience is recomputed from.

**Not verified in a browser:** the scroll anchoring on prepend, which jsdom cannot exercise since it has no layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)